### PR TITLE
Default should be `loader can NOT load unknown`

### DIFF
--- a/src/main/java/de/retest/recheck/review/ignore/JSFilterLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/JSFilterLoader.java
@@ -15,4 +15,9 @@ public class JSFilterLoader implements Loader<JSFilterImpl> {
 	public String save( final JSFilterImpl ignore ) {
 		return "";
 	}
+
+	@Override
+	public boolean canLoad( final String line ) {
+		return false;
+	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/io/Loader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/Loader.java
@@ -2,9 +2,7 @@ package de.retest.recheck.review.ignore.io;
 
 public interface Loader<T> {
 
-	default boolean canLoad( final String line ) {
-		return true;
-	}
+	boolean canLoad( final String line );
 
 	T load( String line );
 


### PR DESCRIPTION
This gets rid of the following ugliness:
```
22:55:18.652 [main] ERROR de.retest.recheck.ignore.JSFilterImpl - Error opening JS file from 'null':
java.lang.NullPointerException: null
	at java.nio.file.Files.provider(Files.java:97)
	at java.nio.file.Files.newInputStream(Files.java:152)
	at java.nio.file.Files.newBufferedReader(Files.java:2784)
	at de.retest.recheck.ignore.JSFilterImpl.readScriptFile(JSFilterImpl.java:44)
	at de.retest.recheck.ignore.JSFilterImpl.<init>(JSFilterImpl.java:35)
	at de.retest.recheck.review.ignore.JSFilterLoader.load(JSFilterLoader.java:11)
	at de.retest.recheck.review.ignore.JSFilterLoader.load(JSFilterLoader.java:1)
	at de.retest.recheck.review.ignore.io.Loaders.lambda$10(Loaders.java:88)
	at java.util.Optional.map(Optional.java:215)
	at de.retest.recheck.review.ignore.io.Loaders.load(Loaders.java:88)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at de.retest.recheck.review.workers.LoadFilterWorker.load(LoadFilterWorker.java:44)
	at de.retest.recheck.ignore.RecheckIgnoreUtil.loadRecheckIgnore(RecheckIgnoreUtil.java:39)
	at de.retest.recheck.RecheckImpl.<init>(RecheckImpl.java:84)
	at de.retest.recheck.RecheckImpl.<init>(RecheckImpl.java:73)
```