### PR TITLE
Fix element has attribute differences if empty due to filtering

### DIFF
--- a/src/main/java/de/retest/recheck/ui/diff/ElementDifference.java
+++ b/src/main/java/de/retest/recheck/ui/diff/ElementDifference.java
@@ -131,7 +131,7 @@ public class ElementDifference implements Difference, Comparable<ElementDifferen
 	}
 
 	public boolean hasAttributesDifferences() {
-		return attributesDifference != null;
+		return attributesDifference != null && attributesDifference.size() > 0;
 	}
 
 	public boolean hasIdentAttributesDifferences() {

--- a/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
+++ b/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
@@ -135,6 +135,27 @@ class TestReportFilterTest {
 	}
 
 	@Test
+	void filter_element_difference_should_have_no_differences_if_filtered() {
+		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
+		final AttributesDifference attributes = mock( AttributesDifference.class );
+		when( attributes.getDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
+
+		final ElementDifference difference = mock( ElementDifference.class );
+		when( difference.getAttributesDifference() ).thenReturn( attributes );
+
+		final Filter filterAll = mock( Filter.class );
+		when( filterAll.matches( any() ) ).thenReturn( true );
+		when( filterAll.matches( any(), any() ) ).thenReturn( true );
+
+		final ElementDifference filteredDifference = TestReportFilter.filter( difference, filterAll );
+
+		assertThat( filteredDifference.hasAttributesDifferences() ).isFalse();
+		assertThat( filteredDifference.hasIdentAttributesDifferences() ).isFalse();
+		assertThat( filteredDifference.isInsertionOrDeletion() ).isFalse();
+		assertThat( filteredDifference.hasAnyDifference() ).isFalse();
+	}
+
+	@Test
 	void root_element_difference_should_be_filtered_properly() throws Exception {
 		when( originalElementDifference.getIdentifyingAttributes() ).thenReturn( identAttributes );
 		when( originalElementDifference.getIdentifyingAttributes().identifier() ).thenReturn( "identifier" );

--- a/src/test/java/de/retest/recheck/ui/diff/ElementDifferenceTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/ElementDifferenceTest.java
@@ -14,11 +14,52 @@ import de.retest.recheck.ui.descriptors.Element;
 class ElementDifferenceTest {
 
 	@Test
-	void hasAttributesDifferences_should_respect_all_possible_difference_representations() {
+	void hasAttributesDifferences_should_return_false_if_difference_empty() {
+		final AttributesDifference emptyAttributes = mock( AttributesDifference.class );
+		when( emptyAttributes.getDifferences() ).thenReturn( Collections.emptyList() );
+		when( emptyAttributes.size() ).thenReturn( 0 );
+
+		final Element element = mock( Element.class );
+		final List<ElementDifference> childDifferences = Collections.emptyList();
+		final ElementDifference cut =
+				new ElementDifference( element, emptyAttributes, null, null, null, childDifferences );
+
+		assertThat( cut.hasAttributesDifferences() ).isFalse();
+	}
+
+	@Test
+	void hasAttributesDifferences_should_return_false_if_difference_null() {
+		final Element element = mock( Element.class );
+		final List<ElementDifference> childDifferences = Collections.emptyList();
+		final ElementDifference cut = new ElementDifference( element, null, null, null, null, childDifferences );
+
+		assertThat( cut.hasAttributesDifferences() ).isFalse();
+	}
+
+	@Test
+	void hasAttributesDifferences_should_return_true_if_difference_contained() {
+		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
+
+		final AttributesDifference attributes = mock( AttributesDifference.class );
+		when( attributes.getDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
+		when( attributes.size() ).thenReturn( 1 );
+
+		final Element element = mock( Element.class );
+		final List<ElementDifference> childDifferences = Collections.emptyList();
+		final ElementDifference cut = new ElementDifference( element, null, null, null, null, childDifferences );
+
+		assertThat( cut.hasAttributesDifferences() ).isFalse();
+	}
+
+	@Test
+	void hasAnyDifference_should_respect_all_possible_difference_representations() {
 		final Element element = mock( Element.class );
 		final List<ElementDifference> childDifferences = Collections.emptyList();
 
+		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
 		final AttributesDifference attributes = mock( AttributesDifference.class );
+		when( attributes.getDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
+		when( attributes.size() ).thenReturn( 1 );
 		final IdentifyingAttributesDifference identifying = mock( IdentifyingAttributesDifference.class );
 		final InsertedDeletedElementDifference insertion = mock( InsertedDeletedElementDifference.class );
 		when( insertion.isInserted() ).thenReturn( true );


### PR DESCRIPTION
When there are no differences and we try to filter or the filter removes all differences, the printer still prints verbose messages:
```
 text at foo[1]/bar[1]
     no differences
```
This resolves this issue by also checking the size of the difference.