### PR TITLE
Feature/ignelem should ign all attr diffs

### DIFF
--- a/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
@@ -26,7 +26,7 @@ public class ElementFilter implements Filter {
 
 	@Override
 	public boolean matches( final Element element, final AttributeDifference attributeDifference ) {
-		return false;
+		return matcher.test( element );
 	}
 
 	@Override

--- a/src/test/java/de/retest/recheck/review/ignore/ElementFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ElementFilterLoaderTest.java
@@ -11,6 +11,7 @@ import de.retest.recheck.review.ignore.ElementFilter.ElementFilterLoader;
 import de.retest.recheck.review.ignore.matcher.ElementIdMatcher;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.diff.AttributeDifference;
 
 class ElementFilterLoaderTest {
 
@@ -29,6 +30,24 @@ class ElementFilterLoaderTest {
 
 		final ElementIdMatcher matcher = new ElementIdMatcher( element );
 		ignore = new ElementFilter( matcher );
+	}
+
+	@Test
+	void ignore_element_by_tag_should_work() {
+		cut = new ElementFilterLoader();
+		final ElementFilter filter = cut.load( "matcher: type=meta" );
+
+		final IdentifyingAttributes attributes = mock( IdentifyingAttributes.class );
+		when( attributes.get( "type" ) ).thenReturn( "meta" );
+		when( attributes.getType() ).thenReturn( "meta" );
+
+		final Element element = mock( Element.class );
+		when( element.getIdentifyingAttributes() ).thenReturn( attributes );
+
+		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
+
+		assertThat( filter.matches( element ) ).isTrue();
+		assertThat( filter.matches( element, attributeDifference ) ).isTrue();
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/review/ignore/ElementFilterTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ElementFilterTest.java
@@ -40,9 +40,18 @@ class ElementFilterTest {
 	}
 
 	@Test
-	void matches_should_always_be_false() {
+	void matches_diff_should_match_when_element_does() {
 		final Element element = mock( Element.class );
 		when( element.getRetestId() ).thenReturn( "abc" );
+		final AttributeDifference difference = mock( AttributeDifference.class );
+
+		assertThat( cut.matches( element, difference ) ).isTrue();
+	}
+
+	@Test
+	void matches_diff_should_NOT_match_when_element_does() {
+		final Element element = mock( Element.class );
+		when( element.getRetestId() ).thenReturn( "cba" );
 		final AttributeDifference difference = mock( AttributeDifference.class );
 
 		assertThat( cut.matches( element, difference ) ).isFalse();


### PR DESCRIPTION
I have no idea why this was missing ... but it is specified in the docs: https://docs.retest.de/recheck/how-ignore-works/