### PR TITLE
We need to be able to set the retestId, or else the log output is wrong

### DIFF
--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -108,8 +108,8 @@ public class Element implements Serializable, Comparable<Element> {
 	 * Note that the retestId is immutable, so this method returns a new Element that is a copy of the old one with the
 	 * new retestId.
 	 */
-	public Element setRetestId( final String retestId ) {
-		return Element.create( retestId, this, identifyingAttributes, attributes );
+	public Element applyRetestId( final String retestId ) {
+		return Element.create( retestId, parent, identifyingAttributes, attributes );
 	}
 
 	protected List<Element> createNewElementList( final ActionChangeSet actionChangeSet,

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -104,6 +104,14 @@ public class Element implements Serializable, Comparable<Element> {
 		return element;
 	}
 
+	/**
+	 * Note that the retestId is immutable, so this method returns a new Element that is a copy of the old one with the
+	 * new retestId.
+	 */
+	public Element setRetestId( final String retestId ) {
+		return Element.create( retestId, this, identifyingAttributes, attributes );
+	}
+
 	protected List<Element> createNewElementList( final ActionChangeSet actionChangeSet,
 			final IdentifyingAttributes newIdentAttributes ) {
 		List<Element> newContainedElements = containedElements;


### PR DESCRIPTION
Ok ... finally there doesn't seem to be a way around it. We need the returned Element have the same retestId as the old element...