### PR TITLE
Ignored identifying attributes should cause no difference

### DIFF
--- a/src/main/java/de/retest/recheck/ui/descriptors/Attribute.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Attribute.java
@@ -83,6 +83,9 @@ public abstract class Attribute implements Serializable, Comparable<Attribute> {
 
 	public abstract Attribute applyChanges( Serializable actual );
 
+	/**
+	 * @return The weight of the attribute used for matching (not for diffing).
+	 */
 	public double getWeight() {
 		return NORMAL_WEIGHT;
 	}

--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifference.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifference.java
@@ -12,9 +12,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import de.retest.recheck.ui.descriptors.Attribute;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import lombok.EqualsAndHashCode;
 
 @XmlRootElement
 @XmlAccessorType( XmlAccessType.FIELD )
+@EqualsAndHashCode
 public class IdentifyingAttributesDifference implements LeafDifference {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
@@ -26,8 +26,7 @@ public class IdentifyingAttributesDifferenceFinder {
 		final List<AttributeDifference> attributeDifferences = new ArrayList<>();
 
 		for ( final Attribute expectedAttr : expected.getAttributes() ) {
-			if ( Double.compare( expectedAttr.getWeight(), Attribute.IGNORE_WEIGHT ) == 0
-					|| expectedAttr.isNotVisible() ) {
+			if ( expectedAttr.isNotVisible() ) {
 				continue;
 			}
 			final String key = expectedAttr.getKey();

--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
@@ -21,7 +21,8 @@ public class IdentifyingAttributesDifferenceFinder {
 		final List<AttributeDifference> attributeDifferences = new ArrayList<>();
 
 		for ( final Attribute expectedAttr : expected.getAttributes() ) {
-			if ( Double.compare( expectedAttr.getWeight(), 0.0d ) == 0 || expectedAttr.isNotVisible() ) {
+			if ( Double.compare( expectedAttr.getWeight(), Attribute.IGNORE_WEIGHT ) == 0
+					|| expectedAttr.isNotVisible() ) {
 				continue;
 			}
 			final String key = expectedAttr.getKey();

--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
@@ -15,6 +15,11 @@ public class IdentifyingAttributesDifferenceFinder {
 
 	public IdentifyingAttributesDifference differenceFor( final IdentifyingAttributes expected,
 			final IdentifyingAttributes actual ) {
+		return differenceFor( expected, actual, GloballyIgnoredAttributes.getInstance() );
+	}
+
+	IdentifyingAttributesDifference differenceFor( final IdentifyingAttributes expected,
+			final IdentifyingAttributes actual, final GloballyIgnoredAttributes ignored ) {
 		Objects.requireNonNull( expected, "Expected cannot be null!" );
 		Objects.requireNonNull( actual, "Actual cannot be null!" );
 
@@ -28,7 +33,7 @@ public class IdentifyingAttributesDifferenceFinder {
 			final String key = expectedAttr.getKey();
 			final Serializable expectedValue = expectedAttr.getValue();
 			final Serializable actualValue = actual.get( key );
-			if ( GloballyIgnoredAttributes.getInstance().shouldIgnoreAttribute( key ) ) {
+			if ( ignored.shouldIgnoreAttribute( key ) ) {
 				continue;
 			}
 			if ( key.equals( "path" ) ) {

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -5,12 +5,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.XmlTransformerUtil;
+import de.retest.recheck.ignore.GloballyIgnoredAttributes;
 import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.descriptors.Attribute;
 import de.retest.recheck.ui.descriptors.DefaultAttribute;
@@ -46,6 +49,16 @@ class IdentifyingAttributesDifferenceFinderTest {
 		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, differentOnlyVisible );
 
 		assertThat( diff ).isNull();
+	}
+
+	@Test
+	void ignored_attribute_should_produce_no_difference() throws Exception {
+		final Collection<String> ignoredAttributes = Arrays.asList( IdentifyingAttributes.PATH_ATTRIBUTE_KEY );
+		final GloballyIgnoredAttributes ignored = GloballyIgnoredAttributes.getTestInstance( ignoredAttributes );
+		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, differentOnlyPath, ignored );
+
+		assertThat( diff ).isNull();
+		GloballyIgnoredAttributes.getTestInstance();
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -1,7 +1,6 @@
 package de.retest.recheck.ui.diff;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,15 +47,9 @@ public class IdentifyingAttributesDifferenceFinderTest {
 
 	@Test
 	public void attributes_with_weight_zero_should_produce_no_difference() throws Exception {
-		final Attribute attribute1 = new DefaultAttribute( "key", "value1" ) {
-			private static final long serialVersionUID = 1L;
+		final String key = "key";
 
-			@Override
-			public double getWeight() {
-				return Attribute.IGNORE_WEIGHT;
-			}
-		};
-		final Attribute attribute2 = new DefaultAttribute( "key", "value2" ) {
+		final Attribute attribute1 = new DefaultAttribute( key, "value1" ) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -66,9 +59,19 @@ public class IdentifyingAttributesDifferenceFinderTest {
 		};
 		final IdentifyingAttributes expected = mock( IdentifyingAttributes.class );
 		when( expected.getAttributes() ).thenReturn( Collections.singletonList( attribute1 ) );
+
+		final Attribute attribute2 = new DefaultAttribute( key, "value2" ) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public double getWeight() {
+				return Attribute.IGNORE_WEIGHT;
+			}
+		};
 		final IdentifyingAttributes actual = mock( IdentifyingAttributes.class );
 		when( actual.getAttributes() ).thenReturn( Collections.singletonList( attribute2 ) );
-		when( actual.get( anyString() ) ).thenReturn( attribute2.getValue() );
+
+		when( actual.get( key ) ).thenReturn( attribute2.getValue() );
 
 		final IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
 

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -1,0 +1,166 @@
+package de.retest.recheck.ui.diff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.Attribute;
+import de.retest.recheck.ui.descriptors.DefaultAttribute;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+
+public class IdentifyingAttributesDifferenceFinderTest {
+
+	private static class Type {}
+
+	private static class AnotherType {}
+
+	private IdentifyingAttributes origin;
+	private IdentifyingAttributes different;
+	private IdentifyingAttributes differentOnlyPath;
+	private IdentifyingAttributes differentOnlyVisible;
+
+	private IdentifyingAttributesDifferenceFinder cut;
+
+	@Before
+	public void setUp() {
+		origin = IdentifyingAttributes.create( Path.fromString( "parentPath/type[1]" ), Type.class );
+		different = IdentifyingAttributes.create( Path.fromString( "anotherParentPath/anotherType[1]" ),
+				AnotherType.class );
+		differentOnlyPath = IdentifyingAttributes.create( Path.fromString( "parentPath/anotherType[1]" ), Type.class );
+		differentOnlyVisible = IdentifyingAttributes.create( Path.fromString( "parentPath/type[1]" ), Type.class );
+
+		cut = new IdentifyingAttributesDifferenceFinder();
+	}
+
+	@Test
+	public void visible_attributes_should_produce_no_difference() {
+		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, differentOnlyVisible );
+
+		assertThat( diff ).isNull();
+	}
+
+	@Test
+	public void attributes_with_weight_zero_should_produce_no_difference() throws Exception {
+		final Attribute attribute1 = new DefaultAttribute( "key", "value1" ) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public double getWeight() {
+				return Attribute.IGNORE_WEIGHT;
+			}
+		};
+		final Attribute attribute2 = new DefaultAttribute( "key", "value2" ) {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public double getWeight() {
+				return Attribute.IGNORE_WEIGHT;
+			}
+		};
+		final IdentifyingAttributes expected = mock( IdentifyingAttributes.class );
+		when( expected.getAttributes() ).thenReturn( Collections.singletonList( attribute1 ) );
+		final IdentifyingAttributes actual = mock( IdentifyingAttributes.class );
+		when( actual.getAttributes() ).thenReturn( Collections.singletonList( attribute2 ) );
+		when( actual.get( anyString() ) ).thenReturn( attribute2.getValue() );
+
+		final IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
+
+		assertThat( diff ).isNull();
+	}
+
+	@Test
+	public void path_differences_should_only_be_accounted_for_topmost_elements_iff_there_is_no_type_difference() {
+		IdentifyingAttributes expected = IdentifyingAttributes.create( Path.fromString( "a/b/c/d/e[1]" ), Type.class );
+		IdentifyingAttributes actual = IdentifyingAttributes.create( Path.fromString( "A/b/c/d/e[1]" ), Type.class );
+		IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
+
+		assertThat( diff ).isNull();
+
+		expected = IdentifyingAttributes.create( Path.fromString( "a/b/c/d/e[1]" ), Type.class );
+		actual = IdentifyingAttributes.create( Path.fromString( "a/b/C/d/e[1]" ), Type.class );
+		diff = cut.differenceFor( expected, actual );
+
+		assertThat( diff ).isNull();
+
+		actual = IdentifyingAttributes.create( Path.fromString( "a/b/c/d/E[1]" ), AnotherType.class );
+		diff = cut.differenceFor( expected, actual );
+
+		assertThat( diff ).isNotNull();
+		assertThat( diff.getAttributeDifferences().size() ).isEqualTo( 2 );
+
+		expected = IdentifyingAttributes.create( Path.fromString( "a/b/c/d/e[1]" ), Type.class );
+		actual = IdentifyingAttributes.create( Path.fromString( "a/b/c/d/E[1]" ), Type.class );
+		diff = cut.differenceFor( expected, actual );
+
+		assertThat( diff ).isNotNull();
+		assertThat( diff.getAttributeDifferences().size() ).isEqualTo( 1 );
+	}
+
+	//	@Test
+	//	public void differences_should_be_recognized_accordingly() {
+	//		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
+	//
+	//		assertThat( diff.getElementDifferences().size() ).isEqualTo( 0 );
+	//		assertThat( diff.getAttributeDifferences().size() ).isEqualTo( 2 );
+	//		assertThat( diff.getNonEmptyDifferences().size() ).isEqualTo( 0 );
+	//		assertThat( diff.size() ).isEqualTo( 1 );
+	//		verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( diff ) );
+	//	}
+	//
+	//	@Test
+	//	public void different_paths_and_components_should_be_recognized_accordingly() throws Exception {
+	//		final IdentifyingAttributes expected = IdentifyingAttributes
+	//				.create( Path.fromString( AnotherType.class.getSimpleName() + "[1]" ), AnotherType.class );
+	//		final IdentifyingAttributes actual =
+	//				IdentifyingAttributes.create( Path.fromString( Type.class.getSimpleName() + "[1]" ), Type.class );
+	//
+	//		final IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
+	//
+	//		verifyObject( diff );
+	//		verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( diff ) );
+	//	}
+
+	@Test
+	public void toString_should_work_correctly_for_path_differences() {
+		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, differentOnlyPath );
+
+		assertThat( diff.toString() )
+				.isEqualTo( "expected path: parentPath[1]/type[1] - actual path: parentPath[1]/anotherType[1]" );
+	}
+
+	@Test
+	public void toString_should_work_correctly_for_multiple_differences() {
+		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
+
+		assertThat( diff.toString() ).isEqualTo(
+				"expected path: parentPath[1]/type[1] expected type: de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type - actual path: anotherParentPath[1]/anotherType[1] actual type: de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType" );
+	}
+
+	@Test
+	public void expected_and_actual_strings_should_be_correct() {
+		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
+
+		assertThat( diff.getExpected() ).isEqualTo(
+				"path=parentPath[1]/type[1] type=de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type" );
+		assertThat( diff.getActual() ).isEqualTo(
+				"path=anotherParentPath[1]/anotherType[1] type=de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType" );
+	}
+
+	@Test( expected = NullPointerException.class )
+	public void exception_should_be_thrown_if_expected_is_null() {
+		cut.differenceFor( null, origin );
+	}
+
+	@Test( expected = NullPointerException.class )
+	public void exception_should_be_thrown_if_actual_is_null() {
+		cut.differenceFor( origin, null );
+	}
+
+}

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -1,13 +1,14 @@
 package de.retest.recheck.ui.diff;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.XmlTransformerUtil;
 import de.retest.recheck.ui.Path;
@@ -16,7 +17,7 @@ import de.retest.recheck.ui.descriptors.DefaultAttribute;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.util.ApprovalsUtil;
 
-public class IdentifyingAttributesDifferenceFinderTest {
+class IdentifyingAttributesDifferenceFinderTest {
 
 	private static class Type {}
 
@@ -29,8 +30,8 @@ public class IdentifyingAttributesDifferenceFinderTest {
 
 	private IdentifyingAttributesDifferenceFinder cut;
 
-	@Before
-	public void setUp() {
+	@BeforeEach
+	void setUp() {
 		origin = IdentifyingAttributes.create( Path.fromString( "parentPath/type[1]" ), Type.class );
 		different = IdentifyingAttributes.create( Path.fromString( "anotherParentPath/anotherType[1]" ),
 				AnotherType.class );
@@ -41,14 +42,14 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void visible_attributes_should_produce_no_difference() {
+	void visible_attributes_should_produce_no_difference() {
 		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, differentOnlyVisible );
 
 		assertThat( diff ).isNull();
 	}
 
 	@Test
-	public void attributes_with_weight_zero_should_produce_no_difference() throws Exception {
+	void attributes_with_weight_zero_should_produce_no_difference() throws Exception {
 		final String key = "key";
 
 		final Attribute attribute1 = new DefaultAttribute( key, "value1" ) {
@@ -81,7 +82,7 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void path_differences_should_only_be_accounted_for_topmost_elements_iff_there_is_no_type_difference() {
+	void path_differences_should_only_be_accounted_for_topmost_elements_iff_there_is_no_type_difference() {
 		IdentifyingAttributes expected = IdentifyingAttributes.create( Path.fromString( "a/b/c/d/e[1]" ), Type.class );
 		IdentifyingAttributes actual = IdentifyingAttributes.create( Path.fromString( "A/b/c/d/e[1]" ), Type.class );
 		IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
@@ -109,7 +110,7 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void differences_should_be_recognized_accordingly() {
+	void differences_should_be_recognized_accordingly() {
 		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
 
 		assertThat( diff.getElementDifferences().size() ).isEqualTo( 0 );
@@ -121,7 +122,7 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void different_paths_and_components_should_be_recognized_accordingly() throws Exception {
+	void different_paths_and_components_should_be_recognized_accordingly() throws Exception {
 		final IdentifyingAttributes expected = IdentifyingAttributes
 				.create( Path.fromString( AnotherType.class.getSimpleName() + "[1]" ), AnotherType.class );
 		final IdentifyingAttributes actual =
@@ -133,7 +134,7 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void toString_should_work_correctly_for_path_differences() {
+	void toString_should_work_correctly_for_path_differences() {
 		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, differentOnlyPath );
 
 		assertThat( diff.toString() )
@@ -141,7 +142,7 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void toString_should_work_correctly_for_multiple_differences() {
+	void toString_should_work_correctly_for_multiple_differences() {
 		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
 
 		assertThat( diff.toString() ).isEqualTo(
@@ -149,7 +150,7 @@ public class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	public void expected_and_actual_strings_should_be_correct() {
+	void expected_and_actual_strings_should_be_correct() {
 		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
 
 		assertThat( diff.getExpected() ).isEqualTo(
@@ -158,14 +159,14 @@ public class IdentifyingAttributesDifferenceFinderTest {
 				"path=anotherParentPath[1]/anotherType[1] type=de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType" );
 	}
 
-	@Test( expected = NullPointerException.class )
-	public void exception_should_be_thrown_if_expected_is_null() {
-		cut.differenceFor( null, origin );
+	@Test
+	void exception_should_be_thrown_if_expected_is_null() {
+		assertThatThrownBy( () -> cut.differenceFor( null, origin ) ).isExactlyInstanceOf( NullPointerException.class );
 	}
 
-	@Test( expected = NullPointerException.class )
-	public void exception_should_be_thrown_if_actual_is_null() {
-		cut.differenceFor( origin, null );
+	@Test
+	void exception_should_be_thrown_if_actual_is_null() {
+		assertThatThrownBy( () -> cut.differenceFor( origin, null ) ).isExactlyInstanceOf( NullPointerException.class );
 	}
 
 }

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -9,10 +9,12 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.retest.recheck.XmlTransformerUtil;
 import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.descriptors.Attribute;
 import de.retest.recheck.ui.descriptors.DefaultAttribute;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.util.ApprovalsUtil;
 
 public class IdentifyingAttributesDifferenceFinderTest {
 
@@ -106,29 +108,29 @@ public class IdentifyingAttributesDifferenceFinderTest {
 		assertThat( diff.getAttributeDifferences().size() ).isEqualTo( 1 );
 	}
 
-	//	@Test
-	//	public void differences_should_be_recognized_accordingly() {
-	//		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
-	//
-	//		assertThat( diff.getElementDifferences().size() ).isEqualTo( 0 );
-	//		assertThat( diff.getAttributeDifferences().size() ).isEqualTo( 2 );
-	//		assertThat( diff.getNonEmptyDifferences().size() ).isEqualTo( 0 );
-	//		assertThat( diff.size() ).isEqualTo( 1 );
-	//		verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( diff ) );
-	//	}
-	//
-	//	@Test
-	//	public void different_paths_and_components_should_be_recognized_accordingly() throws Exception {
-	//		final IdentifyingAttributes expected = IdentifyingAttributes
-	//				.create( Path.fromString( AnotherType.class.getSimpleName() + "[1]" ), AnotherType.class );
-	//		final IdentifyingAttributes actual =
-	//				IdentifyingAttributes.create( Path.fromString( Type.class.getSimpleName() + "[1]" ), Type.class );
-	//
-	//		final IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
-	//
-	//		verifyObject( diff );
-	//		verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( diff ) );
-	//	}
+	@Test
+	public void differences_should_be_recognized_accordingly() {
+		final IdentifyingAttributesDifference diff = cut.differenceFor( origin, different );
+
+		assertThat( diff.getElementDifferences().size() ).isEqualTo( 0 );
+		assertThat( diff.getAttributeDifferences().size() ).isEqualTo( 2 );
+		assertThat( diff.getNonEmptyDifferences().size() ).isEqualTo( 0 );
+		assertThat( diff.size() ).isEqualTo( 1 );
+
+		ApprovalsUtil.verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( diff ) );
+	}
+
+	@Test
+	public void different_paths_and_components_should_be_recognized_accordingly() throws Exception {
+		final IdentifyingAttributes expected = IdentifyingAttributes
+				.create( Path.fromString( AnotherType.class.getSimpleName() + "[1]" ), AnotherType.class );
+		final IdentifyingAttributes actual =
+				IdentifyingAttributes.create( Path.fromString( Type.class.getSimpleName() + "[1]" ), Type.class );
+
+		final IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
+
+		ApprovalsUtil.verifyXml( XmlTransformerUtil.toXmlFragmentViaJAXB( diff ) );
+	}
 
 	@Test
 	public void toString_should_work_correctly_for_path_differences() {

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -62,10 +62,12 @@ class IdentifyingAttributesDifferenceFinderTest {
 	}
 
 	@Test
-	void attributes_with_weight_zero_should_produce_no_difference() throws Exception {
+	void attributes_with_ignore_weight_should_produce_difference() throws Exception {
 		final String key = "key";
+		final String expectedValue = "value1";
+		final String actualValue = "value2";
 
-		final Attribute attribute1 = new DefaultAttribute( key, "value1" ) {
+		final Attribute attribute1 = new DefaultAttribute( key, expectedValue ) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -73,10 +75,10 @@ class IdentifyingAttributesDifferenceFinderTest {
 				return Attribute.IGNORE_WEIGHT;
 			}
 		};
-		final IdentifyingAttributes expected = mock( IdentifyingAttributes.class );
-		when( expected.getAttributes() ).thenReturn( Collections.singletonList( attribute1 ) );
+		final IdentifyingAttributes expectedIdentAttributes = mock( IdentifyingAttributes.class );
+		when( expectedIdentAttributes.getAttributes() ).thenReturn( Collections.singletonList( attribute1 ) );
 
-		final Attribute attribute2 = new DefaultAttribute( key, "value2" ) {
+		final Attribute attribute2 = new DefaultAttribute( key, actualValue ) {
 			private static final long serialVersionUID = 1L;
 
 			@Override
@@ -84,14 +86,15 @@ class IdentifyingAttributesDifferenceFinderTest {
 				return Attribute.IGNORE_WEIGHT;
 			}
 		};
-		final IdentifyingAttributes actual = mock( IdentifyingAttributes.class );
-		when( actual.getAttributes() ).thenReturn( Collections.singletonList( attribute2 ) );
+		final IdentifyingAttributes actualIdentAttributes = mock( IdentifyingAttributes.class );
+		when( actualIdentAttributes.getAttributes() ).thenReturn( Collections.singletonList( attribute2 ) );
+		when( actualIdentAttributes.get( key ) ).thenReturn( attribute2.getValue() );
 
-		when( actual.get( key ) ).thenReturn( attribute2.getValue() );
-
-		final IdentifyingAttributesDifference diff = cut.differenceFor( expected, actual );
-
-		assertThat( diff ).isNull();
+		final IdentifyingAttributesDifference actualDiff =
+				cut.differenceFor( expectedIdentAttributes, actualIdentAttributes );
+		final IdentifyingAttributesDifference expectedDiff = new IdentifyingAttributesDifference(
+				expectedIdentAttributes, Arrays.asList( new AttributeDifference( key, expectedValue, actualValue ) ) );
+		assertThat( actualDiff ).isEqualTo( expectedDiff );
 	}
 
 	@Test

--- a/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.differences_should_be_recognized_accordingly.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.differences_should_be_recognized_accordingly.approved.xml
@@ -1,0 +1,13 @@
+<identifyingAttributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="4a4744180ebcb6a912e30679732aff30b2f906ea14b22edeef8e2428cba9f0d3">
+	<attribute key="path" xsi:type="pathAttribute">parentPath[1]/type[1]</attribute>
+	<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+	<attribute key="type" xsi:type="stringAttribute">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type</attribute>
+	<attributeDifference key="path" attributeDifferenceId="99e2e6b492e99075f2ad0c022a1dfaed7bd99a98695eb612f4703a82ab1e23cf">
+		<expected xsi:type="xsd:string">parentPath[1]/type[1]</expected>
+		<actual xsi:type="xsd:string">anotherParentPath[1]/anotherType[1]</actual>
+	</attributeDifference>
+	<attributeDifference key="type" attributeDifferenceId="886ce09093615d835af906ee8516f5623bf1a15f2cf7e9f4f7bd5a7688eccf58">
+		<expected xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type</expected>
+		<actual xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType</actual>
+	</attributeDifference>
+</identifyingAttributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.different_paths_and_components_should_be_recognized_accordingly.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.different_paths_and_components_should_be_recognized_accordingly.approved.xml
@@ -1,0 +1,13 @@
+<identifyingAttributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="1b34c45a52e339e7f7e9ccff2dd60297566b419af9fef5f8b09af49e5569afe3">
+	<attribute key="path" xsi:type="pathAttribute">AnotherType[1]</attribute>
+	<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+	<attribute key="type" xsi:type="stringAttribute">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType</attribute>
+	<attributeDifference key="path" attributeDifferenceId="02642fe8cf782225a14d2188b087976b7205eb66ed6858d62ec97a77e43a31b5">
+		<expected xsi:type="xsd:string">AnotherType[1]</expected>
+		<actual xsi:type="xsd:string">Type[1]</actual>
+	</attributeDifference>
+	<attributeDifference key="type" attributeDifferenceId="0a919a43bfd37fabc5fd6775f56d83ed69d7c9fb785e152f71d694f6a35e2336">
+		<expected xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType</expected>
+		<actual xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type</actual>
+	</attributeDifference>
+</identifyingAttributesDifference>


### PR DESCRIPTION
Commit ae83da9 makes sure that the weight is considered during diffing. Since we have changed this from 0 to `Double.MIN_NORMAL`, I assume we don't want absolute outline differences anymore? What is the expected behavior for `AttributeUtilTest#getActualAbsoluteOutline_should_return_actual_absolute_outline()`? There is no difference no more.