### PR TITLE
Fix IdentifyingAttributesDifferenceFinder

### DIFF
--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
@@ -25,7 +25,8 @@ public class IdentifyingAttributesDifferenceFinder {
 
 		final List<AttributeDifference> attributeDifferences = new ArrayList<>();
 
-		for ( final Attribute expectedAttr : expected.getAttributes() ) {
+		final List<Attribute> expectedAttributes = expected.getAttributes();
+		for ( final Attribute expectedAttr : expectedAttributes ) {
 			if ( expectedAttr.isNotVisible() ) {
 				continue;
 			}
@@ -41,12 +42,15 @@ public class IdentifyingAttributesDifferenceFinder {
 				}
 				continue;
 			}
-			if ( expectedValue == null && actualValue != null ) {
-				attributeDifferences.add( new AdditionalAttributeDifference( key, actual.getAttribute( key ) ) );
-			} else if ( differs( expectedValue, actualValue ) ) {
+			if ( differs( expectedValue, actualValue ) ) {
 				attributeDifferences.add( new AttributeDifference( key, expectedValue, actualValue ) );
 			}
 		}
+
+		actual.getAttributes().stream() //
+				.filter( actualAttr -> expected.get( actualAttr.getKey() ) == null ) //
+				.map( additionalAttr -> new AdditionalAttributeDifference( additionalAttr.getKey(), additionalAttr ) ) //
+				.forEach( attributeDifferences::add );
 
 		return attributeDifferences.isEmpty() ? null
 				: new IdentifyingAttributesDifference( expected, attributeDifferences );

--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
@@ -1,5 +1,7 @@
 package de.retest.recheck.ui.diff;
 
+import static de.retest.recheck.ui.descriptors.IdentifyingAttributes.PATH_ATTRIBUTE_KEY;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,23 +29,22 @@ public class IdentifyingAttributesDifferenceFinder {
 
 		final List<Attribute> expectedAttributes = expected.getAttributes();
 		for ( final Attribute expectedAttr : expectedAttributes ) {
-			if ( expectedAttr.isNotVisible() ) {
-				continue;
-			}
 			final String key = expectedAttr.getKey();
 			final Serializable expectedValue = expectedAttr.getValue();
 			final Serializable actualValue = actual.get( key );
-			if ( ignored.shouldIgnoreAttribute( key ) ) {
+
+			if ( expectedAttr.isNotVisible() || ignored.shouldIgnoreAttribute( key ) ) {
 				continue;
 			}
-			if ( key.equals( "path" ) ) {
+
+			if ( key.equals( PATH_ATTRIBUTE_KEY ) ) {
 				if ( pathDiffers( expected, actual ) ) {
 					attributeDifferences.add( new AttributeDifference( key, expected.getPath(), actual.getPath() ) );
 				}
-				continue;
-			}
-			if ( differs( expectedValue, actualValue ) ) {
-				attributeDifferences.add( new AttributeDifference( key, expectedValue, actualValue ) );
+			} else {
+				if ( differs( expectedValue, actualValue ) ) {
+					attributeDifferences.add( new AttributeDifference( key, expectedValue, actualValue ) );
+				}
 			}
 		}
 

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import de.retest.recheck.XmlTransformerUtil;
 import de.retest.recheck.ignore.GloballyIgnoredAttributes;
 import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.AdditionalAttributeDifference;
 import de.retest.recheck.ui.descriptors.Attribute;
 import de.retest.recheck.ui.descriptors.DefaultAttribute;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
@@ -59,6 +60,24 @@ class IdentifyingAttributesDifferenceFinderTest {
 
 		assertThat( diff ).isNull();
 		GloballyIgnoredAttributes.getTestInstance();
+	}
+
+	@Test
+	void new_identifying_attributes_should_produce_difference() throws Exception {
+		final IdentifyingAttributes expectedIdentAttributes = new IdentifyingAttributes( Collections.emptyList() );
+
+		final String newKey = "key";
+		final Attribute newIdentifyingAttribute = new DefaultAttribute( newKey, "value" );
+		final IdentifyingAttributes actualIdentAttributes =
+				new IdentifyingAttributes( Arrays.asList( newIdentifyingAttribute ) );
+
+		final IdentifyingAttributesDifference actualDiff =
+				cut.differenceFor( expectedIdentAttributes, actualIdentAttributes );
+
+		final IdentifyingAttributesDifference expectedDiff =
+				new IdentifyingAttributesDifference( expectedIdentAttributes,
+						Arrays.asList( new AdditionalAttributeDifference( newKey, newIdentifyingAttribute ) ) );
+		assertThat( actualDiff ).isEqualTo( expectedDiff );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.java
@@ -2,8 +2,6 @@ package de.retest.recheck.ui.diff;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -94,8 +92,7 @@ class IdentifyingAttributesDifferenceFinderTest {
 				return Attribute.IGNORE_WEIGHT;
 			}
 		};
-		final IdentifyingAttributes expectedIdentAttributes = mock( IdentifyingAttributes.class );
-		when( expectedIdentAttributes.getAttributes() ).thenReturn( Collections.singletonList( attribute1 ) );
+		final IdentifyingAttributes expectedIdentAttributes = new IdentifyingAttributes( Arrays.asList( attribute1 ) );
 
 		final Attribute attribute2 = new DefaultAttribute( key, actualValue ) {
 			private static final long serialVersionUID = 1L;
@@ -105,9 +102,7 @@ class IdentifyingAttributesDifferenceFinderTest {
 				return Attribute.IGNORE_WEIGHT;
 			}
 		};
-		final IdentifyingAttributes actualIdentAttributes = mock( IdentifyingAttributes.class );
-		when( actualIdentAttributes.getAttributes() ).thenReturn( Collections.singletonList( attribute2 ) );
-		when( actualIdentAttributes.get( key ) ).thenReturn( attribute2.getValue() );
+		final IdentifyingAttributes actualIdentAttributes = new IdentifyingAttributes( Arrays.asList( attribute2 ) );
 
 		final IdentifyingAttributesDifference actualDiff =
 				cut.differenceFor( expectedIdentAttributes, actualIdentAttributes );


### PR DESCRIPTION
Before:

```java
for ( final Attribute expectedAttr : expected.getAttributes() ) {
	// ...
	if ( expectedValue == null && actualValue != null ) {
				attributeDifferences.add( new AdditionalAttributeDifference( key, actual.getAttribute( key ) ) );
	}
	// ...
}
```

We are iterating over the expected attributes to find additional attributes, but this doesn't work:

```
expectedIdent = { }
actualIdent = { foo }
```

When we only iterate over `expectedIdent`, we miss the new `foo` attribute from `actualIdent`.