### PR TITLE
Remove obsolete XML migrator instances

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/migration/XmlMigratorInstances.java
+++ b/src/main/java/de/retest/recheck/persistence/migration/XmlMigratorInstances.java
@@ -56,14 +56,6 @@ public enum XmlMigratorInstances {
 					.toList();
 		}
 	},
-	de_retest_recheck_report_ReplayResult() {
-		@Override
-		List<Pair<Integer, XmlTransformer>> migrations() {
-			return new MigrationPairs() //
-					.add( 20, IncompatibleChangesTransformer.recheckVersion1() ) //
-					.toList();
-		}
-	},
 	de_retest_recheck_test_Test() {
 		@Override
 		List<Pair<Integer, XmlTransformer>> migrations() {
@@ -78,14 +70,6 @@ public enum XmlMigratorInstances {
 					.add( 1, new AddRetestIdTestTransformer() ) //
 					.add( 2, new ContainedComponents2ContainedElementsTransformer() ) //
 					.add( 3, new PathAndType2LowerCaseTransformer() ) //
-					.toList();
-		}
-	},
-	de_retest_recheck_report_TestReport() {
-		@Override
-		List<Pair<Integer, XmlTransformer>> migrations() {
-			return new MigrationPairs() //
-					.add( 20, IncompatibleChangesTransformer.recheckVersion1() ) //
 					.toList();
 		}
 	};

--- a/src/test/java/de/retest/recheck/persistence/migration/XmlMigratorInstancesTest.java
+++ b/src/test/java/de/retest/recheck/persistence/migration/XmlMigratorInstancesTest.java
@@ -37,7 +37,6 @@ public class XmlMigratorInstancesTest {
 		assertThat( XmlMigratorInstances.get( "de.retest.recheck.ui.actions.ActionSequence" ) ).isNotNull();
 		assertThat( XmlMigratorInstances.get( "de.retest.recheck.suite.CapturedSuite" ) ).isNotNull();
 		assertThat( XmlMigratorInstances.get( "de.retest.recheck.suite.ExecutableSuite" ) ).isNotNull();
-		assertThat( XmlMigratorInstances.get( "de.retest.recheck.report.ReplayResult" ) ).isNotNull();
 		assertThat( XmlMigratorInstances.get( "de.retest.recheck.test.Test" ) ).isNotNull();
 		assertThat( XmlMigratorInstances.get( "de.retest.recheck.ui.descriptors.SutState" ) ).isNotNull();
 	}


### PR DESCRIPTION
Made a mistake during rebase, which is how these changes from #148 have been integrated. As we don't migrate reports at all (since they are binary files), the migrators can be removed.