### PR TITLE
fix-javadoc-fail

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -11,9 +11,8 @@ ${MVN} clean package -DskipTests
 # Test with JDK 11
 wget --quiet https://github.com/sormuras/bach/raw/master/install-jdk.sh && . ./install-jdk.sh -F 11
 
-# We cannot simply use verify due to https://bugs.openjdk.java.net/browse/JDK-8212233.
 if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
-    ${MVN} org.jacoco:jacoco-maven-plugin:prepare-agent test failsafe:integration-test sonar:sonar
+    ${MVN} org.jacoco:jacoco-maven-plugin:prepare-agent test verify sonar:sonar
 else
-    ${MVN} org.jacoco:jacoco-maven-plugin:prepare-agent test failsafe:integration-test
+    ${MVN} org.jacoco:jacoco-maven-plugin:prepare-agent test verify
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,10 @@
 						</goals>
 					</execution>
 				</executions>
+				<!-- See https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+	            <configuration>
+	      			<source>8</source>
+	    		</configuration>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 			<artifactId>lombok</artifactId>
 			<version>1.18.8</version>
 		</dependency>
-		
+
 		<!-- retest-model -->
 		<dependency>
 			<groupId>net.java.quickcheck</groupId>
@@ -325,9 +325,9 @@
 					</execution>
 				</executions>
 				<!-- See https://bugs.openjdk.java.net/browse/JDK-8212233 -->
-	            <configuration>
-	      			<source>8</source>
-	    		</configuration>
+				<configuration>
+					<source>8</source>
+				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
Added fix for javadoc fail on jdk11 which essentially results in javadoc being executed with `-source 8` and the javadoc to be generated.