### PR TITLE
Avoid NPE if given image is null

### DIFF
--- a/src/main/java/de/retest/recheck/ui/image/ImageUtils.java
+++ b/src/main/java/de/retest/recheck/ui/image/ImageUtils.java
@@ -194,6 +194,9 @@ public class ImageUtils {
 
 	public static Image scaleProportionallyToMaxWidthHeight( final BufferedImage image, final int maxWidth,
 			final int maxHeight ) {
+		if ( image == null ) {
+			return null;
+		}
 		if ( maxWidth >= image.getWidth() && maxHeight >= image.getHeight() ) {
 			return image;
 		}

--- a/src/test/java/de/retest/recheck/ui/image/ImageUtilsTest.java
+++ b/src/test/java/de/retest/recheck/ui/image/ImageUtilsTest.java
@@ -37,6 +37,11 @@ public class ImageUtilsTest {
 	}
 
 	@Test
+	public void scaling_should_be_robust() throws IOException {
+		assertThat( ImageUtils.scaleProportionallyToMaxWidthHeight( null, 25, 25 ) ).isNull();
+	}
+
+	@Test
 	public void marking_at_0_should_increase_imagesize() throws IOException {
 		final BufferedImage image = ImageUtils.readImage( LOGIN_PNG );
 		final BufferedImage marked = ImageUtils.mark( image, new Rectangle( 0, 5, 96, 16 ) );


### PR DESCRIPTION
java.lang.NullPointerException
                at de.retest.ui.image.ImageUtils.scaleProportionallyToMaxWidthHeight(ImageUtils.java:176)
                at de.retest.gui.helper.ScaledImage.setImage(ScaledImage.java:34)
                at de.retest.gui.helper.ScaledImage.<init>(ScaledImage.java:29)
                at de.retest.gui.helper.TargetNotFoundErrorPanelCreator.createWindowsScreenshotsPanel(TargetNotFoundErrorPanelCreator.java:129)
                at de.retest.gui.helper.TargetNotFoundErrorPanelCreator.createWindowsScreenshotsPanel(TargetNotFoundErrorPanelCreator.java:114)
                at de.retest.gui.helper.TargetNotFoundErrorPanelCreator.createDetailView(TargetNotFoundErrorPanelCreator.java:84)
                at de.retest.gui.helper.TargetNotFoundErrorPanelCreator.buildContent(TargetNotFoundErrorPanelCreator.java:75)
                at de.retest.gui.helper.ReTestErrorHandler.handleTargetNotFound(ReTestErrorHandler.java:99)
                at de.retest.gui.helper.ReTestErrorHandler.handleError(ReTestErrorHandler.java:60)
                at de.retest.gui.recapture.ExportActionSequenceModel$3.run(ExportActionSequenceModel.java:98)