### PR TITLE
Avoid exception in log

### DIFF
--- a/src/main/java/de/retest/recheck/ui/image/ImageUtils.java
+++ b/src/main/java/de/retest/recheck/ui/image/ImageUtils.java
@@ -230,7 +230,7 @@ public class ImageUtils {
 	}
 
 	public static BufferedImage cutImage( final BufferedImage image, final Rectangle bounds ) {
-		if ( image == null || bounds == null ) {
+		if ( image == null || bounds == null || bounds.width <= 0 || bounds.height <= 0 ) {
 			return null;
 		}
 		if ( bounds.x >= image.getWidth() ) {


### PR DESCRIPTION
01:03:04.273 ERROR [pool-5-thread-3] [de.retest.recheck.ui.image.ImageUtils] - Exception cutting image with width/height 800/1317 to bounds java.awt.Rectangle[x=0,y=0,width=794,height=0]:
 java.awt.image.RasterFormatException: negative or zero height
	at java.awt.image.Raster.<init>(Raster.java:1105)
	at java.awt.image.WritableRaster.<init>(WritableRaster.java:129)
	at sun.awt.image.SunWritableRaster.<init>(SunWritableRaster.java:129)
	at sun.awt.image.ByteComponentRaster.<init>(ByteComponentRaster.java:154)
	at sun.awt.image.ByteInterleavedRaster.<init>(ByteInterleavedRaster.java:191)
	at sun.awt.image.ByteInterleavedRaster.createWritableChild(ByteInterleavedRaster.java:1261)
	at java.awt.image.BufferedImage.getSubimage(BufferedImage.java:1202)
	at de.retest.recheck.ui.image.ImageUtils.cutImage(ImageUtils.java:256)
	at de.retest.recheck.ui.image.ImageUtils.cutImage(ImageUtils.java:226)