### PR TITLE
Feature/added attribute goes missing

### DIFF
--- a/src/main/java/de/retest/recheck/XmlTransformerUtil.java
+++ b/src/main/java/de/retest/recheck/XmlTransformerUtil.java
@@ -1,17 +1,34 @@
 package de.retest.recheck;
 
+import java.io.ByteArrayOutputStream;
 import java.util.HashSet;
 import java.util.Set;
 
 import de.retest.recheck.persistence.xml.XmlTransformer;
+import de.retest.recheck.persistence.xml.XmlTransformer.XmlTransformerConfig;
 import de.retest.recheck.report.ReplayResult;
 import de.retest.recheck.ui.descriptors.SutState;
 
 public class XmlTransformerUtil {
+
 	public static XmlTransformer getXmlTransformer() {
 		final Set<Class<?>> xmlDataClasses = new HashSet<>();
 		xmlDataClasses.add( ReplayResult.class );
 		xmlDataClasses.add( SutState.class );
 		return new XmlTransformer( xmlDataClasses );
+	}
+
+	public static <T> String toXML( final T object, final Class<?>... additionalClazzes ) throws Exception {
+		final XmlTransformer xmlTransformer =
+				new XmlTransformer( additionalClazzes, XmlTransformerConfig.CREATE_ONLY_FRAGMENT );
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		xmlTransformer.toXML( object, out );
+		return new String( out.toByteArray() );
+	}
+
+	public static String toXmlFragmentViaJAXB( final Object element, final Class<?>... additionalClazzes ) {
+		final XmlTransformer xmlTransformer =
+				new XmlTransformer( XmlTransformerConfig.CREATE_ONLY_FRAGMENT, additionalClazzes );
+		return xmlTransformer.toXML( element );
 	}
 }

