### PR TITLE
Load ignore files/rules per step

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -56,7 +56,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 	private final SuiteReplayResult suite;
 	private final FileNamerStrategy fileNamerStrategy;
 	private final String suiteName;
-	private final Filter suiteFilter;
+	private final Filter globalAndSuiteFilter;
 
 	private final Map<String, DefaultValueFinder> usedFinders = new HashMap<>();
 
@@ -83,7 +83,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 
 		final GlobalIgnoreApplier globalIgnoreApplier = RecheckIgnoreUtil.loadGlobalRecheckIgnore();
 		final GlobalIgnoreApplier suiteIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore( getSuitePath() );
-		suiteFilter = new CompoundFilter( Arrays.asList( globalIgnoreApplier, suiteIgnoreApplier ) );
+		globalAndSuiteFilter = new CompoundFilter( Arrays.asList( globalIgnoreApplier, suiteIgnoreApplier ) );
 	}
 
 	private static void ensureConfigurationInitialized() {
@@ -165,7 +165,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		currentTestResult = null;
 
 		final GlobalIgnoreApplier stepIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore( currentStepDir );
-		final Filter stepFilter = new CompoundFilter( Arrays.asList( suiteFilter, stepIgnoreApplier ) );
+		final Filter stepFilter = new CompoundFilter( Arrays.asList( globalAndSuiteFilter, stepIgnoreApplier ) );
 
 		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences( stepFilter );
 		logger.info( "Found {} not ignored differences in test {}.", uniqueDifferences.size(),

--- a/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
+++ b/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
@@ -33,7 +33,7 @@ public class RecheckIgnoreUtil {
 		return projectConfigurationFolder.map( p -> p.resolve( filename ) );
 	}
 
-	public static GlobalIgnoreApplier loadRecheckIgnore() {
+	public static GlobalIgnoreApplier loadGlobalRecheckIgnore() {
 		try {
 			final LoadFilterWorker loadFilterWorker = new LoadFilterWorker( NopCounter.getInstance() );
 			return loadFilterWorker.load();
@@ -45,15 +45,18 @@ public class RecheckIgnoreUtil {
 		return GlobalIgnoreApplier.create( NopCounter.getInstance() );
 	}
 
-	public static GlobalIgnoreApplier loadRecheckSuiteIgnore( final File ignoreFilesBasePath ) {
+	/**
+	 * Loads a filter from the argument base path, e.g., test suite and step filters.
+	 */
+	public static GlobalIgnoreApplier loadRecheckIgnore( final File ignoreFilesBasePath ) {
 		try {
 			final LoadFilterWorker loadFilterWorker =
 					new LoadFilterWorker( NopCounter.getInstance(), ignoreFilesBasePath );
 			return loadFilterWorker.load();
 		} catch ( final FileNotFoundException e ) {
-			logger.debug( "Ignoring missing suite ignore file." );
+			logger.debug( String.format( "Ignoring missing suite or step ignore file in '%s'", ignoreFilesBasePath ) );
 		} catch ( final Exception e ) {
-			logger.error( "Exception loading suite ignore file.", e );
+			logger.error( "Exception loading suite or step ignore file.", e );
 		}
 		return GlobalIgnoreApplier.create( NopCounter.getInstance() );
 	}

--- a/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
+++ b/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
@@ -54,7 +54,7 @@ public class RecheckIgnoreUtil {
 					new LoadFilterWorker( NopCounter.getInstance(), ignoreFilesBasePath );
 			return loadFilterWorker.load();
 		} catch ( final FileNotFoundException e ) {
-			logger.debug( String.format( "Ignoring missing suite or step ignore file in '%s'", ignoreFilesBasePath ) );
+			logger.debug( "Ignoring missing suite or step ignore file in '{}'.", ignoreFilesBasePath );
 		} catch ( final Exception e ) {
 			logger.error( "Exception loading suite or step ignore file.", e );
 		}

--- a/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
+++ b/src/main/java/de/retest/recheck/ignore/RecheckIgnoreUtil.java
@@ -46,7 +46,10 @@ public class RecheckIgnoreUtil {
 	}
 
 	/**
-	 * Loads a filter from the argument base path, e.g., test suite and step filters.
+	 * Loads a {@link GlobalIgnoreApplier} from the argument base path, e.g., for suite and step filters.
+	 *
+	 * @param ignoreFilesBasePath
+	 *            the directory in which to look for the filter definition files
 	 */
 	public static GlobalIgnoreApplier loadRecheckIgnore( final File ignoreFilesBasePath ) {
 		try {

--- a/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
@@ -1,16 +1,19 @@
 package de.retest.recheck.printer;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.SuiteReplayResult;
 
 public class SuiteReplayResultPrinter implements Printer<SuiteReplayResult> {
 
 	private final TestReplayResultPrinter delegate;
 
-	public SuiteReplayResultPrinter( final DefaultValueFinderProvider provider, final Filter filter ) {
-		delegate = new TestReplayResultPrinter( provider, filter );
+	public SuiteReplayResultPrinter( final DefaultValueFinderProvider provider,
+			final Map<ActionReplayResult, Filter> filterByResult ) {
+		delegate = new TestReplayResultPrinter( provider, filterByResult );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.printer;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import de.retest.recheck.ignore.Filter;
@@ -10,11 +11,12 @@ import de.retest.recheck.ui.DefaultValueFinder;
 public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private final DefaultValueFinderProvider provider;
-	private final Filter filter;
+	private final Map<ActionReplayResult, Filter> filterByResult;
 
-	public TestReplayResultPrinter( final DefaultValueFinderProvider provider, final Filter filter ) {
+	public TestReplayResultPrinter( final DefaultValueFinderProvider provider,
+			final Map<ActionReplayResult, Filter> filterByResult ) {
 		this.provider = provider;
-		this.filter = filter;
+		this.filterByResult = filterByResult;
 	}
 
 	@Override
@@ -24,7 +26,7 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private String createDescription( final TestReplayResult result ) {
 		final String name = result.getName();
-		final int differences = result.getDifferences( filter ).size();
+		final int differences = result.getDifferences( filterByResult ).size();
 		final int states = result.getActionReplayResults().size();
 		return String.format( "Test '%s' has %d difference(s) in %d state(s):", name, differences, states );
 	}
@@ -37,7 +39,8 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private String formatAction( final ActionReplayResult result, final String indent ) {
 		final DefaultValueFinder finder = provider.findForAction( result.getDescription() );
-		final ActionReplayResultPrinter printer = new ActionReplayResultPrinter( finder, filter );
+		final ActionReplayResultPrinter printer =
+				new ActionReplayResultPrinter( finder, filterByResult.getOrDefault( result, Filter.FILTER_NOTHING ) );
 		return printer.toString( result, indent );
 	}
 }

--- a/src/main/java/de/retest/recheck/printer/TestReportPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReportPrinter.java
@@ -1,16 +1,19 @@
 package de.retest.recheck.printer;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.TestReport;
 
 public class TestReportPrinter implements Printer<TestReport> {
 
 	private final SuiteReplayResultPrinter delegate;
 
-	public TestReportPrinter( final DefaultValueFinderProvider provider, final Filter filter ) {
-		delegate = new SuiteReplayResultPrinter( provider, filter );
+	public TestReportPrinter( final DefaultValueFinderProvider provider,
+			final Map<ActionReplayResult, Filter> filterByResult ) {
+		delegate = new SuiteReplayResultPrinter( provider, filterByResult );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/report/TestReplayResult.java
+++ b/src/main/java/de/retest/recheck/report/TestReplayResult.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -82,10 +83,11 @@ public class TestReplayResult implements Serializable {
 		return uiElementsCount;
 	}
 
-	public Set<LeafDifference> getDifferences( final Filter filter ) {
+	public Set<LeafDifference> getDifferences( final Map<ActionReplayResult, Filter> filterByResult ) {
 		final Set<LeafDifference> diffs = new HashSet<>();
 		for ( final ActionReplayResult actionReplayResult : actionReplayResults ) {
-			diffs.addAll( actionReplayResult.getDifferencesWithout( filter ) );
+			diffs.addAll( actionReplayResult.getDifferencesWithout(
+					filterByResult.getOrDefault( actionReplayResult, Filter.FILTER_NOTHING ) ) );
 		}
 		return diffs;
 	}

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -1,9 +1,9 @@
 package de.retest.recheck.printer;
 
-import static de.retest.recheck.ignore.Filter.FILTER_NOTHING;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -25,13 +25,13 @@ class TestReplayResultPrinterTest {
 
 	@BeforeEach
 	void setUp() {
-		cut = new TestReplayResultPrinter( s -> ( identAttributes, key, value ) -> false, FILTER_NOTHING );
+		cut = new TestReplayResultPrinter( s -> ( identAttributes, key, value ) -> false, Collections.emptyMap() );
 	}
 
 	@Test
 	void toString_should_print_differences_if_empty() {
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( Collections.emptySet() );
+		when( result.getDifferences( any() ) ).thenReturn( Collections.emptySet() );
 		when( result.getActionReplayResults() ).thenReturn( Collections.emptyList() );
 
 		final String string = cut.toString( result );
@@ -42,7 +42,7 @@ class TestReplayResultPrinterTest {
 	@Test
 	void toString_should_respect_indent_if_empty() {
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( Collections.emptySet() );
+		when( result.getDifferences( any() ) ).thenReturn( Collections.emptySet() );
 		when( result.getActionReplayResults() ).thenReturn( Collections.emptyList() );
 
 		final String string = cut.toString( result, "____" );
@@ -72,7 +72,7 @@ class TestReplayResultPrinterTest {
 		when( a1.getDescription() ).thenReturn( "foo" );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
+		when( result.getDifferences( any() ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
 		when( result.getActionReplayResults() ).thenReturn( Collections.singletonList( a1 ) );
 
 		final String string = cut.toString( result, "____" );
@@ -89,7 +89,7 @@ class TestReplayResultPrinterTest {
 		when( a2.getDescription() ).thenReturn( "bar" );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
+		when( result.getDifferences( any() ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
 		when( result.getActionReplayResults() ).thenReturn( Arrays.asList( a1, a2 ) );
 
 		final String string = cut.toString( result );


### PR DESCRIPTION
This pull request proposes a solution for part 2 (level 3) of https://github.com/retest/recheck-web/issues/182: Having an optional filter for each test step.

The two main changes are in `RecheckImpl`:

1.  It gets a new stateful field `File currentStepDir` (kept in a fashion similar to the already existing `currentTestResult`). This makes the information about the current step available in `capTest` to construct a step-specific filter from the suite filter.
1. The former `TestReplayResultPrinter` field is now locally constructed in `RecheckImpl::getDifferencesErrorMessage` using the step-specific filter.

The loading of the step-specific filter delegates to the same logic used by the global and suite filters in `RecheckIgnoreUtil`. As with suite filters, a missing step filter will only log a debug message.

---
On a related note, the `GlobalIgnoreApplier` should perhaps be renamed: It is now used for 1. the global filter, 2. the suite filter, and 3. the step filter. It is rather like a mutable version of the `CompoundFilter`; it also happens to be the type used for loading and saving. So it seems to be something like a `MutablePersistableCompoundFilter`. IMHO, its inner class `PersistableGlobalIgnoreApplier` could also be replaced with a simpler list copy during (de)serialization.