### PR TITLE
Add a gradle compatible file namer

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -8,4 +8,8 @@ set -o pipefail
 export MVN="mvn --settings ${TRAVIS_BUILD_DIR}/.travis.settings.xml"
 
 ###### Maven ######
-${MVN} clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar
+if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
+    ${MVN} clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar
+else
+    ${MVN} clean org.jacoco:jacoco-maven-plugin:prepare-agent verify
+fi

--- a/src/main/java/de/retest/recheck/FileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/FileNamerStrategy.java
@@ -2,10 +2,27 @@ package de.retest.recheck;
 
 import de.retest.recheck.persistence.FileNamer;
 
+/**
+ * Determines the paths under which Golden Master and result files should be persisted.
+ */
 public interface FileNamerStrategy {
 
+	/**
+	 * Creates a file namer for the given base names. For Golden Master files, these typically follow the format
+	 * <code>${TEST_CLASS_NAME}/${TEST_METHOD_NAME}.${STEP_NAME}</code>, whereas result files only use
+	 * <code>${TEST_CLASS_NAME}</code>.
+	 *
+	 * @param baseNames
+	 *            the base names to be used
+	 * @return a file namer using the given base names
+	 */
 	FileNamer createFileNamer( String... baseNames );
 
+	/**
+	 * Determines the current test class name.
+	 *
+	 * @return name of the current test class
+	 */
 	default String getTestClassName() {
 		final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
 		if ( testMethodStack != null ) {
@@ -14,6 +31,11 @@ public interface FileNamerStrategy {
 		throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
 	}
 
+	/**
+	 * Determines the current test method name.
+	 *
+	 * @return name of the current test method
+	 */
 	default String getTestMethodName() {
 		final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
 		if ( testMethodStack != null ) {

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -1,0 +1,49 @@
+package de.retest.recheck;
+
+import java.io.File;
+
+import de.retest.recheck.persistence.FileNamer;
+
+public class GradleConformFileNamerStrategy implements FileNamerStrategy {
+
+    public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/test/resources/retest/";
+    public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/test";
+
+    @Override
+    public FileNamer createFileNamer( final String... baseNames ) {
+        return new FileNamer() {
+
+            @Override
+            public File getFile( final String extension ) {
+                final String baseName = String.join( "/", baseNames );
+                return new File( DEFAULT_RETEST_WORKSPACE_PATH + File.separator
+                        + baseName + extension );
+            }
+
+            @Override
+            public File getResultFile( final String extension ) {
+                final String baseName = String.join( "/", baseNames );
+                return new File( DEFAULT_RETEST_TESTREPORTS_PATH + File.separator
+                        + baseName + extension );
+            }
+        };
+    }
+
+    @Override
+    public String getTestClassName() {
+        final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
+        if ( testMethodStack != null ) {
+            return testMethodStack.getClassName();
+        }
+        throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
+    }
+
+    @Override
+    public String getTestMethodName() {
+        final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
+        if ( testMethodStack != null ) {
+            return testMethodStack.getMethodName();
+        }
+        throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
+    }
+}

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -7,13 +7,31 @@ import java.util.Objects;
 
 import de.retest.recheck.persistence.FileNamer;
 
+/**
+ * Gradle-conform file namer strategy that uses the following paths:
+ * <ul>
+ * <li>Golden Master files: <code>src/${SOURCE_SET_NAME}/resources/retest/recheck/</code></li>
+ * <li>Result files: <code>build/test-results/${SOURCE_SET_NAME}/retest/recheck/</code></li>
+ * </ul>
+ * If not set, "test" will be used for <code>${SOURCE_SET_NAME}</code>.
+ */
 public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 	private final String sourceSetName;
 
+	/**
+	 * Creates a Gradle-conform file namer strategy using "test" for <code>${SOURCE_SET_NAME}</code>.
+	 */
 	public GradleConformFileNamerStrategy() {
 		this( "test" );
 	}
 
+	/**
+	 * Creates a Gradle-conform file namer strategy using <code>sourceSetName</code> for
+	 * <code>${SOURCE_SET_NAME}</code>.
+	 *
+	 * @param sourceSetName
+	 *            value for <code>${SOURCE_SET_NAME}</code>
+	 */
 	public GradleConformFileNamerStrategy( final String sourceSetName ) {
 		Objects.requireNonNull( sourceSetName, "sourceSetName cannot be null!" );
 		if ( sourceSetName.isEmpty() ) {

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -12,7 +12,7 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 		this( "test" );
 	}
 
-	public GradleConformFileNamerStrategy( String sourceSetName ) {
+	public GradleConformFileNamerStrategy( final String sourceSetName ) {
 		Objects.requireNonNull( sourceSetName, "sourceSetName cannot be null!" );
 		if ( sourceSetName.isEmpty() ) {
 			throw new IllegalArgumentException( "sourceSetName cannot be empty!" );

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -12,19 +12,21 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 	@Override
 	public FileNamer createFileNamer( final String... baseNames ) {
 		return new FileNamer() {
-
 			@Override
 			public File getFile( final String extension ) {
-				final String baseName = String.join( "/", baseNames );
-				return new File( DEFAULT_RETEST_WORKSPACE_PATH + File.separator + baseName + extension );
+				return toFile( DEFAULT_RETEST_WORKSPACE_PATH, extension, baseNames );
 			}
 
 			@Override
 			public File getResultFile( final String extension ) {
-				final String baseName = String.join( "/", baseNames );
-				return new File( DEFAULT_RETEST_TESTREPORTS_PATH + File.separator + baseName + extension );
+				return toFile( DEFAULT_RETEST_TESTREPORTS_PATH, extension, baseNames );
 			}
 		};
+	}
+
+	private File toFile( final String prefix, final String extension, final String... baseNames ) {
+		final String baseName = String.join( File.separator, baseNames );
+		return new File( prefix + File.separator + baseName + extension );
 	}
 
 }

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -6,44 +6,42 @@ import de.retest.recheck.persistence.FileNamer;
 
 public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 
-    public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/test/resources/retest/";
-    public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/test";
+	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/test/resources/retest/";
+	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/test";
 
-    @Override
-    public FileNamer createFileNamer( final String... baseNames ) {
-        return new FileNamer() {
+	@Override
+	public FileNamer createFileNamer( final String... baseNames ) {
+		return new FileNamer() {
 
-            @Override
-            public File getFile( final String extension ) {
-                final String baseName = String.join( "/", baseNames );
-                return new File( DEFAULT_RETEST_WORKSPACE_PATH + File.separator
-                        + baseName + extension );
-            }
+			@Override
+			public File getFile( final String extension ) {
+				final String baseName = String.join( "/", baseNames );
+				return new File( DEFAULT_RETEST_WORKSPACE_PATH + File.separator + baseName + extension );
+			}
 
-            @Override
-            public File getResultFile( final String extension ) {
-                final String baseName = String.join( "/", baseNames );
-                return new File( DEFAULT_RETEST_TESTREPORTS_PATH + File.separator
-                        + baseName + extension );
-            }
-        };
-    }
+			@Override
+			public File getResultFile( final String extension ) {
+				final String baseName = String.join( "/", baseNames );
+				return new File( DEFAULT_RETEST_TESTREPORTS_PATH + File.separator + baseName + extension );
+			}
+		};
+	}
 
-    @Override
-    public String getTestClassName() {
-        final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
-        if ( testMethodStack != null ) {
-            return testMethodStack.getClassName();
-        }
-        throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
-    }
+	@Override
+	public String getTestClassName() {
+		final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
+		if ( testMethodStack != null ) {
+			return testMethodStack.getClassName();
+		}
+		throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
+	}
 
-    @Override
-    public String getTestMethodName() {
-        final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
-        if ( testMethodStack != null ) {
-            return testMethodStack.getMethodName();
-        }
-        throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
-    }
+	@Override
+	public String getTestMethodName() {
+		final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
+		if ( testMethodStack != null ) {
+			return testMethodStack.getMethodName();
+		}
+		throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
+	}
 }

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -1,13 +1,27 @@
 package de.retest.recheck;
 
 import java.io.File;
+import java.util.Objects;
 
 import de.retest.recheck.persistence.FileNamer;
 
 public class GradleConformFileNamerStrategy implements FileNamerStrategy {
+	private final String sourceSetName;
 
-	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/test/resources/retest/";
-	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/test/";
+	public GradleConformFileNamerStrategy() {
+		this( "test" );
+	}
+
+	public GradleConformFileNamerStrategy( String sourceSetName ) {
+		Objects.requireNonNull( sourceSetName, "sourceSetName cannot be null!" );
+		if ( sourceSetName.isEmpty() ) {
+			throw new IllegalArgumentException( "sourceSetName cannot be empty!" );
+		}
+		this.sourceSetName = sourceSetName;
+	}
+
+	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/%s/resources/retest/";
+	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/%s/";
 
 	@Override
 	public FileNamer createFileNamer( final String... baseNames ) {
@@ -24,8 +38,9 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 		};
 	}
 
-	private File toFile( final String prefix, final String extension, final String... baseNames ) {
+	private File toFile( final String prefixFormat, final String extension, final String... baseNames ) {
 		final String baseName = String.join( File.separator, baseNames );
+		final String prefix = String.format( prefixFormat, sourceSetName );
 		return new File( prefix + File.separator + baseName + extension );
 	}
 

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -7,7 +7,7 @@ import de.retest.recheck.persistence.FileNamer;
 public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 
 	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/test/resources/retest/";
-	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/test";
+	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/test/";
 
 	@Override
 	public FileNamer createFileNamer( final String... baseNames ) {

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -27,21 +27,4 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 		};
 	}
 
-	@Override
-	public String getTestClassName() {
-		final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
-		if ( testMethodStack != null ) {
-			return testMethodStack.getClassName();
-		}
-		throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
-	}
-
-	@Override
-	public String getTestMethodName() {
-		final StackTraceElement testMethodStack = TestCaseFinder.findTestCaseMethodInStack();
-		if ( testMethodStack != null ) {
-			return testMethodStack.getMethodName();
-		}
-		throw new RuntimeException( "Couldn't identify test method in call stack. Use explicit namer!" );
-	}
 }

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -1,5 +1,7 @@
 package de.retest.recheck;
 
+import static de.retest.recheck.Properties.RECHECK_FOLDER_NAME;
+
 import java.io.File;
 import java.util.Objects;
 
@@ -21,7 +23,7 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 	}
 
 	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/%s/resources/retest/";
-	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/%s/";
+	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/%s/retest/";
 
 	@Override
 	public FileNamer createFileNamer( final String... baseNames ) {
@@ -41,7 +43,7 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 	private File toFile( final String prefixFormat, final String extension, final String... baseNames ) {
 		final String baseName = String.join( File.separator, baseNames );
 		final String prefix = String.format( prefixFormat, sourceSetName );
-		return new File( prefix + File.separator + baseName + extension );
+		return new File( prefix + File.separator + RECHECK_FOLDER_NAME + File.separator + baseName + extension );
 	}
 
 }

--- a/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/GradleConformFileNamerStrategy.java
@@ -22,20 +22,20 @@ public class GradleConformFileNamerStrategy implements FileNamerStrategy {
 		this.sourceSetName = sourceSetName;
 	}
 
-	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/%s/resources/retest/";
-	public static final String DEFAULT_RETEST_TESTREPORTS_PATH = "build/test-results/%s/retest/";
+	public static final String DEFAULT_RETEST_WORKSPACE_PATH_FORMAT = "src/%s/resources/retest/";
+	public static final String DEFAULT_RETEST_TESTREPORTS_PATH_FORMAT = "build/test-results/%s/retest/";
 
 	@Override
 	public FileNamer createFileNamer( final String... baseNames ) {
 		return new FileNamer() {
 			@Override
 			public File getFile( final String extension ) {
-				return toFile( DEFAULT_RETEST_WORKSPACE_PATH, extension, baseNames );
+				return toFile( DEFAULT_RETEST_WORKSPACE_PATH_FORMAT, extension, baseNames );
 			}
 
 			@Override
 			public File getResultFile( final String extension ) {
-				return toFile( DEFAULT_RETEST_TESTREPORTS_PATH, extension, baseNames );
+				return toFile( DEFAULT_RETEST_TESTREPORTS_PATH_FORMAT, extension, baseNames );
 			}
 		};
 	}

--- a/src/main/java/de/retest/recheck/MavenConformFileNamerStrategy.java
+++ b/src/main/java/de/retest/recheck/MavenConformFileNamerStrategy.java
@@ -6,6 +6,13 @@ import java.io.File;
 
 import de.retest.recheck.persistence.FileNamer;
 
+/**
+ * Maven-conform file namer strategy that uses the following paths:
+ * <ul>
+ * <li>Golden Master files: <code>src/test/resources/retest/recheck/</code></li>
+ * <li>Result files: <code>target/test-classes/retest/recheck/</code></li>
+ * </ul>
+ */
 public class MavenConformFileNamerStrategy implements FileNamerStrategy {
 
 	public static final String DEFAULT_RETEST_WORKSPACE_PATH = "src/test/resources/retest/";

--- a/src/test/java/de/retest/recheck/GradleConformFileNamerStrategyTest.java
+++ b/src/test/java/de/retest/recheck/GradleConformFileNamerStrategyTest.java
@@ -1,6 +1,7 @@
 package de.retest.recheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 
@@ -11,7 +12,7 @@ import de.retest.recheck.persistence.FileNamer;
 class GradleConformFileNamerStrategyTest {
 
 	@Test
-	void files_should_be_maven_conform() throws Exception {
+	void files_should_be_gradle_conform() throws Exception {
 		final FileNamerStrategy cut = new GradleConformFileNamerStrategy();
 
 		final FileNamer fileNamer = cut.createFileNamer( "foo", "bar" );
@@ -22,4 +23,29 @@ class GradleConformFileNamerStrategyTest {
 		assertThat( resultFile.getPath() ).isEqualTo( "build/test-results/test/retest/recheck/foo/bar.result" );
 	}
 
+	@Test
+	void files_should_be_in_the_correct_source_set() {
+		final FileNamerStrategy cut = new GradleConformFileNamerStrategy( "integrationTest" );
+
+		final FileNamer fileNamer = cut.createFileNamer( "foo", "bar" );
+		final File recheckFile = fileNamer.getFile( Properties.RECHECK_FILE_EXTENSION );
+		final File resultFile = fileNamer.getResultFile( Properties.REPORT_FILE_EXTENSION );
+
+		assertThat( recheckFile.getPath() ).isEqualTo( "src/integrationTest/resources/retest/recheck/foo/bar.recheck" );
+		assertThat( resultFile.getPath() ).isEqualTo( "build/test-results/integrationTest/retest/recheck/foo/bar.result" );
+	}
+
+	@Test
+	void should_not_allow_null_source_set_name() {
+		assertThatThrownBy( () -> new GradleConformFileNamerStrategy( null ) )
+				.isExactlyInstanceOf( NullPointerException.class )
+				.hasMessage( "sourceSetName cannot be null!" );
+	}
+
+	@Test
+	void should_not_allow_empty_source_set_name() {
+		assertThatThrownBy( () -> new GradleConformFileNamerStrategy( "" ) )
+				.isExactlyInstanceOf( IllegalArgumentException.class )
+				.hasMessage( "sourceSetName cannot be empty!" );
+	}
 }

--- a/src/test/java/de/retest/recheck/GradleConformFileNamerStrategyTest.java
+++ b/src/test/java/de/retest/recheck/GradleConformFileNamerStrategyTest.java
@@ -1,0 +1,25 @@
+package de.retest.recheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.persistence.FileNamer;
+
+class GradleConformFileNamerStrategyTest {
+
+	@Test
+	void files_should_be_maven_conform() throws Exception {
+		final FileNamerStrategy cut = new GradleConformFileNamerStrategy();
+
+		final FileNamer fileNamer = cut.createFileNamer( "foo", "bar" );
+		final File recheckFile = fileNamer.getFile( Properties.RECHECK_FILE_EXTENSION );
+		final File resultFile = fileNamer.getResultFile( Properties.REPORT_FILE_EXTENSION );
+
+		assertThat( recheckFile.getPath() ).isEqualTo( "src/test/resources/retest/recheck/foo/bar.recheck" );
+		assertThat( resultFile.getPath() ).isEqualTo( "build/test-results/test/retest/recheck/foo/bar.result" );
+	}
+
+}

--- a/src/test/java/de/retest/recheck/GradleConformFileNamerStrategyTest.java
+++ b/src/test/java/de/retest/recheck/GradleConformFileNamerStrategyTest.java
@@ -32,20 +32,19 @@ class GradleConformFileNamerStrategyTest {
 		final File resultFile = fileNamer.getResultFile( Properties.REPORT_FILE_EXTENSION );
 
 		assertThat( recheckFile.getPath() ).isEqualTo( "src/integrationTest/resources/retest/recheck/foo/bar.recheck" );
-		assertThat( resultFile.getPath() ).isEqualTo( "build/test-results/integrationTest/retest/recheck/foo/bar.result" );
+		assertThat( resultFile.getPath() )
+				.isEqualTo( "build/test-results/integrationTest/retest/recheck/foo/bar.result" );
 	}
 
 	@Test
 	void should_not_allow_null_source_set_name() {
 		assertThatThrownBy( () -> new GradleConformFileNamerStrategy( null ) )
-				.isExactlyInstanceOf( NullPointerException.class )
-				.hasMessage( "sourceSetName cannot be null!" );
+				.isExactlyInstanceOf( NullPointerException.class ).hasMessage( "sourceSetName cannot be null!" );
 	}
 
 	@Test
 	void should_not_allow_empty_source_set_name() {
 		assertThatThrownBy( () -> new GradleConformFileNamerStrategy( "" ) )
-				.isExactlyInstanceOf( IllegalArgumentException.class )
-				.hasMessage( "sourceSetName cannot be empty!" );
+				.isExactlyInstanceOf( IllegalArgumentException.class ).hasMessage( "sourceSetName cannot be empty!" );
 	}
 }


### PR DESCRIPTION
A file namer which is compatible with the default gradle folder layout.

Currently it uses the hardcoded test reports path `build/test-results/test` for the result files.
The workspace path is identical to the maven file namer.

This will work with the default gradle sourceSet layout for java projects.
Gradle allows users to reconfigure the sourceSets (adding new, etc.), so this might break depending how "strange" die build config is.
I will test some scenarios and report back with the results.