### PR TITLE
Instead of resolving project root 6 times at startup, reduce to two times

### DIFF
--- a/src/main/java/de/retest/recheck/configuration/ProjectConfiguration.java
+++ b/src/main/java/de/retest/recheck/configuration/ProjectConfiguration.java
@@ -40,8 +40,14 @@ public class ProjectConfiguration {
 		return instance;
 	}
 
+	private Optional<Path> projectConfigFolder;
+
 	public Optional<Path> getProjectConfigFolder() {
-		return ProjectRootFinderUtil.getProjectRoot().map( path -> path.resolve( RETEST_PROJECT_CONFIG_FOLDER ) );
+		if ( projectConfigFolder == null ) {
+			projectConfigFolder =
+					ProjectRootFinderUtil.getProjectRoot().map( path -> path.resolve( RETEST_PROJECT_CONFIG_FOLDER ) );
+		}
+		return projectConfigFolder;
 	}
 
 	public Path findProjectConfigFolder() {

--- a/src/main/java/de/retest/recheck/configuration/ProjectConfiguration.java
+++ b/src/main/java/de/retest/recheck/configuration/ProjectConfiguration.java
@@ -105,4 +105,7 @@ public class ProjectConfiguration {
 		return getClass().getClassLoader().getResourceAsStream( fileName );
 	}
 
+	public void resetConfiguration() {
+		projectConfigFolder = null;
+	}
 }

--- a/src/main/java/de/retest/recheck/configuration/ProjectConfiguration.java
+++ b/src/main/java/de/retest/recheck/configuration/ProjectConfiguration.java
@@ -40,7 +40,9 @@ public class ProjectConfiguration {
 		return instance;
 	}
 
-	private Optional<Path> projectConfigFolder;
+	// If this field is null, we haven't set it yet
+	// If it is an empty optional, we know we already set it to "unknown"
+	private Optional<Path> projectConfigFolder = null;
 
 	public Optional<Path> getProjectConfigFolder() {
 		if ( projectConfigFolder == null ) {

--- a/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
+++ b/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
@@ -14,10 +14,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.util.junit.jupiter.SystemProperty;
 
 class SearchFilterFilesTest {
@@ -30,6 +32,11 @@ class SearchFilterFilesTest {
 		retestFolder = temp.resolve( RETEST_PROJECT_CONFIG_FOLDER );
 		filterFolder = retestFolder.resolve( FILTER_FOLDER );
 		Files.createDirectories( filterFolder );
+	}
+
+	@AfterAll
+	static void tearDown() {
+		ProjectConfiguration.getInstance().resetConfiguration();
 	}
 
 	@Test
@@ -47,6 +54,7 @@ class SearchFilterFilesTest {
 	@SystemProperty( key = RETEST_PROJECT_ROOT )
 	void getProjectFilterFiles_should_get_all_project_filters() throws IOException {
 		System.setProperty( RETEST_PROJECT_ROOT, filterFolder.toString() );
+		ProjectConfiguration.getInstance().resetConfiguration();
 		final Path someFilter = filterFolder.resolve( "some.filter" );
 		Files.createFile( someFilter );
 		final Path anotherFilter = filterFolder.resolve( "another.filter" );


### PR DESCRIPTION
Gets rid of cluttered log:

```
22:55:18.381 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Searching for project root under /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.386 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Found project root in /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Searching for project root under /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Found project root in /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Searching for project root under /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Found project root in /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Searching for project root under /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Found project root in /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Searching for project root under /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.387 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Found project root in /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.402 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Searching for project root under /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
22:55:18.402 [main] DEBUG de.retest.recheck.configuration.PathBasedProjectRootFinder - Found project root in /Users/roessler/Documents/startup/workspace/recheck-web-tutorial.
```