### PR TITLE
Max pixel diff ignore

### DIFF
--- a/src/main/java/de/retest/recheck/review/ignore/MaxPixelDiffShouldIgnore.java
+++ b/src/main/java/de/retest/recheck/review/ignore/MaxPixelDiffShouldIgnore.java
@@ -1,0 +1,99 @@
+package de.retest.recheck.review.ignore;
+
+import java.awt.Rectangle;
+import java.io.Serializable;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+
+import de.retest.recheck.ignore.ShouldIgnore;
+import de.retest.recheck.review.ignore.io.RegexLoader;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MaxPixelDiffShouldIgnore implements ShouldIgnore {
+
+	private static final String PIXEL = "px";
+
+	private final double maxPixelDiff;
+
+	public MaxPixelDiffShouldIgnore( final double maxPixelDiff ) {
+		this.maxPixelDiff = maxPixelDiff;
+	}
+
+	@Override
+	public boolean shouldIgnoreElement( final Element element ) {
+		return false;
+	}
+
+	@Override
+	public boolean shouldIgnoreAttributeDifference( final Element element,
+			final AttributeDifference attributeDifference ) {
+		final Serializable expected = attributeDifference.getExpected();
+		final Serializable actual = attributeDifference.getActual();
+
+		if ( expected instanceof Rectangle ) {
+			return checkRectangle( (Rectangle) expected, (Rectangle) actual );
+		}
+
+		if ( expected instanceof String ) {
+			return checkString( (String) expected, (String) actual );
+		}
+
+		return false;
+	}
+
+	private boolean checkRectangle( final Rectangle expected, final Rectangle actual ) {
+		final boolean ignoreX = Math.abs( expected.x - actual.x ) <= maxPixelDiff;
+		final boolean ignoreY = Math.abs( expected.y - actual.y ) <= maxPixelDiff;
+		final boolean ignoreHeight = Math.abs( expected.height - actual.height ) <= maxPixelDiff;
+		final boolean ignoreWidth = Math.abs( expected.width - actual.width ) <= maxPixelDiff;
+		return ignoreX && ignoreY && ignoreHeight && ignoreWidth;
+	}
+
+	private boolean checkString( final String expected, final String actual ) {
+		if ( expected == null || actual == null ) {
+			return false;
+		}
+
+		if ( !expected.endsWith( PIXEL ) || !actual.endsWith( PIXEL ) ) {
+			return false;
+		}
+
+		try {
+			final double expectedDouble = Double.parseDouble( clean( expected ) );
+			final double actualDouble = Double.parseDouble( clean( actual ) );
+			return Math.abs( expectedDouble - actualDouble ) <= maxPixelDiff;
+		} catch ( final NumberFormatException e ) {
+			log.error( "Could not parse {} and {} for max pixel diff.", expected, actual, e );
+			return false;
+		}
+	}
+
+	private static String clean( final String str ) {
+		return str.replace( PIXEL, "" ).replace( ",", "." );
+	}
+
+	@Override
+	public String toString() {
+		return String.format( MaxPixelDiffShouldIgnoreLoader.FORMAT, maxPixelDiff );
+	}
+
+	public static class MaxPixelDiffShouldIgnoreLoader extends RegexLoader<MaxPixelDiffShouldIgnore> {
+
+		private static final String KEY = "maxPixelDiff=";
+		private static final String FORMAT = KEY + "%s";
+		private static final Pattern REGEX = Pattern.compile( KEY + "(\\d+(\\.\\d+)?)" );
+
+		public MaxPixelDiffShouldIgnoreLoader() {
+			super( REGEX );
+		}
+
+		@Override
+		protected MaxPixelDiffShouldIgnore load( final MatchResult regex ) {
+			final double maxPixelDiff = Double.parseDouble( regex.group( 1 ) );
+			return new MaxPixelDiffShouldIgnore( maxPixelDiff );
+		}
+	}
+}

--- a/src/main/java/de/retest/recheck/review/ignore/io/Loaders.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/Loaders.java
@@ -18,6 +18,8 @@ import de.retest.recheck.review.ignore.ElementAttributeShouldIgnore.ElementAttri
 import de.retest.recheck.review.ignore.ElementShouldIgnore;
 import de.retest.recheck.review.ignore.ElementShouldIgnore.ElementShouldIgnoreLoader;
 import de.retest.recheck.review.ignore.JSShouldIgnoreLoader;
+import de.retest.recheck.review.ignore.MaxPixelDiffShouldIgnore;
+import de.retest.recheck.review.ignore.MaxPixelDiffShouldIgnore.MaxPixelDiffShouldIgnoreLoader;
 import de.retest.recheck.review.ignore.ShouldIgnorePreserveLineLoader;
 import de.retest.recheck.review.ignore.ShouldIgnorePreserveLineLoader.ShouldIgnorePreserveLine;
 import de.retest.recheck.review.ignore.matcher.ElementIdMatcher;
