### PR TITLE
Fix delete on close

### DIFF
--- a/src/main/java/de/retest/recheck/util/DeleteOnCloseFileInputStream.java
+++ b/src/main/java/de/retest/recheck/util/DeleteOnCloseFileInputStream.java
@@ -7,9 +7,12 @@ import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
 
+import lombok.extern.slf4j.Slf4j;
+
 /*
  * Taken from https://stackoverflow.com/a/4694155
  */
+@Slf4j
 public class DeleteOnCloseFileInputStream extends FileInputStream {
 
 	private final File file;
@@ -24,7 +27,11 @@ public class DeleteOnCloseFileInputStream extends FileInputStream {
 		try {
 			super.close();
 		} finally {
-			FileUtils.forceDelete( file );
+			if ( file.exists() ) {
+				FileUtils.forceDelete( file );
+			} else {
+				log.debug( "File '{}' has already been deleted.", file );
+			}
 		}
 	}
 }

--- a/src/test/java/de/retest/recheck/util/DeleteOnCloseFileInputStreamTest.java
+++ b/src/test/java/de/retest/recheck/util/DeleteOnCloseFileInputStreamTest.java
@@ -2,23 +2,21 @@ package de.retest.recheck.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class DeleteOnCloseFileInputStreamTest {
-
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+class DeleteOnCloseFileInputStreamTest {
 
 	@Test
-	public void file_should_be_deleted_on_close() throws IOException {
-		final File file = tempFolder.newFile();
-		final InputStream in = new DeleteOnCloseFileInputStream( file );
+	void file_should_be_deleted_on_close( @TempDir final Path temp ) throws IOException {
+		final Path file = temp.resolve( "foo" );
+		Files.createFile( file );
+		final InputStream in = new DeleteOnCloseFileInputStream( file.toFile() );
 
 		in.close();
 

--- a/src/test/java/de/retest/recheck/util/DeleteOnCloseFileInputStreamTest.java
+++ b/src/test/java/de/retest/recheck/util/DeleteOnCloseFileInputStreamTest.java
@@ -23,4 +23,16 @@ class DeleteOnCloseFileInputStreamTest {
 		assertThat( file ).doesNotExist();
 	}
 
+	@Test
+	void already_deleted_file_should_cause_no_exception( @TempDir final Path temp ) throws IOException {
+		final Path file = temp.resolve( "bar" );
+		Files.createFile( file );
+		final InputStream in = new DeleteOnCloseFileInputStream( file.toFile() );
+
+		Files.delete( file );
+		in.close();
+
+		assertThat( file ).doesNotExist();
+	}
+
 }

--- a/src/test/java/de/retest/recheck/util/DeleteOnCloseFileInputStreamTest.java
+++ b/src/test/java/de/retest/recheck/util/DeleteOnCloseFileInputStreamTest.java
@@ -1,0 +1,28 @@
+package de.retest.recheck.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DeleteOnCloseFileInputStreamTest {
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Test
+	public void file_should_be_deleted_on_close() throws IOException {
+		final File file = tempFolder.newFile();
+		final InputStream in = new DeleteOnCloseFileInputStream( file );
+
+		in.close();
+
+		assertThat( file ).doesNotExist();
+	}
+
+}


### PR DESCRIPTION
`XmlTransformer#transform( InputStream )` creates `DeleteOnCloseFileInputStream`s with temporary files. Therefore, it is possible that these files already have been deleted, so this shouldn't yield exceptions.