### PR TITLE
Max pixel diff

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
 import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.execution.RecheckAdapters;
 import de.retest.recheck.execution.RecheckDifferenceFinder;
+import de.retest.recheck.ignore.IgnorePixelDiff;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
+import de.retest.recheck.ignore.ShouldIgnore;
 import de.retest.recheck.persistence.FileNamer;
 import de.retest.recheck.persistence.RecheckSutState;
 import de.retest.recheck.persistence.RecheckTestReportUtil;
@@ -56,6 +58,12 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suite = SuiteReplayResultProvider.getInstance().getSuite( suiteName );
 		ignoreApplier = RecheckIgnoreUtil.loadRecheckIgnore();
 		printer = new TestReplayResultPrinter( usedFinders::get, ignoreApplier );
+
+		final double maxPixelDiff = options.getMaxPixelDiff();
+		if ( maxPixelDiff != 0.0 ) {
+			final ShouldIgnore ignorePixelDiff = new IgnorePixelDiff( maxPixelDiff );
+			ignoreApplier.add( ignorePixelDiff );
+		}
 	}
 
 	private static void ensureConfigurationInitialized() {

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -13,4 +13,7 @@ public class RecheckOptions {
 	@Builder.Default
 	private String suiteName = new MavenConformFileNamerStrategy().getTestClassName();
 
+	@Builder.Default
+	private double maxPixelDiff = 0.0;
+
 }

--- a/src/main/java/de/retest/recheck/ignore/IgnorePixelDiff.java
+++ b/src/main/java/de/retest/recheck/ignore/IgnorePixelDiff.java
@@ -1,0 +1,74 @@
+package de.retest.recheck.ignore;
+
+import java.awt.Rectangle;
+import java.io.Serializable;
+
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class IgnorePixelDiff implements ShouldIgnore {
+
+	private static final String PIXEL = "px";
+
+	private final double maxPixelDiff;
+
+	public IgnorePixelDiff( final double maxPixelDiff ) {
+		this.maxPixelDiff = maxPixelDiff;
+	}
+
+	@Override
+	public boolean shouldIgnoreElement( final Element element ) {
+		return false;
+	}
+
+	@Override
+	public boolean shouldIgnoreAttributeDifference( final Element element,
+			final AttributeDifference attributeDifference ) {
+		final Serializable expected = attributeDifference.getExpected();
+		final Serializable actual = attributeDifference.getActual();
+
+		if ( expected instanceof Rectangle ) {
+			return checkRectangle( (Rectangle) expected, (Rectangle) actual );
+		}
+
+		if ( expected instanceof String ) {
+			return checkString( (String) expected, (String) actual );
+		}
+
+		return false;
+	}
+
+	private boolean checkRectangle( final Rectangle expected, final Rectangle actual ) {
+		final boolean ignoreX = Math.abs( expected.x - actual.x ) <= maxPixelDiff;
+		final boolean ignoreY = Math.abs( expected.y - actual.y ) <= maxPixelDiff;
+		final boolean ignoreHeight = Math.abs( expected.height - actual.height ) <= maxPixelDiff;
+		final boolean ignoreWidth = Math.abs( expected.width - actual.width ) <= maxPixelDiff;
+		return ignoreX && ignoreY && ignoreHeight && ignoreWidth;
+	}
+
+	private boolean checkString( final String expected, final String actual ) {
+		if ( expected == null || actual == null ) {
+			return false;
+		}
+
+		if ( !expected.endsWith( PIXEL ) || !actual.endsWith( PIXEL ) ) {
+			return false;
+		}
+
+		try {
+			final double expectedDouble = Double.valueOf( clean( expected ) );
+			final double actualDouble = Double.valueOf( clean( actual ) );
+			return Math.abs( expectedDouble - actualDouble ) <= maxPixelDiff;
+		} catch ( final NumberFormatException e ) {
+			log.error( "Could not parse {} and {} for max pixel diff.", expected, actual, e );
+			return false;
+		}
+	}
+
+	private static String clean( final String str ) {
+		return str.replace( PIXEL, "" ).replace( ",", "." );
+	}
+
+}

--- a/src/test/java/de/retest/recheck/ignore/IgnorePixelDiffTest.java
+++ b/src/test/java/de/retest/recheck/ignore/IgnorePixelDiffTest.java
@@ -1,0 +1,83 @@
+package de.retest.recheck.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.awt.Rectangle;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class IgnorePixelDiffTest {
+
+	double maxPixelDiff = 5.0;
+	ShouldIgnore cut = new IgnorePixelDiff( maxPixelDiff );
+
+	@Test
+	void should_ignore_diff_when_max_pixel_diff_is_not_exceeded() throws Exception {
+		final Rectangle expected = new Rectangle( 0, 0, 10, 10 );
+		final Rectangle actual = new Rectangle( 1, -1, 15, 5 );
+		final AttributeDifference diff = new AttributeDifference( "outline", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_not_ignore_diff_when_max_pixel_diff_is_exceeded() throws Exception {
+		final Rectangle expected = new Rectangle( 0, 0, 10, 10 );
+		final Rectangle actual = new Rectangle( 1, -1, 15, 5 );
+		final AttributeDifference diff = new AttributeDifference( "outline", expected, actual );
+
+		final ShouldIgnore cut = new IgnorePixelDiff( 0.0 );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isFalse();
+	}
+
+	@Test
+	void should_handle_pixel_strings_with_integers_and_floats() throws Exception {
+		final String expected = "50px";
+		final String actual = "45.3px";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_handle_pixel_strings_with_negative_integers_and_floats() throws Exception {
+		final String expected = "-50px";
+		final String actual = "-45.3px";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_handle_pixel_strings_with_different_decimal_separators() throws Exception {
+		final String expected = "50.0px";
+		final String actual = "45,3px";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_skip_nulls() throws Exception {
+		final String expected = null;
+		final String actual = null;
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isFalse();
+	}
+
+	@Test
+	void should_skip_non_pixel_strings() throws Exception {
+		final String expected = "bar";
+		final String actual = "baz";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isFalse();
+	}
+
+}


### PR DESCRIPTION
Draft for a general approach to ignore pixel diffs. Will wait for the next innovations & ideas meeting, but what do you think? Usage is quite simple:

```java
RecheckOptions opts = RecheckOptions.builder().maxPixelDiff(5.0).build();
Recheck re = new RecheckImpl(opts);
```