### PR TITLE
Feature/options filter

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -4,7 +4,6 @@ import static de.retest.recheck.util.FileUtil.normalize;
 
 import java.awt.HeadlessException;
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -15,9 +14,7 @@ import org.slf4j.LoggerFactory;
 import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.execution.RecheckAdapters;
 import de.retest.recheck.execution.RecheckDifferenceFinder;
-import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.ignore.RecheckIgnoreUtil;
 import de.retest.recheck.persistence.CloudPersistence;
 import de.retest.recheck.persistence.FileNamer;
 import de.retest.recheck.persistence.RecheckSutState;
@@ -26,7 +23,6 @@ import de.retest.recheck.printer.TestReplayResultPrinter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
-import de.retest.recheck.review.GlobalIgnoreApplier;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.recheck.ui.diff.LeafDifference;
@@ -82,9 +78,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suiteName = options.getSuiteName();
 		suite = SuiteAggregator.getInstance().getSuite( suiteName );
 
-		final GlobalIgnoreApplier globalIgnoreApplier = RecheckIgnoreUtil.loadRecheckIgnore();
-		final GlobalIgnoreApplier suiteIgnoreApplier = RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() );
-		filter = new CompoundFilter( Arrays.asList( globalIgnoreApplier, suiteIgnoreApplier ) );
+		filter = options.getFilter();
 
 		printer = new TestReplayResultPrinter( usedFinders::get, filter );
 
@@ -157,10 +151,6 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 			adapter.notifyAboutDifferences( actionReplayResult );
 		}
 		return actionReplayResult;
