### PR TITLE
Simplify path differs

### DIFF
--- a/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
+++ b/src/main/java/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinder.java
@@ -58,8 +58,7 @@ public class IdentifyingAttributesDifferenceFinder {
 	}
 
 	private static boolean pathDiffers( final IdentifyingAttributes expected, final IdentifyingAttributes actual ) {
-		return !expected.getPathElement().toString().replace( expected.getParentPath(), actual.getParentPath() )
-				.equals( actual.getPathElement().toString() );
+		return !expected.getPathElement().equals( actual.getPathElement() );
 	}
 
 	// We treat null == "". This is OK for visible attributeDifferences but less suitable for invisible ones.


### PR DESCRIPTION
Isn't:

```java
return !expected.getPathElement().toString()
        .replace( expected.getParentPath(), actual.getParentPath() )
        .equals( actual.getPathElement().toString() );
```

Equal to:

```java
String expectedPathElementString = expected.getPathElement().toString()
        .replace( expected.getParentPath(), actual.getParentPath() )
String actualPathElement = actual.getPathElement().toString();
return !expectedPathElementString.equals( actualPathElementString );
```

And since `getPathElement()` doesn't contain the parent path:

```java
String expectedPathElementString = expected.getPathElement().toString();
String actualPathElement = actual.getPathElement().toString();
return !expectedPathElementString.equals( actualPathElementString );
```

As we have a proper `equals( Object )` and `hashCode()`, can't we omit the `toString()`:

```java
return !expected.getPathElement().equals( actual.getPathElement() );
```

However, you reverted this change in bae02a22bdd4b0c2959a86a1f26464e344a5c291. Is there a special case I'm missing?