### PR TITLE
Fix IO exception during gradle runs

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/RecheckTestReportUtil.java
+++ b/src/main/java/de/retest/recheck/persistence/RecheckTestReportUtil.java
@@ -23,6 +23,7 @@ public class RecheckTestReportUtil {
 	public static void persist( final SuiteReplayResult suite, final File file ) {
 		logger.info( "Persisting test report to file '{}'.", FileUtil.canonicalPathQuietly( file ) );
 		try {
+			FileUtil.ensureFolder( file );
 			persistence.save( file.toURI(), TestReport.fromApi( suite ) );
 		} catch ( final IOException e ) {
 			throw new UncheckedIOException( "Could not save test report.", e );

--- a/src/test/java/de/retest/recheck/persistence/RecheckTestReportUtilTest.java
+++ b/src/test/java/de/retest/recheck/persistence/RecheckTestReportUtilTest.java
@@ -19,10 +19,12 @@ import de.retest.recheck.report.SuiteReplayResult;
 class RecheckTestReportUtilTest {
 
 	File file;
+	File fileMissingFolders;
 
 	@BeforeEach
 	void setUp( @TempDir final Path temp ) {
 		file = temp.resolve( "test.report" ).toFile();
+		fileMissingFolders = temp.resolve( "retest" + File.separator + "recheck" + File.separator + "test.report" ).toFile();
 	}
 
 	@Test
@@ -41,5 +43,13 @@ class RecheckTestReportUtilTest {
 
 		RecheckTestReportUtil.persist( replayResult, file );
 		assertThat( file.exists() ).isTrue();
+	}
+
+	@Test
+	void persist_should_create_missing_folders() {
+		final SuiteReplayResult replayResult = mock( SuiteReplayResult.class );
+		when( replayResult.getDifferencesCount() ).thenReturn( 0 );
+
+		RecheckTestReportUtil.persist( replayResult, fileMissingFolders );
 	}
 }


### PR DESCRIPTION
Hi,

this fixes a problem when running the current release version with gradle:
```
Could not save replay result.
java.io.UncheckedIOException: Could not save replay result.
	at de.retest.recheck.persistence.RecheckReplayResultUtil.persist(RecheckReplayResultUtil.java:26)
	at de.retest.recheck.RecheckImpl.cap(RecheckImpl.java:153)
	at com.dextradata.agentmanagement.MyRecheckWebTest.tearDown(MyRecheckWebTest.java:57)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[...snip...]
Caused by: java.nio.file.NoSuchFileException: C:\project\build\test-results\webTest\retest\recheck\com.dextradata.agentmanagement.MyRecheckWebTest.result
	at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:79)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
[...snip...]
```
As mentioned in https://github.com/retest/recheck/pull/124#issuecomment-469020869 the test Result persistence needs to create the missing folders for gradle tests.

See also:
* https://github.com/retest/recheck-web/issues/169


I noticed there are two `RecheckTestReportUtilTests`:
1. in the package `de.retest.persistence`.
2. in the package `de.retest.recheck.persistence` which is identical to the Package of the `RecheckTestReportUtil`