### PR TITLE
Issue182: Load recheck.ignore file by suite

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -62,7 +62,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 
 	private final Map<String, DefaultValueFinder> usedFinders = new HashMap<>();
 	private final TestReplayResultPrinter printer;
-	private final Filter ignoreApplier;
+	private final Filter filter;
 
 	/**
 	 * Constructor that works purely with defaults. Default {@link FileNamerStrategy} assumes being called from within a
@@ -85,9 +85,9 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		final GlobalIgnoreApplier globalIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore();
 		final GlobalIgnoreApplier suiteIgnoreApplier = RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() );
 
-		ignoreApplier = new CompoundFilter( Lists.newArrayList( globalIgnoreApplier, suiteIgnoreApplier ) );
+		filter = new CompoundFilter( Lists.newArrayList( globalIgnoreApplier, suiteIgnoreApplier ) );
 
-		printer = new TestReplayResultPrinter( usedFinders::get, ignoreApplier );
+		printer = new TestReplayResultPrinter( usedFinders::get, filter );
 	}
 
 	private static void ensureConfigurationInitialized() {
@@ -167,7 +167,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suite.addTest( currentTestResult );
 		final TestReplayResult finishedTestResult = currentTestResult;
 		currentTestResult = null;
-		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences( ignoreApplier );
+		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences( filter );
 		logger.info( "Found {} not ignored differences in test {}.", uniqueDifferences.size(),
 				finishedTestResult.getName() );
 		if ( !uniqueDifferences.isEmpty() ) {

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -83,7 +83,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suite = SuiteReplayResultProvider.getInstance().getSuite( suiteName );
 
 		final GlobalIgnoreApplier globalIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore();
-		final GlobalIgnoreApplier suiteIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore( getSuitePath() );
+		final GlobalIgnoreApplier suiteIgnoreApplier = RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() );
 
 		ignoreApplier = new CompoundFilter( Lists.newArrayList( globalIgnoreApplier, suiteIgnoreApplier ) );
 

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -3,6 +3,7 @@ package de.retest.recheck;
 import static de.retest.recheck.util.FileUtil.normalize;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -10,8 +11,6 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.execution.RecheckAdapters;
@@ -84,8 +83,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 
 		final GlobalIgnoreApplier globalIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore();
 		final GlobalIgnoreApplier suiteIgnoreApplier = RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() );
-
-		filter = new CompoundFilter( Lists.newArrayList( globalIgnoreApplier, suiteIgnoreApplier ) );
+		filter = new CompoundFilter( Arrays.asList( globalIgnoreApplier, suiteIgnoreApplier ) );
 
 		printer = new TestReplayResultPrinter( usedFinders::get, filter );
 	}

--- a/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
+++ b/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
@@ -42,13 +42,13 @@ public class RecheckIgnoreUtil {
 		}
 	}
 
-	public static GlobalIgnoreApplier loadRecheckIgnore( final File ignoreFilesBasePath ) {
+	public static GlobalIgnoreApplier loadRecheckSuiteIgnore( final File ignoreFilesBasePath ) {
 		try {
 			final LoadFilterWorker loadFilterWorker =
 					new LoadFilterWorker( NopCounter.getInstance(), ignoreFilesBasePath );
 			return loadFilterWorker.load();
 		} catch ( final Exception e ) {
-			logger.debug( "Ignoring missing ignore file.", e );
+			logger.debug( "Ignoring missing suite ignore file.", e );
 			return GlobalIgnoreApplier.create( NopCounter.getInstance() );
 		}
 	}

--- a/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
+++ b/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.ignore;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -33,11 +34,21 @@ public class RecheckIgnoreUtil {
 
 	public static GlobalIgnoreApplier loadRecheckIgnore() {
 		try {
-			final LoadFilterWorker loadFilterWorker =
-					new LoadFilterWorker( NopCounter.getInstance() );
+			final LoadFilterWorker loadFilterWorker = new LoadFilterWorker( NopCounter.getInstance() );
 			return loadFilterWorker.load();
 		} catch ( final Exception e ) {
 			logger.error( "Could not load recheck ignore file.", e );
+			return GlobalIgnoreApplier.create( NopCounter.getInstance() );
+		}
+	}
+
+	public static GlobalIgnoreApplier loadRecheckIgnore( final File ignoreFilesBasePath ) {
+		try {
+			final LoadFilterWorker loadFilterWorker =
+					new LoadFilterWorker( NopCounter.getInstance(), ignoreFilesBasePath );
+			return loadFilterWorker.load();
+		} catch ( final Exception e ) {
+			logger.debug( "Ignoring missing ignore file.", e );
 			return GlobalIgnoreApplier.create( NopCounter.getInstance() );
 		}
 	}

--- a/src/main/java/de/retest/recheck/review/workers/LoadFilterWorker.java
+++ b/src/main/java/de/retest/recheck/review/workers/LoadFilterWorker.java
@@ -1,5 +1,8 @@
 package de.retest.recheck.review.workers;
 
+import static de.retest.recheck.configuration.ProjectConfiguration.RECHECK_IGNORE;
+import static de.retest.recheck.configuration.ProjectConfiguration.RECHECK_IGNORE_JSRULES;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -8,7 +11,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.JSFilterImpl;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
@@ -20,41 +22,46 @@ import de.retest.recheck.review.ignore.io.Loaders;
 public class LoadFilterWorker {
 
 	private final Counter counter;
-	private final Optional<Path> ignoreFile;
-	private final Optional<Path> ignoreRuleFile;
+	private final File ignoreFilesBasePath;
 
 	public LoadFilterWorker( final Counter counter ) {
-		this.counter = counter;
-
-		ignoreFile = RecheckIgnoreUtil.getIgnoreFile();
-		ignoreRuleFile = RecheckIgnoreUtil.getIgnoreRuleFile();
+		this( counter, null );
 	}
 
 	public LoadFilterWorker( final Counter counter, final File ignoreFilesBasePath ) {
 		this.counter = counter;
-
-		ignoreFile = resolveAndCheckFile( ignoreFilesBasePath, ProjectConfiguration.RECHECK_IGNORE );
-		ignoreRuleFile = resolveAndCheckFile( ignoreFilesBasePath, ProjectConfiguration.RECHECK_IGNORE_JSRULES );
-	}
-
-	private static Optional<Path> resolveAndCheckFile( final File basePath, final String filename ) {
-		final File resolved = new File( basePath, filename );
-		return resolved.exists() ? Optional.of( resolved.toPath() ) : Optional.empty();
+		this.ignoreFilesBasePath = ignoreFilesBasePath;
 	}
 
 	public GlobalIgnoreApplier load() throws IOException {
-
-		final Stream<String> ignoreFileLines = Files
-				.lines( ignoreFile.orElseThrow( () -> new IllegalArgumentException( "No recheck.ignore found." ) ) );
+		final Optional<Path> ignoreFile = getIgnoreFile();
+		final Stream<String> ignoreFileLines = Files.lines(
+				ignoreFile.orElseThrow( () -> new IllegalArgumentException( "No '" + RECHECK_IGNORE + "' found." ) ) );
 		final PersistableGlobalIgnoreApplier ignoreApplier = Loaders.load( ignoreFileLines ) //
 				.filter( Filter.class::isInstance ) //
 				.map( Filter.class::cast ) //
 				.collect( Collectors.collectingAndThen( Collectors.toList(), PersistableGlobalIgnoreApplier::new ) );
 		final GlobalIgnoreApplier result = GlobalIgnoreApplier.create( counter, ignoreApplier );
 
+		final Optional<Path> ignoreRuleFile = getIgnoreRuleFile();
 		ignoreRuleFile.ifPresent( file -> result.add( new JSFilterImpl( file ) ) );
 
 		return result;
+	}
+
+	private Optional<Path> getIgnoreFile() {
+		return ignoreFilesBasePath != null ? resolveAndCheckFile( ignoreFilesBasePath, RECHECK_IGNORE )
+				: RecheckIgnoreUtil.getIgnoreFile();
+	}
+
+	private Optional<Path> getIgnoreRuleFile() {
+		return ignoreFilesBasePath != null ? resolveAndCheckFile( ignoreFilesBasePath, RECHECK_IGNORE_JSRULES )
+				: RecheckIgnoreUtil.getIgnoreRuleFile();
+	}
+
+	private static Optional<Path> resolveAndCheckFile( final File basePath, final String filename ) {
+		final File resolved = new File( basePath, filename );
+		return resolved.exists() ? Optional.of( resolved.toPath() ) : Optional.empty();
 	}
 
 	public Counter getCounter() {

--- a/src/main/java/de/retest/recheck/review/workers/LoadFilterWorker.java
+++ b/src/main/java/de/retest/recheck/review/workers/LoadFilterWorker.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.workers;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -7,9 +8,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import de.retest.recheck.configuration.ProjectConfiguration;
+import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.JSFilterImpl;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.review.GlobalIgnoreApplier;
 import de.retest.recheck.review.GlobalIgnoreApplier.PersistableGlobalIgnoreApplier;
 import de.retest.recheck.review.counter.Counter;
@@ -18,13 +20,30 @@ import de.retest.recheck.review.ignore.io.Loaders;
 public class LoadFilterWorker {
 
 	private final Counter counter;
+	private final Optional<Path> ignoreFile;
+	private final Optional<Path> ignoreRuleFile;
 
 	public LoadFilterWorker( final Counter counter ) {
 		this.counter = counter;
+
+		ignoreFile = RecheckIgnoreUtil.getIgnoreFile();
+		ignoreRuleFile = RecheckIgnoreUtil.getIgnoreRuleFile();
+	}
+
+	public LoadFilterWorker( final Counter counter, final File ignoreFilesBasePath ) {
+		this.counter = counter;
+
+		ignoreFile = resolveAndCheckFile( ignoreFilesBasePath, ProjectConfiguration.RECHECK_IGNORE );
+		ignoreRuleFile = resolveAndCheckFile( ignoreFilesBasePath, ProjectConfiguration.RECHECK_IGNORE_JSRULES );
+	}
+
+	private static Optional<Path> resolveAndCheckFile( final File basePath, final String filename ) {
+		final File resolved = new File( basePath, filename );
+		return resolved.exists() ? Optional.of( resolved.toPath() ) : Optional.empty();
 	}
 
 	public GlobalIgnoreApplier load() throws IOException {
-		final Optional<Path> ignoreFile = RecheckIgnoreUtil.getIgnoreFile();
+
 		final Stream<String> ignoreFileLines = Files
 				.lines( ignoreFile.orElseThrow( () -> new IllegalArgumentException( "No recheck.ignore found." ) ) );
 		final PersistableGlobalIgnoreApplier ignoreApplier = Loaders.load( ignoreFileLines ) //
@@ -33,7 +52,7 @@ public class LoadFilterWorker {
 				.collect( Collectors.collectingAndThen( Collectors.toList(), PersistableGlobalIgnoreApplier::new ) );
 		final GlobalIgnoreApplier result = GlobalIgnoreApplier.create( counter, ignoreApplier );
 
-		RecheckIgnoreUtil.getIgnoreRuleFile().ifPresent( file -> result.add( new JSFilterImpl( file ) ) );
+		ignoreRuleFile.ifPresent( file -> result.add( new JSFilterImpl( file ) ) );
 
 		return result;
 	}

--- a/src/test/java/de/retest/recheck/RecheckImplTest.java
+++ b/src/test/java/de/retest/recheck/RecheckImplTest.java
@@ -4,7 +4,9 @@ import static de.retest.recheck.Properties.TEST_REPORT_FILE_EXTENSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -18,7 +20,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import de.retest.recheck.persistence.FileNamer;
@@ -41,8 +42,8 @@ class RecheckImplTest {
 		} catch ( final Exception e ) {
 			// ignore exception, fear AssertionErrors...
 		}
-		Mockito.verify( check ).createFileNamer( "de.retest.recheck.RecheckImplTest" );
-		Mockito.verify( check ).createFileNamer( ArgumentMatchers.endsWith( ".!@#_$^&)te}{_____xt!(@_$" ) );
+		verify( check ).createFileNamer( "de.retest.recheck.RecheckImplTest" );
+		verify( check ).createFileNamer( endsWith( ".!@#_$^&)te}{_____xt!(@_$" ) );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/RecheckImplTest.java
+++ b/src/test/java/de/retest/recheck/RecheckImplTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import de.retest.recheck.persistence.FileNamer;
@@ -27,21 +28,10 @@ import de.retest.recheck.ui.descriptors.RootElement;
 
 class RecheckImplTest {
 
-	private static class FileNamerStrategyCheck implements FileNamerStrategy {
-
-		private boolean wasCalled = false;
-
-		@Override
-		public FileNamer createFileNamer( final String... baseNames ) {
-			assertThat( baseNames[0] ).endsWith( ".!@#_$^&)te}{_____xt!(@_$" );
-			wasCalled = true;
-			return Mockito.mock( FileNamer.class );
-		}
-	}
-
 	@Test
 	void using_strange_stepText_should_be_normalized() throws Exception {
-		final FileNamerStrategyCheck check = new FileNamerStrategyCheck();
+		final FileNamerStrategy check = mock( FileNamerStrategy.class, Mockito.RETURNS_DEEP_STUBS );
+
 		final RecheckOptions opts = RecheckOptions.builder() //
 				.fileNamerStrategy( check ).build();
 		final RecheckImpl cut = new RecheckImpl( opts );
@@ -51,7 +41,8 @@ class RecheckImplTest {
 		} catch ( final Exception e ) {
 			// ignore exception, fear AssertionErrors...
 		}
-		assertThat( check.wasCalled ).isTrue();
+		Mockito.verify( check ).createFileNamer( "de.retest.recheck.RecheckImplTest" );
+		Mockito.verify( check ).createFileNamer( ArgumentMatchers.endsWith( ".!@#_$^&)te}{_____xt!(@_$" ) );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/review/workers/LoadFilterWorkerTest.java
+++ b/src/test/java/de/retest/recheck/review/workers/LoadFilterWorkerTest.java
@@ -1,7 +1,7 @@
 package de.retest.recheck.review.workers;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,16 +21,16 @@ public class LoadFilterWorkerTest {
 	@Test
 	void loading_without_ignore_file_should_fail( @TempDir final Path root ) throws Exception {
 		final LoadFilterWorker worker = new LoadFilterWorker( NopCounter.getInstance(), root.toFile() );
-		assertThrows( IllegalArgumentException.class, () -> worker.load() );
+		assertThatThrownBy( worker::load ) //
+				.isExactlyInstanceOf( IllegalArgumentException.class ) //
+				.hasMessage( "No recheck.ignore found." );
 	}
 
 	@Test
 	void loading_with_ignore_file_should_succeed( @TempDir final Path root ) throws Exception {
-
 		givenFileWithLines( root.resolve( ProjectConfiguration.RECHECK_IGNORE ).toFile(), "#" );
-
 		final LoadFilterWorker worker = new LoadFilterWorker( NopCounter.getInstance(), root.toFile() );
-		assertNotNull( worker.load() );
+		assertThat( worker.load() ).isNotNull();
 	}
 
 	private static void givenFileWithLines( final File file, final String lines ) throws IOException {

--- a/src/test/java/de/retest/recheck/review/workers/LoadFilterWorkerTest.java
+++ b/src/test/java/de/retest/recheck/review/workers/LoadFilterWorkerTest.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.workers;
 
+import static de.retest.recheck.configuration.ProjectConfiguration.RECHECK_IGNORE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.io.TempDir;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
-import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.review.counter.NopCounter;
 
 public class LoadFilterWorkerTest {
@@ -23,12 +23,12 @@ public class LoadFilterWorkerTest {
 		final LoadFilterWorker worker = new LoadFilterWorker( NopCounter.getInstance(), root.toFile() );
 		assertThatThrownBy( worker::load ) //
 				.isExactlyInstanceOf( IllegalArgumentException.class ) //
-				.hasMessage( "No recheck.ignore found." );
+				.hasMessage( "No '" + RECHECK_IGNORE + "' found." );
 	}
 
 	@Test
 	void loading_with_ignore_file_should_succeed( @TempDir final Path root ) throws Exception {
-		givenFileWithLines( root.resolve( ProjectConfiguration.RECHECK_IGNORE ).toFile(), "#" );
+		givenFileWithLines( root.resolve( RECHECK_IGNORE ).toFile(), "#" );
 		final LoadFilterWorker worker = new LoadFilterWorker( NopCounter.getInstance(), root.toFile() );
 		assertThat( worker.load() ).isNotNull();
 	}

--- a/src/test/java/de/retest/recheck/review/workers/LoadFilterWorkerTest.java
+++ b/src/test/java/de/retest/recheck/review/workers/LoadFilterWorkerTest.java
@@ -1,0 +1,39 @@
+package de.retest.recheck.review.workers;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+import de.retest.recheck.configuration.ProjectConfiguration;
+import de.retest.recheck.review.counter.NopCounter;
+
+public class LoadFilterWorkerTest {
+
+	@Test
+	void loading_without_ignore_file_should_fail( @TempDir final Path root ) throws Exception {
+		final LoadFilterWorker worker = new LoadFilterWorker( NopCounter.getInstance(), root.toFile() );
+		assertThrows( IllegalArgumentException.class, () -> worker.load() );
+	}
+
+	@Test
+	void loading_with_ignore_file_should_succeed( @TempDir final Path root ) throws Exception {
+
+		givenFileWithLines( root.resolve( ProjectConfiguration.RECHECK_IGNORE ).toFile(), "#" );
+
+		final LoadFilterWorker worker = new LoadFilterWorker( NopCounter.getInstance(), root.toFile() );
+		assertNotNull( worker.load() );
+	}
+
+	private static void givenFileWithLines( final File file, final String lines ) throws IOException {
+		Files.asCharSink( file, Charsets.UTF_8 ).write( lines );
+	}
+}


### PR DESCRIPTION
This pull request pertains to the first half of https://github.com/retest/recheck-web/issues/182 : 

The RetestImpl now loads a second, optional, suite-specific filter in addition to the already loaded global one.

The new suite filter is loaded from the suite's golden master directory. It is loaded with the same mechanism as the global filter (e.g., also allows for a rules file). One difference is that a missing suite filter is not logged as an error (but as a debug message).

The remaining part of issue 182 is adding the step-wise filters (called level 3 in issue 182)