### PR TITLE
Fix pixel diff save

### DIFF
--- a/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
@@ -9,8 +9,10 @@ import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.review.ignore.io.RegexLoader;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.diff.AttributeDifference;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+@Getter
 @Slf4j
 public class PixelDiffFilter implements Filter {
 

--- a/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
@@ -19,14 +19,14 @@ public class PixelDiffFilter implements Filter {
 	private static final String PIXEL = "px";
 
 	/**
-	 * Indicates whether {@link #pixelDiff} is specified as float ({@code true}) or integer ({@code false}). Although
+	 * Indicates whether {@link #pixelDiff} is specified as double ({@code true}) or integer ({@code false}). Although
 	 * internally it is always treated as a double, this is important for serialization.
 	 */
-	private final boolean specifiedAsFloat;
+	private final boolean specifiedAsDouble;
 	private final double pixelDiff;
 
-	public PixelDiffFilter( final boolean specifiedAsFloat, final double pixelDiff ) {
-		this.specifiedAsFloat = specifiedAsFloat;
+	public PixelDiffFilter( final boolean specifiedAsDouble, final double pixelDiff ) {
+		this.specifiedAsDouble = specifiedAsDouble;
 		this.pixelDiff = pixelDiff;
 	}
 
@@ -84,7 +84,7 @@ public class PixelDiffFilter implements Filter {
 
 	@Override
 	public String toString() {
-		final String value = specifiedAsFloat ? Double.toString( pixelDiff ) : Integer.toString( (int) pixelDiff );
+		final String value = specifiedAsDouble ? Double.toString( pixelDiff ) : Integer.toString( (int) pixelDiff );
 		return String.format( PixelDiffFilterLoader.FORMAT, value );
 	}
 
@@ -101,9 +101,9 @@ public class PixelDiffFilter implements Filter {
 		@Override
 		protected PixelDiffFilter load( final MatchResult regex ) {
 			final String value = regex.group( 1 );
-			final boolean specifiedAsFloat = value.contains( "." );
+			final boolean specifiedAsDouble = value.contains( "." );
 			final double pixelDiff = Double.parseDouble( value );
-			return new PixelDiffFilter( specifiedAsFloat, pixelDiff );
+			return new PixelDiffFilter( specifiedAsDouble, pixelDiff );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
@@ -16,9 +16,15 @@ public class PixelDiffFilter implements Filter {
 
 	private static final String PIXEL = "px";
 
+	/**
+	 * Indicates whether {@link #pixelDiff} is specified as float ({@code true}) or integer ({@code false}). Although
+	 * internally it is always treated as a double, this is important for serialization.
+	 */
+	private final boolean specifiedAsFloat;
 	private final double pixelDiff;
 
-	public PixelDiffFilter( final double pixelDiff ) {
+	public PixelDiffFilter( final boolean specifiedAsFloat, final double pixelDiff ) {
+		this.specifiedAsFloat = specifiedAsFloat;
 		this.pixelDiff = pixelDiff;
 	}
 
@@ -76,7 +82,8 @@ public class PixelDiffFilter implements Filter {
 
 	@Override
 	public String toString() {
-		return String.format( PixelDiffFilterLoader.FORMAT, pixelDiff );
+		final String value = specifiedAsFloat ? Double.toString( pixelDiff ) : Integer.toString( (int) pixelDiff );
+		return String.format( PixelDiffFilterLoader.FORMAT, value );
 	}
 
 	public static class PixelDiffFilterLoader extends RegexLoader<PixelDiffFilter> {
@@ -91,8 +98,10 @@ public class PixelDiffFilter implements Filter {
 
 		@Override
 		protected PixelDiffFilter load( final MatchResult regex ) {
-			final double pixelDiff = Double.parseDouble( regex.group( 1 ) );
-			return new PixelDiffFilter( pixelDiff );
+			final String value = regex.group( 1 );
+			final boolean specifiedAsFloat = value.contains( "." );
+			final double pixelDiff = Double.parseDouble( value );
+			return new PixelDiffFilter( specifiedAsFloat, pixelDiff );
 		}
 	}
 }

--- a/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterLoaderTest.java
@@ -27,13 +27,13 @@ class PixelDiffFilterLoaderTest {
 		final String intDiff = "pixel-diff=5";
 		assertThat( cut.canLoad( intDiff ) ).isTrue();
 		final PixelDiffFilter loadedIntDiff = cut.load( intDiff );
-		assertThat( loadedIntDiff.isSpecifiedAsFloat() ).isFalse();
+		assertThat( loadedIntDiff.isSpecifiedAsDouble() ).isFalse();
 		assertThat( loadedIntDiff.getPixelDiff() ).isEqualTo( 5.0 );
 
 		final String doubleDiff = "pixel-diff=5.0";
 		assertThat( cut.canLoad( doubleDiff ) ).isTrue();
 		final PixelDiffFilter loadedDoubleDiff = cut.load( doubleDiff );
-		assertThat( loadedDoubleDiff.isSpecifiedAsFloat() ).isTrue();
+		assertThat( loadedDoubleDiff.isSpecifiedAsDouble() ).isTrue();
 		assertThat( loadedDoubleDiff.getPixelDiff() ).isEqualTo( 5.0 );
 	}
 

--- a/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterLoaderTest.java
@@ -26,11 +26,15 @@ class PixelDiffFilterLoaderTest {
 
 		final String intDiff = "pixel-diff=5";
 		assertThat( cut.canLoad( intDiff ) ).isTrue();
-		assertThat( cut.load( intDiff ) ).hasFieldOrPropertyWithValue( "pixelDiff", 5.0 );
+		final PixelDiffFilter loadedIntDiff = cut.load( intDiff );
+		assertThat( loadedIntDiff.isSpecifiedAsFloat() ).isFalse();
+		assertThat( loadedIntDiff.getPixelDiff() ).isEqualTo( 5.0 );
 
 		final String doubleDiff = "pixel-diff=5.0";
 		assertThat( cut.canLoad( doubleDiff ) ).isTrue();
-		assertThat( cut.load( doubleDiff ) ).hasFieldOrPropertyWithValue( "pixelDiff", 5.0 );
+		final PixelDiffFilter loadedDoubleDiff = cut.load( doubleDiff );
+		assertThat( loadedDoubleDiff.isSpecifiedAsFloat() ).isTrue();
+		assertThat( loadedDoubleDiff.getPixelDiff() ).isEqualTo( 5.0 );
 	}
 
 }

--- a/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterTest.java
@@ -14,7 +14,7 @@ import de.retest.recheck.ui.diff.AttributeDifference;
 class PixelDiffFilterTest {
 
 	double pixelDiff = 5.0;
-	Filter cut = new PixelDiffFilter( pixelDiff );
+	Filter cut = new PixelDiffFilter( false, pixelDiff );
 
 	@Test
 	void should_filter_diff_when_pixel_diff_is_not_exceeded() throws Exception {
@@ -31,7 +31,7 @@ class PixelDiffFilterTest {
 		final Rectangle actual = new Rectangle( 1, -1, 15, 5 );
 		final AttributeDifference diff = new AttributeDifference( "outline", expected, actual );
 
-		final Filter cut = new PixelDiffFilter( 0.0 );
+		final Filter cut = new PixelDiffFilter( false, 0.0 );
 
 		assertThat( cut.matches( mock( Element.class ), diff ) ).isFalse();
 	}

--- a/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterTest.java
@@ -81,4 +81,10 @@ class PixelDiffFilterTest {
 		assertThat( cut.matches( mock( Element.class ), diff ) ).isFalse();
 	}
 
+	@Test
+	void specifiedAsDouble_flag_should_control_toString() throws Exception {
+		assertThat( new PixelDiffFilter( false, 0.0 ) ).hasToString( "pixel-diff=0" );
+		assertThat( new PixelDiffFilter( true, 0.0 ) ).hasToString( "pixel-diff=0.0" );
+	}
+
 }

--- a/src/test/resources/de/retest/recheck/review/workers/recheck.ignore
+++ b/src/test/resources/de/retest/recheck/review/workers/recheck.ignore
@@ -17,3 +17,6 @@ attribute-regex= .*
 
 # Intentional error to trigger logging 
 attribute:outline
+
+pixel-diff=5
+pixel-diff=5.0


### PR DESCRIPTION
Both float (`pixel-diff=5.0`) and integer (`pixel-diff=5`) is allowed for specifying allowed pixel diffs in a `recheck.ignore`. However, as we internally always treat it as a double, we have to remember how it has been specified such that we don't manipulate existing ignore files.