@@ -46,6 +48,7 @@ public class Loaders {
 		pairs.add( Pair.of( AttributeShouldIgnore.class, new AttributeShouldIgnoreLoader() ) );
 		pairs.add( Pair.of( AttributeRegexShouldIgnore.class, new AttributeRegexShouldIgnoreLoader() ) );
 		pairs.add( Pair.of( ElementShouldIgnore.class, new ElementShouldIgnoreLoader() ) );
+		pairs.add( Pair.of( MaxPixelDiffShouldIgnore.class, new MaxPixelDiffShouldIgnoreLoader() ) );
 		pairs.add( Pair.of( ShouldIgnorePreserveLine.class, new ShouldIgnorePreserveLineLoader() ) );
 		pairs.add( Pair.of( JSShouldIgnoreImpl.class, new JSShouldIgnoreLoader() ) );
 		return pairs;

--- a/src/test/java/de/retest/recheck/review/ignore/MaxPixelDiffShouldIgnoreLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/MaxPixelDiffShouldIgnoreLoaderTest.java
@@ -1,0 +1,36 @@
+package de.retest.recheck.review.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.review.ignore.MaxPixelDiffShouldIgnore.MaxPixelDiffShouldIgnoreLoader;
+
+class MaxPixelDiffShouldIgnoreLoaderTest {
+
+	@Test
+	void should_not_load_non_integer_and_non_double() throws Exception {
+		final MaxPixelDiffShouldIgnoreLoader cut = new MaxPixelDiffShouldIgnoreLoader();
+
+		assertThat( cut.canLoad( "foo=bar" ) ).isFalse();
+		assertThat( cut.canLoad( "maxPixelDiff=baz" ) ).isFalse();
+		assertThat( cut.canLoad( "maxPixelDiff=-5" ) ).isFalse();
+		assertThat( cut.canLoad( "maxPixelDiff=5." ) ).isFalse();
+		assertThat( cut.canLoad( "maxPixelDiff=5.0." ) ).isFalse();
+		assertThat( cut.canLoad( "maxPixelDiff=5,0" ) ).isFalse();
+	}
+
+	@Test
+	void should_load_integer_and_double() throws Exception {
+		final MaxPixelDiffShouldIgnoreLoader cut = new MaxPixelDiffShouldIgnoreLoader();
+
+		final String intDiff = "maxPixelDiff=5";
+		assertThat( cut.canLoad( intDiff ) ).isTrue();
+		assertThat( cut.load( intDiff ) ).hasFieldOrPropertyWithValue( "maxPixelDiff", 5.0 );
+
+		final String doubleDiff = "maxPixelDiff=5.0";
+		assertThat( cut.canLoad( doubleDiff ) ).isTrue();
+		assertThat( cut.load( doubleDiff ) ).hasFieldOrPropertyWithValue( "maxPixelDiff", 5.0 );
+	}
+
+}

--- a/src/test/java/de/retest/recheck/review/ignore/MaxPixelDiffShouldIgnoreTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/MaxPixelDiffShouldIgnoreTest.java
@@ -1,0 +1,84 @@
+package de.retest.recheck.review.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.awt.Rectangle;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ignore.ShouldIgnore;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class MaxPixelDiffShouldIgnoreTest {
+
+	double maxPixelDiff = 5.0;
+	ShouldIgnore cut = new MaxPixelDiffShouldIgnore( maxPixelDiff );
+
+	@Test
+	void should_ignore_diff_when_max_pixel_diff_is_not_exceeded() throws Exception {
+		final Rectangle expected = new Rectangle( 0, 0, 10, 10 );
+		final Rectangle actual = new Rectangle( 1, -1, 15, 5 );
+		final AttributeDifference diff = new AttributeDifference( "outline", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_not_ignore_diff_when_max_pixel_diff_is_exceeded() throws Exception {
+		final Rectangle expected = new Rectangle( 0, 0, 10, 10 );
+		final Rectangle actual = new Rectangle( 1, -1, 15, 5 );
+		final AttributeDifference diff = new AttributeDifference( "outline", expected, actual );
+
+		final ShouldIgnore cut = new MaxPixelDiffShouldIgnore( 0.0 );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isFalse();
+	}
+
+	@Test
+	void should_handle_pixel_strings_with_integers_and_floats() throws Exception {
+		final String expected = "50px";
+		final String actual = "45.3px";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_handle_pixel_strings_with_negative_integers_and_floats() throws Exception {
+		final String expected = "-50px";
+		final String actual = "-45.3px";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_handle_pixel_strings_with_different_decimal_separators() throws Exception {
+		final String expected = "50.0px";
+		final String actual = "45,3px";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isTrue();
+	}
+
+	@Test
+	void should_skip_nulls() throws Exception {
+		final String expected = null;
+		final String actual = null;
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isFalse();
+	}
+
+	@Test
+	void should_skip_non_pixel_strings() throws Exception {
+		final String expected = "bar";
+		final String actual = "baz";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.shouldIgnoreAttributeDifference( mock( Element.class ), diff ) ).isFalse();
+	}
+
+}


### PR DESCRIPTION
Draft we can discuss tomorrow in our innovation meeting. Basically, this allows to ignore max pixel diffs by adding e.g. `maxPixelDiff=5` (or `5.0`) to `recheck.ignore`.