### PR TITLE
Downgrade kryo-serializers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,8 @@
 		<dependency>
 			<groupId>de.javakaffee</groupId>
 			<artifactId>kryo-serializers</artifactId>
-			<version>0.45</version>
+			<!-- last version compatible with kryo v4 -->
+			<version>0.43</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
v0.43 is the last version compatible with kryo v4 (which is what we use), everything beyond uses kryo v5+ (which is only RC). This also causes problems with Gradle. See also:

* https://search.maven.org/artifact/de.javakaffee/kryo-serializers/0.43/bundle
* https://github.com/retest/recheck-web/issues/169#issuecomment-468236488