### PR TITLE
Feature/fix report filter if no diff

### DIFF
--- a/src/main/java/de/retest/recheck/report/ActionReplayResult.java
+++ b/src/main/java/de/retest/recheck/report/ActionReplayResult.java
@@ -102,7 +102,7 @@ public class ActionReplayResult implements Serializable {
 		if ( error != null || targetNotFound != null ) {
 			return withError( data, ErrorHolder.of( error, targetNotFound ) );
 		}
-		if ( !difference.getRootElementDifferences().isEmpty() ) {
+		if ( difference != null && !difference.getRootElementDifferences().isEmpty() ) {
 			return withDifference( data, WindowRetriever.empty(), DifferenceRetriever.of( difference ),
 					actualDuration );
 		}

--- a/src/main/java/de/retest/recheck/report/TestReportFilter.java
+++ b/src/main/java/de/retest/recheck/report/TestReportFilter.java
@@ -59,17 +59,14 @@ public class TestReportFilter {
 		final StateDifference newStateDifference = filter( actionReplayResult.getStateDifference(), filter );
 		final long actualDuration = actionReplayResult.getDuration();
 		final SutState actualState = new SutState( actionReplayResult.getWindows() );
-		final ActionReplayResult newActionReplayResult = ActionReplayResult.createActionReplayResult( data, error,
-				targetNotFound, newStateDifference, actualDuration, actualState );
-		return newActionReplayResult;
+		return ActionReplayResult.createActionReplayResult( data, error, targetNotFound, newStateDifference,
+				actualDuration, actualState );
 	}
 
 	static StateDifference filter( final StateDifference stateDifference, final Filter filter ) {
 		final List<RootElementDifference> newRootElementDifferences =
 				filter( stateDifference.getRootElementDifferences(), filter );
-		final StateDifference newStateDifference =
-				new StateDifference( newRootElementDifferences, stateDifference.getDurationDifference() );
-		return newStateDifference;
+		return new StateDifference( newRootElementDifferences, stateDifference.getDurationDifference() );
 	}
 
 	static List<RootElementDifference> filter( final List<RootElementDifference> rootElementDifferences,
@@ -83,9 +80,8 @@ public class TestReportFilter {
 
 	static RootElementDifference filter( final RootElementDifference rootElementDifference, final Filter filter ) {
 		final ElementDifference newElementDifference = filter( rootElementDifference.getElementDifference(), filter );
-		final RootElementDifference newRootElementDifference = new RootElementDifference( newElementDifference,
-				rootElementDifference.getExpectedDescriptor(), rootElementDifference.getActualDescriptor() );
-		return newRootElementDifference;
+		return new RootElementDifference( newElementDifference, rootElementDifference.getExpectedDescriptor(),
+				rootElementDifference.getActualDescriptor() );
 	}
 
 	static ElementDifference filter( final ElementDifference elementDiff, final Filter filter ) {
@@ -102,10 +98,8 @@ public class TestReportFilter {
 		if ( !elementDiff.getChildDifferences().isEmpty() ) {
 			childDifferences = filter( elementDiff.getChildDifferences(), filter );
 		}
-		final ElementDifference newElementDiff =
-				new ElementDifference( elementDiff.getElement(), attributesDifference, identifyingAttributesDifference,
-						elementDiff.getExpectedScreenshot(), elementDiff.getActualScreenshot(), childDifferences );
-		return newElementDiff;
+		return new ElementDifference( elementDiff.getElement(), attributesDifference, identifyingAttributesDifference,
+				elementDiff.getExpectedScreenshot(), elementDiff.getActualScreenshot(), childDifferences );
 	}
 
 	static Collection<ElementDifference> filter( final Collection<ElementDifference> elementDifferences,

--- a/src/main/java/de/retest/recheck/report/TestReportFilter.java
+++ b/src/main/java/de/retest/recheck/report/TestReportFilter.java
@@ -64,6 +64,9 @@ public class TestReportFilter {
 	}
 
 	static StateDifference filter( final StateDifference stateDifference, final Filter filter ) {
+		if ( stateDifference == null || stateDifference.getRootElementDifferences().isEmpty() ) {
+			return stateDifference;
+		}
 		final List<RootElementDifference> newRootElementDifferences =
 				filter( stateDifference.getRootElementDifferences(), filter );
 		return new StateDifference( newRootElementDifferences, stateDifference.getDurationDifference() );

--- a/src/test/java/de/retest/recheck/report/ActionReplayResultTest.java
+++ b/src/test/java/de/retest/recheck/report/ActionReplayResultTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mockito;
 
 import de.retest.recheck.execution.RecheckDifferenceFinder;
 import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.report.action.ActionReplayData;
 import de.retest.recheck.review.ignore.AttributeFilter;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.Path;
@@ -20,6 +21,7 @@ import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.descriptors.MutableAttributes;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
+import de.retest.recheck.ui.diff.StateDifference;
 
 class ActionReplayResultTest {
 
@@ -109,4 +111,25 @@ class ActionReplayResultTest {
 		assertThat( differences.getWindows() ).isEmpty();
 	}
 
+	@Test
+	void factory_method_should_return_no_difference_if_state_is_null() {
+		final ActionReplayData data = mock( ActionReplayData.class );
+		final SutState sutState = mock( SutState.class );
+		final StateDifference difference = null; // This difference should be null vs empty
+		final ActionReplayResult result =
+				ActionReplayResult.createActionReplayResult( data, null, null, difference, 0L, sutState );
+
+		assertThat( result.hasDifferences() ).isFalse();
+	}
+
+	@Test
+	void factory_method_should_return_no_difference_if_state_is_empty() {
+		final ActionReplayData data = mock( ActionReplayData.class );
+		final SutState sutState = mock( SutState.class );
+		final StateDifference difference = mock( StateDifference.class ); // This difference should be empty vs null
+		final ActionReplayResult result =
+				ActionReplayResult.createActionReplayResult( data, null, null, difference, 0L, sutState );
+
+		assertThat( result.hasDifferences() ).isFalse();
+	}
 }

--- a/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
+++ b/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
@@ -1,6 +1,7 @@
 package de.retest.recheck.report;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -160,12 +161,35 @@ class TestReportFilterTest {
 	}
 
 	@Test
+	void state_difference_should_not_throw_if_null() {
+		final StateDifference empty = null; // This is the cause
+		assertThatCode( () -> TestReportFilter.filter( empty, mock( Filter.class ) ) ).doesNotThrowAnyException();
+	}
+
+	@Test
+	void state_difference_should_not_destroy_if_no_difference() {
+		final StateDifference empty = null; // This is the cause
+		final StateDifference difference = mock( StateDifference.class );
+
+		assertThat( TestReportFilter.filter( empty, mock( Filter.class ) ) ).isEqualTo( empty );
+		assertThat( TestReportFilter.filter( difference, mock( Filter.class ) ) ).isEqualTo( difference );
+	}
+
+	@Test
 	void action_replay_result_should_be_filtered_properly() throws Exception {
 		final ActionReplayResult filteredActionReplayResult =
 				TestReportFilter.filter( originalActionReplayResult, filter );
 		final List<AttributeDifference> differences = filteredActionReplayResult.getStateDifference()
 				.getRootElementDifferences().get( 0 ).getElementDifference().getAttributesDifference().getDifferences();
 		assertThat( differences ).containsExactly( notFilterMe );
+	}
+
+	@Test
+	void action_replay_result_should_not_throw_if_null() {
+		final ActionReplayResult result = mock( ActionReplayResult.class );
+		when( result.getStateDifference() ).thenReturn( null ); // Just to make sure that this is the cause
+
+		assertThatCode( () -> TestReportFilter.filter( result, mock( Filter.class ) ) ).doesNotThrowAnyException();
 	}
 
 	@Test


### PR DESCRIPTION
When using the filter mechanism with no differences (i.e. `StateDifference` is null), this method throws an `NPE`. 