--- a/src/main/java/de/retest/recheck/ui/diff/AttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/AttributesDifferenceFinder.java
@@ -56,9 +56,6 @@ public class AttributesDifferenceFinder {
 
 	private AttributeDifference differenceFor( final IdentifyingAttributes identAttributes, final Serializable expected,
 			final Serializable actual, final String key ) {
-		if ( expected == null ) {
-			return null;
-		}
 		if ( GloballyIgnoredAttributes.getInstance().shouldIgnoreAttribute( key ) ) {
 			return null;
 		}

--- a/src/test/java/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.java
@@ -76,6 +76,17 @@ public class AttributesDifferenceFinderTest {
 	}
 
 	@Test
+	public void added_attribute() {
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( "key", "value2" );
+		final AttributesDifference difference =
+				cut.differenceFor( element( new MutableAttributes().immutable() ), element( attributes2.immutable() ) );
+
+		assertThat( difference.size() ).isEqualTo( 1 );
+		assertThat( difference.toString() ).isEqualTo( "{key: expected=\"null\", actual=\"value2\"}" );
+	}
+
+	@Test
 	@Ignore
 	public void attributesDifference_with_different_key_and_different_values() {
 		final MutableAttributes attributes1 = new MutableAttributes();

--- a/src/test/java/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -87,7 +86,6 @@ public class AttributesDifferenceFinderTest {
 	}
 
 	@Test
-	@Ignore
 	public void attributesDifference_with_different_key_and_different_values() {
 		final MutableAttributes attributes1 = new MutableAttributes();
 		attributes1.put( "key1", "value1" );
@@ -127,7 +125,6 @@ public class AttributesDifferenceFinderTest {
 	}
 
 	@Test
-	@Ignore
 	public void attributesDifference_with_less_expected_than_actual() {
 		final MutableAttributes attributes1 = new MutableAttributes();
 		attributes1.put( "key1", "value1" );

--- a/src/test/java/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.java
@@ -1,0 +1,219 @@
+package de.retest.recheck.ui.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import de.retest.recheck.XmlTransformerUtil;
+import de.retest.recheck.ui.DefaultValueFinder;
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.Attributes;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.MutableAttributes;
+import de.retest.recheck.ui.image.ImageUtils;
+import de.retest.recheck.util.ApprovalsUtil;
+
+public class AttributesDifferenceFinderTest {
+
+	@Rule
+	public final TemporaryFolder temp = new TemporaryFolder();
+
+	private final IdentifyingAttributes identifyingAttributes =
+			IdentifyingAttributes.create( Path.fromString( "/Window[1]" ), getClass() );
+	private final AttributesDifferenceFinder cut = new AttributesDifferenceFinder( mock( DefaultValueFinder.class ) );
+
+	@Test
+	public void attributesDifference_with_identical_empty_attributes() throws Exception {
+		final AttributesDifference difference =
+				cut.differenceFor( element( new Attributes() ), element( new Attributes() ) );
+
+		assertThat( difference ).isNull();
+	}
+
+	@Test
+	public void attributesDifference_with_identical_populated_attributes() throws Exception {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		attributes1.put( "key", "value" );
+		attributes1.put( "another-key", "another-value" );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( "key", "value" );
+		attributes2.put( "another-key", "another-value" );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+
+		assertThat( difference ).isNull();
+	}
+
+	@Test
+	public void attributesDifference_with_the_same_key_but_different_values() {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		attributes1.put( "key", "value1" );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( "key", "value2" );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+
+		assertThat( difference.size() ).isEqualTo( 1 );
+		assertThat( difference.getElementDifferences().size() ).isEqualTo( 0 );
+		assertThat( difference.getNonEmptyDifferences() ).isEmpty();
+		assertThat( difference.toString() ).isEqualTo( "{key: expected=\"value1\", actual=\"value2\"}" );
+
+		ApprovalsUtil.verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( difference ) );
+	}
+
+	@Test
+	@Ignore
+	public void attributesDifference_with_different_key_and_different_values() {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		attributes1.put( "key1", "value1" );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( "key2", "value2" );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+
+		assertThat( difference.size() ).isEqualTo( 2 );
+		assertThat( difference.getElementDifferences().size() ).isEqualTo( 0 );
+		assertThat( difference.getNonEmptyDifferences() ).isEmpty();
+		assertThat( difference.toString() ).isEqualTo(
+				"{key1: expected=\"value1\", actual=\"null\", key2: expected=\"null\", actual=\"value2\"}" );
+
+		ApprovalsUtil.verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( difference ) );
+	}
+
+	@Test
+	public void attributesDifference_with_more_expected_than_actual() {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		attributes1.put( "key1", "value1" );
+		attributes1.put( "key2", "value2" );
+		attributes1.put( "key3", "value3" );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( "key2", "different-value" );
+		attributes2.put( "key1", "value1" );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+
+		assertThat( difference.size() ).isEqualTo( 2 );
+		assertThat( difference.toString() ).contains( "key2: expected=\"value2\", actual=\"different-value\"" );
+		assertThat( difference.toString() ).contains( "key3: expected=\"value3\", actual=\"null\"" );
+		assertThat( difference.getElementDifferences().size() ).isEqualTo( 0 );
+		assertThat( difference.getNonEmptyDifferences() ).isEmpty();
+
+		ApprovalsUtil.verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( difference ) );
+	}
+
+	@Test
+	@Ignore
+	public void attributesDifference_with_less_expected_than_actual() {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		attributes1.put( "key1", "value1" );
+		attributes1.put( "key2", "value2" );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( "key2", "different-value" );
+		attributes2.put( "key1", "value1" );
+		attributes2.put( "key3", "value3" );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+
+		assertThat( difference.size() ).isEqualTo( 2 );
+		assertThat( difference.getElementDifferences().size() ).isEqualTo( 0 );
+		assertThat( difference.getNonEmptyDifferences() ).isEmpty();
+		assertThat( difference.toString() ).isEqualTo(
+				"{key2: expected=\"value2\", actual=\"different-value\", key3: expected=\"null\", actual=\"value3\"}" );
+
+		ApprovalsUtil.verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( difference ) );
+	}
+
+	@Test
+	public void for_nondefault_values_expected_should_be_default() throws Exception {
+		final MutableAttributes nondefault = new MutableAttributes();
+		nondefault.put( "font", "Lucida Grance-italic-123" );
+		nondefault.put( "background", "#FF0000" );
+		nondefault.put( "foreground", "#00FF00" );
+
+		final MutableAttributes defaults = new MutableAttributes();
+		defaults.put( "font", "Arial" );
+		defaults.put( "background", "#FFFFFF" );
+		defaults.put( "foreground", "#000000" );
+
+		final IdentifyingAttributes identifyingAttributes =
+				IdentifyingAttributes.create( Path.fromString( "/Window[1]" ), getClass() );
+
+		final DefaultValueFinder dvf = Mockito.mock( DefaultValueFinder.class );
+
+		final AttributesDifferenceFinder cut = new AttributesDifferenceFinder( dvf );
+		final Attributes attributes = new Attributes();
+
+		final AttributesDifference difference =
+				cut.differenceFor( element( defaults.immutable() ), element( nondefault.immutable() ) );
+		assertThat( difference.expected().toString() )
+				.isEqualTo( "{background=#FFFFFF, font=Arial, foreground=#000000}" );
+	}
+
+	@Test
+	public void default_values_should_not_cause_difference() throws Exception {
+		final String attributesKey = "foo";
+		final String attributesValue = "bar";
+		final MutableAttributes mutable = new MutableAttributes();
+		mutable.put( attributesKey, attributesValue );
+
+		final DefaultValueFinder dvf = Mockito.mock( DefaultValueFinder.class );
+		when( dvf.isDefaultValue( identifyingAttributes, attributesKey, attributesValue ) ).thenReturn( true );
+
+		final AttributesDifferenceFinder cut = new AttributesDifferenceFinder( dvf );
+
+		final Element expected = element( new Attributes() );
+		final Element actual = element( mutable.immutable() );
+		assertThat( cut.differenceFor( expected, actual ) ).isNull();
+	}
+
+	public void same_screenshot_should_not_cause_difference() throws Exception {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		final BufferedImage img = createImg( Color.BLACK );
+		attributes1.put( ImageUtils.image2Screenshot( "", img ) );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( ImageUtils.image2Screenshot( "", img ) );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+		assertThat( difference ).isNull();
+	}
+
+	@Test
+	public void different_screenshots_should_cause_difference() throws Exception {
+		final MutableAttributes attributes1 = new MutableAttributes();
+		attributes1.put( ImageUtils.image2Screenshot( "", createImg( Color.BLACK ) ) );
+		final MutableAttributes attributes2 = new MutableAttributes();
+		attributes2.put( ImageUtils.image2Screenshot( "", createImg( Color.WHITE ) ) );
+		final AttributesDifference difference =
+				cut.differenceFor( element( attributes1.immutable() ), element( attributes2.immutable() ) );
+		assertThat( difference.size() ).isEqualTo( 1 );
+	}
+
+	private Element element( final Attributes attributes ) {
+		return Element.create( "id", mock( Element.class ), identifyingAttributes, attributes );
+	}
+
+	private BufferedImage createImg( final Color color ) {
+		final BufferedImage result = new BufferedImage( 20, 20, BufferedImage.TYPE_INT_RGB );
+		final Graphics2D g2 = result.createGraphics();
+		g2.setColor( color );
+		g2.fillRect( 0, 0, 20, 20 );
+		try {
+			ImageIO.write( result, "PNG", temp.newFile( "target/" + color + ".png" ) );
+		} catch ( final IOException e ) {}
+		return result;
+	}
+}

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_different_key_and_different_values.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_different_key_and_different_values.approved.xml
@@ -1,0 +1,8 @@
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="5c4843e957445234524e049433378d20ec7bb872d4625cfd5ab90f84756daba2">
+	<differences key="key1" attributeDifferenceId="3c9683017f9e4bf33d0fbedd26bf143fd72de9b9dd145441b75f0604047ea28e">
+		<expected xsi:type="xsd:string">value1</expected>
+	</differences>
+	<differences key="key2" attributeDifferenceId="0537d481f73a757334328052da3af9626ced97028e20b849f6115c22cd765197">
+		<actual xsi:type="xsd:string">value2</actual>
+	</differences>
+</attributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_less_expected_than_actual.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_less_expected_than_actual.approved.xml
@@ -1,0 +1,9 @@
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="aeb46b023fb28df81a30394ce4e9822bfe2eac07f74832e80d844a8efa388178">
+	<differences key="key2" attributeDifferenceId="46cb03830259ae4ec134e64705cceffe25e67bc5b10af4ec29bf5853222aa0a0">
+		<expected xsi:type="xsd:string">value2</expected>
+		<actual xsi:type="xsd:string">different-value</actual>
+	</differences>
+	<differences key="key3" attributeDifferenceId="89dc6ae7f06a9f46b565af03eab0ece0bf6024d3659b7e3a1d03573cfeb0b59d">
+		<actual xsi:type="xsd:string">value3</actual>
+	</differences>
+</attributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_more_expected_than_actual.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_more_expected_than_actual.approved.xml
@@ -1,0 +1,9 @@
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="aeb46b023fb28df81a30394ce4e9822bfe2eac07f74832e80d844a8efa388178">
+	<differences key="key2" attributeDifferenceId="46cb03830259ae4ec134e64705cceffe25e67bc5b10af4ec29bf5853222aa0a0">
+		<expected xsi:type="xsd:string">value2</expected>
+		<actual xsi:type="xsd:string">different-value</actual>
+	</differences>
+	<differences key="key3" attributeDifferenceId="89dc6ae7f06a9f46b565af03eab0ece0bf6024d3659b7e3a1d03573cfeb0b59d">
+		<expected xsi:type="xsd:string">value3</expected>
+	</differences>
+</attributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_the_same_key_but_different_values.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_the_same_key_but_different_values.approved.xml
@@ -1,0 +1,6 @@
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="7eec93af28496e7aa8f2ff4d3557542698725b8b8bf26da1d8298d4d3ecc9e7d">
+	<differences key="key" attributeDifferenceId="bbf83e3a0a45262ce65be4dc05194f7abe74c78225544b7e0f036ea11f388d59">
+		<expected xsi:type="xsd:string">value1</expected>
+		<actual xsi:type="xsd:string">value2</actual>
+	</differences>
+</attributesDifference>


### PR DESCRIPTION
Den Code in AttributeDifferenceFinder hattest Du hinzugefügt:
```
if ( expected == null ) {	
	return null;	
}
```
mit der Commit-Message: "Fix for filtered default values"
Weißt Du noch warum? So können wir das leider nicht machen, ignoriert hinzugekommene Attribute...