-	}
-
-	private File getSuitePath() {
-		return fileNamerStrategy.createFileNamer( suiteName ).getFile( "" );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -1,24 +1,91 @@
 package de.retest.recheck;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.experimental.SuperBuilder;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
-@SuperBuilder
+import de.retest.recheck.ignore.CompoundFilter;
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.ignore.RecheckIgnoreUtil;
+import lombok.Getter;
+
 @Getter
 public class RecheckOptions {
 
-	@Builder.Default
-	private final FileNamerStrategy fileNamerStrategy = new MavenConformFileNamerStrategy();
+	private final FileNamerStrategy fileNamerStrategy;
+	private final String suiteName;
+	private final boolean reportUploadEnabled;
+	private final Filter filter;
 
-	@Builder.Default
-	private final String suiteName = null;
-
-	@Builder.Default
-	private final boolean reportUploadEnabled = false;
+	public RecheckOptions( final FileNamerStrategy fileNamerStrategy, final String suiteName,
+			final boolean reportUploadEnabled, final Filter filter ) {
+		this.fileNamerStrategy = fileNamerStrategy;
+		this.suiteName = suiteName;
+		this.reportUploadEnabled = reportUploadEnabled;
+		this.filter = filter;
+	}
 
 	public String getSuiteName() {
 		return suiteName == null ? fileNamerStrategy.getTestClassName() : suiteName;
 	}
 
+	public static RecheckOptionsBuilder builder() {
+		return new RecheckOptionsBuilder();
+	}
+
+	public static class RecheckOptionsBuilder {
+		private FileNamerStrategy fileNamerStrategy = new MavenConformFileNamerStrategy();
+		private String suiteName = null;
+		private boolean reportUploadEnabled = false;
+		private Filter filter = null;
+		private final List<Filter> filterToAdd =
+				new ArrayList<>( Arrays.asList( RecheckIgnoreUtil.loadRecheckIgnore() ) );
+		private boolean addSuiteFilter = true;
+
+		public RecheckOptionsBuilder fileNamerStrategy( final FileNamerStrategy fileNamerStrategy ) {
+			this.fileNamerStrategy = fileNamerStrategy;
+			return this;
+		}
+
+		public RecheckOptionsBuilder suiteName( final String suiteName ) {
+			this.suiteName = suiteName;
+			return this;
+		}
+
+		public RecheckOptionsBuilder reportUploadEnabled( final boolean reportUploadEnabled ) {
+			this.reportUploadEnabled = reportUploadEnabled;
+			return this;
+		}
+
+		public RecheckOptionsBuilder filter( final Filter filter ) {
+			addSuiteFilter = false;
+			this.filter = filter;
+			return this;
+		}
+
+		public RecheckOptionsBuilder addFilter( final Filter added ) {
+			if ( filter instanceof CompoundFilter ) {
+				filterToAdd.add( added );
+			} else {
+				throw new IllegalStateException(
+						"Can only combine `filter()` and `add(filter)` if the set filter is of type `CompoundFilter`." );
+			}
+			return this;
+		}
+
+		private File getSuitePath() {
+			return fileNamerStrategy.createFileNamer( suiteName ).getFile( "" );
+		}
+
+		public RecheckOptions build() {
+			if ( addSuiteFilter ) {
+				filterToAdd.add( RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() ) );
+			}
+			if ( filter == null ) {
+				filter = new CompoundFilter( filter );
+			}
+			return new RecheckOptions( fileNamerStrategy, suiteName, reportUploadEnabled, filter );
+		}
+	}
 }

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -15,7 +15,7 @@ public class RecheckOptions {
 	private final String suiteName = null;
 
 	@Builder.Default
-	private boolean reportUploadEnabled = false;
+	private final boolean reportUploadEnabled = false;
 
 	public String getSuiteName() {
 		return suiteName == null ? fileNamerStrategy.getTestClassName() : suiteName;

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -20,17 +20,13 @@ public class RecheckOptions {
 	private final boolean reportUploadEnabled;
 	private final Filter filter;
 
-	public String getSuiteName() {
-		return suiteName == null ? fileNamerStrategy.getTestClassName() : suiteName;
-	}
-
 	public static RecheckOptionsBuilder builder() {
 		return new RecheckOptionsBuilder();
 	}
 
 	public static class RecheckOptionsBuilder {
 		private FileNamerStrategy fileNamerStrategy = new MavenConformFileNamerStrategy();
-		private String suiteName = null;
+		private String suiteName = fileNamerStrategy.getTestClassName();
 		private boolean reportUploadEnabled = false;
 		private Filter filter = null;
 		private final List<Filter> filterToAdd = new ArrayList<>();

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -53,8 +53,8 @@ public class RecheckOptions {
 			return this;
 		}
 
-		public RecheckOptionsBuilder reportUploadEnabled( final boolean reportUploadEnabled ) {
-			this.reportUploadEnabled = reportUploadEnabled;
+		public RecheckOptionsBuilder enableReportUpload() {
+			reportUploadEnabled = true;
 			return this;
 		}
 

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -65,11 +65,11 @@ public class RecheckOptions {
 		}
 
 		public RecheckOptionsBuilder addFilter( final Filter added ) {
-			if ( filter instanceof CompoundFilter ) {
+			if ( filter == null ) {
 				filterToAdd.add( added );
 			} else {
 				throw new IllegalStateException(
-						"Can only combine `filter()` and `add(filter)` if the set filter is of type `CompoundFilter`." );
+						"Cannot combine `filter()` and `add(filter)`. Use a `CompoundFilter` to do that." );
 			}
 			return this;
 		}
@@ -83,7 +83,7 @@ public class RecheckOptions {
 				filterToAdd.add( RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() ) );
 			}
 			if ( filter == null ) {
-				filter = new CompoundFilter( filter );
+				filter = new CompoundFilter( filterToAdd );
 			}
 			return new RecheckOptions( fileNamerStrategy, suiteName, reportUploadEnabled, filter );
 		}

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -35,6 +35,7 @@ public class RecheckOptions {
 
 		public RecheckOptionsBuilder fileNamerStrategy( final FileNamerStrategy fileNamerStrategy ) {
 			this.fileNamerStrategy = fileNamerStrategy;
+			suiteName = fileNamerStrategy.getTestClassName();
 			return this;
 		}
 

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -2,14 +2,16 @@ package de.retest.recheck;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor( access = AccessLevel.PRIVATE )
 @Getter
 public class RecheckOptions {
 
@@ -17,14 +19,6 @@ public class RecheckOptions {
 	private final String suiteName;
 	private final boolean reportUploadEnabled;
 	private final Filter filter;
-
-	public RecheckOptions( final FileNamerStrategy fileNamerStrategy, final String suiteName,
-			final boolean reportUploadEnabled, final Filter filter ) {
-		this.fileNamerStrategy = fileNamerStrategy;
-		this.suiteName = suiteName;
-		this.reportUploadEnabled = reportUploadEnabled;
-		this.filter = filter;
-	}
 
 	public String getSuiteName() {
 		return suiteName == null ? fileNamerStrategy.getTestClassName() : suiteName;
@@ -39,9 +33,9 @@ public class RecheckOptions {
 		private String suiteName = null;
 		private boolean reportUploadEnabled = false;
 		private Filter filter = null;
-		private final List<Filter> filterToAdd =
-				new ArrayList<>( Arrays.asList( RecheckIgnoreUtil.loadRecheckIgnore() ) );
-		private boolean addSuiteFilter = true;
+		private final List<Filter> filterToAdd = new ArrayList<>();
+
+		private RecheckOptionsBuilder() {}
 
 		public RecheckOptionsBuilder fileNamerStrategy( final FileNamerStrategy fileNamerStrategy ) {
 			this.fileNamerStrategy = fileNamerStrategy;
@@ -58,8 +52,7 @@ public class RecheckOptions {
 			return this;
 		}
 
-		public RecheckOptionsBuilder filter( final Filter filter ) {
-			addSuiteFilter = false;
+		public RecheckOptionsBuilder setFilter( final Filter filter ) {
 			this.filter = filter;
 			return this;
 		}
@@ -69,23 +62,22 @@ public class RecheckOptions {
 				filterToAdd.add( added );
 			} else {
 				throw new IllegalStateException(
-						"Cannot combine `filter()` and `add(filter)`. Use a `CompoundFilter` to do that." );
+						"Cannot combine `setFilter()` and `add(Filter)`. Use a `CompoundFilter` to do that." );
 			}
 			return this;
 		}
 
-		private File getSuitePath() {
-			return fileNamerStrategy.createFileNamer( suiteName ).getFile( "" );
-		}
-
 		public RecheckOptions build() {
-			if ( addSuiteFilter ) {
-				filterToAdd.add( RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() ) );
-			}
 			if ( filter == null ) {
+				filterToAdd.add( RecheckIgnoreUtil.loadRecheckIgnore() );
+				filterToAdd.add( RecheckIgnoreUtil.loadRecheckSuiteIgnore( getSuitePath() ) );
 				filter = new CompoundFilter( filterToAdd );
 			}
 			return new RecheckOptions( fileNamerStrategy, suiteName, reportUploadEnabled, filter );
+		}
+
+		private File getSuitePath() {
+			return fileNamerStrategy.createFileNamer( suiteName ).getFile( "" );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/ignore/CompoundFilter.java
+++ b/src/main/java/de/retest/recheck/ignore/CompoundFilter.java
@@ -1,7 +1,7 @@
 package de.retest.recheck.ignore;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import de.retest.recheck.ui.descriptors.Element;
@@ -11,16 +11,16 @@ public class CompoundFilter implements Filter {
 
 	private final List<Filter> filters;
 
-	public CompoundFilter( final List<Filter> filters ) {
-		this.filters = new ArrayList<>( filters );
+	public CompoundFilter() {
+		this( Collections.emptyList() );
 	}
 
 	public CompoundFilter( final Filter... filters ) {
-		this.filters = new ArrayList<>( Arrays.asList( filters ) );
+		this( Arrays.asList( filters ) );
 	}
 
-	public CompoundFilter() {
-		filters = new ArrayList<>();
+	public CompoundFilter( final List<Filter> filters ) {
+		this.filters = filters;
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/ignore/CompoundFilter.java
+++ b/src/main/java/de/retest/recheck/ignore/CompoundFilter.java
@@ -1,5 +1,7 @@
 package de.retest.recheck.ignore;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import de.retest.recheck.ui.descriptors.Element;
@@ -10,7 +12,15 @@ public class CompoundFilter implements Filter {
 	private final List<Filter> filters;
 
 	public CompoundFilter( final List<Filter> filters ) {
-		this.filters = filters;
+		this.filters = new ArrayList<>( filters );
+	}
+
+	public CompoundFilter( final Filter... filters ) {
+		this.filters = new ArrayList<>( Arrays.asList( filters ) );
+	}
+
+	public CompoundFilter() {
+		filters = new ArrayList<>();
 	}
 
 	@Override

--- a/src/test/java/de/retest/recheck/RecheckImplTest.java
+++ b/src/test/java/de/retest/recheck/RecheckImplTest.java
@@ -119,7 +119,7 @@ public class RecheckImplTest {
 	@Test
 	public void headless_no_key_should_result_in_AssertionError() throws Exception {
 		final RecheckOptions opts = RecheckOptions.builder() //
-				.reportUploadEnabled( true ) //
+				.enableReportUpload() //
 				.build();
 		mockStatic( Rehub.class );
 		doThrow( new HeadlessException() ).when( Rehub.class, method( Rehub.class, "init" ) ).withNoArguments();

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -3,27 +3,21 @@ package de.retest.recheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.ignore.RecheckIgnoreUtil;
 
-@RunWith( PowerMockRunner.class )
-@PrepareForTest( RecheckIgnoreUtil.class )
-public class RecheckOptionsTest {
+class RecheckOptionsTest {
 
 	@Test
-	public void should_reuse_file_namer_strategy_for_suite_name() throws Exception {
+	void should_reuse_file_namer_strategy_for_suite_name() throws Exception {
 		final RecheckOptions cut = RecheckOptions.builder().build();
 		assertThat( cut.getSuiteName() ).isEqualTo( getClass().getName() );
 	}
 
 	@Test
-	public void should_use_suite_name_if_set() throws Exception {
+	void should_use_suite_name_if_set() throws Exception {
 		final RecheckOptions cut = RecheckOptions.builder() //
 				.suiteName( "bar" ) //
 				.build();
@@ -31,7 +25,7 @@ public class RecheckOptionsTest {
 	}
 
 	@Test
-	public void should_use_reportUploadEnabled() {
+	void should_use_reportUploadEnabled() {
 		final RecheckOptions cut = RecheckOptions.builder() //
 				.enableReportUpload() //
 				.build();
@@ -39,7 +33,7 @@ public class RecheckOptionsTest {
 	}
 
 	@Test
-	public void addFilter_should_add_filter_to_existing() {
+	void addFilter_should_add_filter_to_existing() {
 		final Filter filter = mock( Filter.class );
 		final RecheckOptions cut = RecheckOptions.builder() //
 				.addFilter( filter ) //
@@ -49,7 +43,7 @@ public class RecheckOptionsTest {
 	}
 
 	@Test
-	public void filter_should_replace_existing() {
+	void setFilter_should_replace_existing() {
 		final Filter filter = mock( Filter.class );
 		final RecheckOptions cut = RecheckOptions.builder() //
 				.setFilter( filter ) //

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -76,7 +76,7 @@ public class RecheckOptionsTest {
 	public void filter_should_replace_existing() {
 		final Filter filter = mock( Filter.class );
 		final RecheckOptions cut = RecheckOptions.builder() //
-				.filter( filter ) //
+				.setFilter( filter ) //
 				.build();
 		assertThat( cut.getFilter() ).isEqualTo( filter );
 	}

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -57,7 +57,7 @@ public class RecheckOptionsTest {
 	@Test
 	public void should_use_reportUploadEnabled() {
 		final RecheckOptions cut = RecheckOptions.builder() //
-				.reportUploadEnabled( true ) //
+				.enableReportUpload() //
 				.build();
 		assertThat( cut.isReportUploadEnabled() ).isEqualTo( true );
 	}

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -15,6 +15,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import de.retest.recheck.ignore.CompoundFilter;
+import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
 import de.retest.recheck.persistence.FileNamer;
 
@@ -41,6 +43,7 @@ public class RecheckOptionsTest {
 				.build();
 
 		assertThat( cut.getSuiteName() ).isEqualTo( fileNamerStrategy.getTestClassName() );
+		assertThat( cut.getFileNamerStrategy() ).isEqualTo( fileNamerStrategy );
 	}
 
 	@Test
@@ -51,4 +54,30 @@ public class RecheckOptionsTest {
 		assertThat( cut.getSuiteName() ).isEqualTo( "bar" );
 	}
 
+	@Test
+	public void should_use_reportUploadEnabled() {
+		final RecheckOptions cut = RecheckOptions.builder() //
+				.reportUploadEnabled( true ) //
+				.build();
+		assertThat( cut.isReportUploadEnabled() ).isEqualTo( true );
+	}
+
+	@Test
+	public void addFilter_should_add_filter_to_existing() {
+		final Filter filter = mock( Filter.class );
+		final RecheckOptions cut = RecheckOptions.builder() //
+				.addFilter( filter ) //
+				.build();
+		assertThat( cut.getFilter() ).isInstanceOf( CompoundFilter.class );
+		assertThat( ((CompoundFilter) cut.getFilter()).getFilters() ).contains( filter );
+	}
+
+	@Test
+	public void filter_should_replace_existing() {
+		final Filter filter = mock( Filter.class );
+		final RecheckOptions cut = RecheckOptions.builder() //
+				.filter( filter ) //
+				.build();
+		assertThat( cut.getFilter() ).isEqualTo( filter );
+	}
 }

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -39,7 +39,10 @@ class RecheckOptionsTest {
 				.addFilter( filter ) //
 				.build();
 		assertThat( cut.getFilter() ).isInstanceOf( CompoundFilter.class );
-		assertThat( ((CompoundFilter) cut.getFilter()).getFilters() ).contains( filter );
+		final CompoundFilter compoundFilter = (CompoundFilter) cut.getFilter();
+		// added filter + global ignore + suite ignore
+		assertThat( compoundFilter.getFilters() ).hasSize( 3 );
+		assertThat( compoundFilter.getFilters() ).contains( filter );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -2,6 +2,8 @@ package de.retest.recheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,8 +14,12 @@ class RecheckOptionsTest {
 
 	@Test
 	void should_reuse_file_namer_strategy_for_suite_name() throws Exception {
-		final RecheckOptions cut = RecheckOptions.builder().build();
-		assertThat( cut.getSuiteName() ).isEqualTo( getClass().getName() );
+		final FileNamerStrategy fileNamerStrategy = spy( new MavenConformFileNamerStrategy() );
+		when( fileNamerStrategy.getTestClassName() ).thenReturn( "foo" );
+		final RecheckOptions cut = RecheckOptions.builder() //
+				.fileNamerStrategy( fileNamerStrategy ) //
+				.build();
+		assertThat( cut.getSuiteName() ).isEqualTo( "foo" );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -1,15 +1,40 @@
 package de.retest.recheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
 
-import org.junit.jupiter.api.Test;
+import java.io.File;
 
-class RecheckOptionsTest {
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import de.retest.recheck.ignore.RecheckIgnoreUtil;
+import de.retest.recheck.persistence.FileNamer;
+
+@RunWith( PowerMockRunner.class )
+@PrepareForTest( RecheckIgnoreUtil.class )
+public class RecheckOptionsTest {
 
 	@Test
-	void should_reuse_file_namer_strategy_for_suite_name() throws Exception {
+	public void should_reuse_file_namer_strategy_for_suite_name() throws Exception {
+		mockStatic( RecheckIgnoreUtil.class );
+		PowerMockito
+				.when( RecheckIgnoreUtil.class,
+						method( RecheckIgnoreUtil.class, "loadRecheckSuiteIgnore", File.class ) )
+				.withArguments( any() ).thenReturn( null );
+
 		final FileNamerStrategy fileNamerStrategy = mock( FileNamerStrategy.class );
+
+		final FileNamer fileNamer = mock( FileNamer.class );
+		when( fileNamerStrategy.createFileNamer( any() ) ).thenReturn( fileNamer );
+		when( fileNamerStrategy.getTestClassName() ).thenReturn( "SOME_SPECIAL_VALUE" );
 
 		final RecheckOptions cut = RecheckOptions.builder() //
 				.fileNamerStrategy( fileNamerStrategy ) //
@@ -19,7 +44,7 @@ class RecheckOptionsTest {
 	}
 
 	@Test
-	void should_use_suite_name_if_set() throws Exception {
+	public void should_use_suite_name_if_set() throws Exception {
 		final RecheckOptions cut = RecheckOptions.builder() //
 				.suiteName( "bar" ) //
 				.build();

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -1,24 +1,16 @@
 package de.retest.recheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.support.membermodification.MemberMatcher.method;
-
-import java.io.File;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
-import de.retest.recheck.persistence.FileNamer;
 
 @RunWith( PowerMockRunner.class )
 @PrepareForTest( RecheckIgnoreUtil.class )
@@ -26,24 +18,8 @@ public class RecheckOptionsTest {
 
 	@Test
 	public void should_reuse_file_namer_strategy_for_suite_name() throws Exception {
-		mockStatic( RecheckIgnoreUtil.class );
-		PowerMockito
-				.when( RecheckIgnoreUtil.class,
-						method( RecheckIgnoreUtil.class, "loadRecheckSuiteIgnore", File.class ) )
-				.withArguments( any() ).thenReturn( null );
-
-		final FileNamerStrategy fileNamerStrategy = mock( FileNamerStrategy.class );
-
-		final FileNamer fileNamer = mock( FileNamer.class );
-		when( fileNamerStrategy.createFileNamer( any() ) ).thenReturn( fileNamer );
-		when( fileNamerStrategy.getTestClassName() ).thenReturn( "SOME_SPECIAL_VALUE" );
-
-		final RecheckOptions cut = RecheckOptions.builder() //
-				.fileNamerStrategy( fileNamerStrategy ) //
-				.build();
-
-		assertThat( cut.getSuiteName() ).isEqualTo( fileNamerStrategy.getTestClassName() );
-		assertThat( cut.getFileNamerStrategy() ).isEqualTo( fileNamerStrategy );
+		final RecheckOptions cut = RecheckOptions.builder().build();
+		assertThat( cut.getSuiteName() ).isEqualTo( getClass().getName() );
 	}
 
 	@Test


### PR DESCRIPTION
As far as I understood, this should be a first step towards solving https://github.com/retest/recheck-web/issues/326:
"As long as there's a way to ignore on demand, via code I'm fine."

Anyways this is a good idea. 

Now it's great that we filter only for assertions, but still report any differences in the report ... making this a sensible and unproblematic change.