### PR TITLE
Feature/display inserted deleted elements

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckCapMessage.java
+++ b/src/main/java/de/retest/recheck/RecheckCapMessage.java
@@ -1,21 +1,16 @@
 package de.retest.recheck;
 
 import java.io.File;
-import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import de.retest.recheck.printer.TestReplayResultPrinter;
 import de.retest.recheck.report.TestReplayResult;
-import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
-import de.retest.recheck.ui.diff.LeafDifference;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 class RecheckCapMessage {
 
 	private final String suiteName;
-	private final Set<LeafDifference> uniqueDifferences;
 	private final TestReplayResult testReplayResult;
 	private final TestReplayResultPrinter testReplayResultPrinter;
 	private final File resultFile;
@@ -37,25 +32,10 @@ class RecheckCapMessage {
 		final String allDiffs = testReplayResultPrinter.toString( testReplayResult );
 		final String reportPath = resultFile.getAbsolutePath();
 
-		// TODO temporary workaround for InsertedDeletedElementDifferences
-		final String insertedDeletedDiffs = uniqueDifferences.stream() //
-				.filter( InsertedDeletedElementDifference.class::isInstance ) //
-				.map( InsertedDeletedElementDifference.class::cast ) //
-				.map( toDifferencesErrorMessage() ) //
-				.collect( Collectors.joining( "\n" ) );
-
 		return "A detailed report will be created at '" + reportPath + "'. " //
 				+ "You can review the details by using our CLI (https://github.com/retest/recheck.cli/) or GUI (https://retest.de/review/).\n" //
 				+ "\n" //
 				+ numChecks + " check(s) in '" + suiteName + "' found the following difference(s):\n" //
-				+ allDiffs + "\n" //
-				+ insertedDeletedDiffs;
+				+ allDiffs;
 	}
-
-	private static Function<InsertedDeletedElementDifference, String> toDifferencesErrorMessage() {
-		return diff -> diff.isInserted() //
-				? "\t" + diff.getActual().getIdentifyingAttributes().getPath() + " was inserted!" //
-				: "\t" + diff.getExpected().getIdentifyingAttributes().getPath() + " was deleted!";
-	}
-
 }

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -57,7 +57,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 	private TestReplayResult currentTestResult;
 
 	private final Map<String, DefaultValueFinder> usedFinders = new HashMap<>();
-	private final TestReplayResultPrinter printer;
+	private final TestReplayResultPrinter printer = new TestReplayResultPrinter( usedFinders::get );
 	private final Filter filter;
 
 	/**
@@ -79,8 +79,6 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suite = SuiteAggregator.getInstance().getSuite( suiteName );
 
 		filter = options.getFilter();
-
-		printer = new TestReplayResultPrinter( usedFinders::get, filter );
 
 		if ( isRehubEnabled( options ) ) {
 			try {

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -178,7 +178,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 				finishedTestResult.getName() );
 		if ( !uniqueDifferences.isEmpty() ) {
 			final RecheckCapMessage msg =
-					new RecheckCapMessage( suiteName, uniqueDifferences, finishedTestResult, printer, getResultFile() );
+					new RecheckCapMessage( suiteName, finishedTestResult, printer, getResultFile() );
 			throw new AssertionError( msg );
 		}
 	}

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -23,6 +23,8 @@ import de.retest.recheck.printer.TestReplayResultPrinter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
+import de.retest.recheck.report.TestReportFilter;
+import de.retest.recheck.review.GlobalIgnoreApplier;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.recheck.ui.diff.LeafDifference;
@@ -169,9 +171,9 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 	@Override
 	public void capTest() {
 		suite.addTest( currentTestResult );
-		final TestReplayResult finishedTestResult = currentTestResult;
+		final TestReplayResult finishedTestResult = TestReportFilter.filter( currentTestResult, filter );
 		currentTestResult = null;
-		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences( filter );
+		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences( Filter.FILTER_NOTHING );
 		logger.info( "Found {} not ignored differences in test {}.", uniqueDifferences.size(),
 				finishedTestResult.getName() );
 		if ( !uniqueDifferences.isEmpty() ) {

--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -11,11 +11,9 @@ import de.retest.recheck.ui.actions.ExceptionWrapper;
 public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 
 	private final ElementDifferencePrinter printer;
-	private final Filter filter;
 
-	public ActionReplayResultPrinter( final DefaultValueFinder defaultValueFinder, final Filter filter ) {
-		printer = new ElementDifferencePrinter( defaultValueFinder, filter );
-		this.filter = filter;
+	public ActionReplayResultPrinter( final DefaultValueFinder defaultValueFinder ) {
+		printer = new ElementDifferencePrinter( defaultValueFinder );
 	}
 
 	@Override
@@ -42,8 +40,7 @@ public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 
 	private String createDifferences( final ActionReplayResult difference, final String indent ) {
 		return difference.getAllElementDifferences().stream() //
-				.filter( diff -> !filter.matches( diff.getElement() ) ) //
-				.filter( diff -> !diff.getAttributeDifferences( filter ).isEmpty() )
+				.filter( diff -> !diff.getAttributeDifferences( Filter.FILTER_NOTHING ).isEmpty() )
 				.map( diff -> printer.toString( diff, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -3,10 +3,10 @@ package de.retest.recheck.printer;
 import java.util.stream.Collectors;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.actions.ExceptionWrapper;
+import de.retest.recheck.ui.diff.ElementDifference;
 
 public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 
@@ -40,7 +40,7 @@ public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 
 	private String createDifferences( final ActionReplayResult difference, final String indent ) {
 		return difference.getAllElementDifferences().stream() //
-				.filter( diff -> !diff.getAttributeDifferences( Filter.FILTER_NOTHING ).isEmpty() )
+				.filter( ElementDifference::hasAnyDifference ) //
 				.map( diff -> printer.toString( diff, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/main/java/de/retest/recheck/printer/AttributeDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/AttributeDifferencePrinter.java
@@ -5,7 +5,9 @@ import java.io.Serializable;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.AttributeDifference;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class AttributeDifferencePrinter implements Printer<AttributeDifference> {
 
 	private static final String IS_DEFAULT = "(default or absent)";
@@ -14,11 +16,6 @@ public class AttributeDifferencePrinter implements Printer<AttributeDifference> 
 
 	private final IdentifyingAttributes attributes;
 	private final DefaultValueFinder defaultProvider;
-
-	public AttributeDifferencePrinter( final IdentifyingAttributes attributes, final DefaultValueFinder finder ) {
-		this.attributes = attributes;
-		defaultProvider = finder;
-	}
 
 	@Override
 	public String toString( final AttributeDifference difference, final String indent ) {

--- a/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
@@ -6,16 +6,12 @@ import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.ElementDifference;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class ElementDifferencePrinter implements Printer<ElementDifference> {
 
 	private final DefaultValueFinder finder;
-	private final Filter filter;
-
-	public ElementDifferencePrinter( final DefaultValueFinder finder, final Filter filter ) {
-		this.finder = finder;
-		this.filter = filter;
-	}
 
 	@Override
 	public String toString( final ElementDifference difference, final String indent ) {
@@ -30,7 +26,7 @@ public class ElementDifferencePrinter implements Printer<ElementDifference> {
 	private String createDifferences( final ElementDifference difference, final String indent ) {
 		final IdentifyingAttributes attributes = difference.getIdentifyingAttributes();
 		final AttributeDifferencePrinter delegate = new AttributeDifferencePrinter( attributes, finder );
-		return difference.getAttributeDifferences( filter ).stream() //
+		return difference.getAttributeDifferences( Filter.FILTER_NOTHING ).stream() //
 				.map( d -> delegate.toString( d, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
@@ -6,6 +6,8 @@ import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
+import de.retest.recheck.ui.diff.LeafDifference;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -24,6 +26,11 @@ public class ElementDifferencePrinter implements Printer<ElementDifference> {
 	}
 
 	private String createDifferences( final ElementDifference difference, final String indent ) {
+		final LeafDifference identifyingAttributesDifference = difference.getIdentifyingAttributesDifference();
+		if ( identifyingAttributesDifference instanceof InsertedDeletedElementDifference ) {
+			final Printer<InsertedDeletedElementDifference> printer = new InsertedDeletedElementDifferencePrinter();
+			return printer.toString( (InsertedDeletedElementDifference) identifyingAttributesDifference, indent );
+		}
 		final IdentifyingAttributes attributes = difference.getIdentifyingAttributes();
 		final AttributeDifferencePrinter delegate = new AttributeDifferencePrinter( attributes, finder );
 		return difference.getAttributeDifferences( Filter.FILTER_NOTHING ).stream() //

--- a/src/main/java/de/retest/recheck/printer/InsertedDeletedElementDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/InsertedDeletedElementDifferencePrinter.java
@@ -1,0 +1,11 @@
+package de.retest.recheck.printer;
+
+import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
+
+public class InsertedDeletedElementDifferencePrinter implements Printer<InsertedDeletedElementDifference> {
+
+	@Override
+	public String toString( final InsertedDeletedElementDifference difference, final String indent ) {
+		return indent + (difference.isInserted() ? "was inserted" : "was deleted");
+	}
+}

--- a/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
@@ -2,15 +2,14 @@ package de.retest.recheck.printer;
 
 import java.util.stream.Collectors;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.SuiteReplayResult;
 
 public class SuiteReplayResultPrinter implements Printer<SuiteReplayResult> {
 
 	private final TestReplayResultPrinter delegate;
 
-	public SuiteReplayResultPrinter( final DefaultValueFinderProvider provider, final Filter filter ) {
-		delegate = new TestReplayResultPrinter( provider, filter );
+	public SuiteReplayResultPrinter( final DefaultValueFinderProvider provider ) {
+		delegate = new TestReplayResultPrinter( provider );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
@@ -6,16 +6,12 @@ import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.TestReplayResult;
 import de.retest.recheck.ui.DefaultValueFinder;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private final DefaultValueFinderProvider provider;
-	private final Filter filter;
-
-	public TestReplayResultPrinter( final DefaultValueFinderProvider provider, final Filter filter ) {
-		this.provider = provider;
-		this.filter = filter;
-	}
 
 	@Override
 	public String toString( final TestReplayResult difference, final String indent ) {
@@ -24,7 +20,7 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private String createDescription( final TestReplayResult result ) {
 		final String name = result.getName();
-		final int differences = result.getDifferences( filter ).size();
+		final int differences = result.getDifferences( Filter.FILTER_NOTHING ).size();
 		final int states = result.getActionReplayResults().size();
 		return String.format( "Test '%s' has %d difference(s) in %d state(s):", name, differences, states );
 	}
@@ -37,7 +33,7 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private String formatAction( final ActionReplayResult result, final String indent ) {
 		final DefaultValueFinder finder = provider.findForAction( result.getDescription() );
-		final ActionReplayResultPrinter printer = new ActionReplayResultPrinter( finder, filter );
+		final ActionReplayResultPrinter printer = new ActionReplayResultPrinter( finder );
 		return printer.toString( result, indent );
 	}
 }

--- a/src/main/java/de/retest/recheck/printer/TestReportPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReportPrinter.java
@@ -2,15 +2,14 @@ package de.retest.recheck.printer;
 
 import java.util.stream.Collectors;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.TestReport;
 
 public class TestReportPrinter implements Printer<TestReport> {
 
 	private final SuiteReplayResultPrinter delegate;
 
-	public TestReportPrinter( final DefaultValueFinderProvider provider, final Filter filter ) {
-		delegate = new SuiteReplayResultPrinter( provider, filter );
+	public TestReportPrinter( final DefaultValueFinderProvider provider ) {
+		delegate = new SuiteReplayResultPrinter( provider );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/report/TestReportFilter.java
+++ b/src/main/java/de/retest/recheck/report/TestReportFilter.java
@@ -21,8 +21,7 @@ import de.retest.recheck.ui.diff.StateDifference;
 
 public class TestReportFilter {
 
-	private TestReportFilter() {
-	}
+	private TestReportFilter() {}
 
 	public static TestReport filter( final TestReport report, final Filter filter ) {
 		final TestReport newTestReport = new TestReport();
@@ -42,7 +41,7 @@ public class TestReportFilter {
 		return newSuiteReplayResult;
 	}
 
-	static TestReplayResult filter( final TestReplayResult testReplayResult, final Filter filter ) {
+	public static TestReplayResult filter( final TestReplayResult testReplayResult, final Filter filter ) {
 		final TestReplayResult newTestReplayResult =
 				new TestReplayResult( testReplayResult.getName(), testReplayResult.getTestNr() );
 		for ( final ActionReplayResult actionReplayResult : testReplayResult.getActionReplayResults() ) {

--- a/src/test/java/de/retest/recheck/RecheckCapMessageTest.java
+++ b/src/test/java/de/retest/recheck/RecheckCapMessageTest.java
@@ -3,20 +3,10 @@ package de.retest.recheck;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
 import org.junit.jupiter.api.Test;
 
-import de.retest.recheck.printer.TestReplayResultPrinter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.TestReplayResult;
-import de.retest.recheck.ui.descriptors.Element;
-import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
-import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
-import de.retest.recheck.ui.diff.LeafDifference;
 import de.retest.recheck.util.ApprovalsUtil;
 
 class RecheckCapMessageTest {
@@ -33,45 +23,8 @@ class RecheckCapMessageTest {
 		testReplayResult.addAction( actionReplayResult0 );
 		testReplayResult.addAction( actionReplayResult1 );
 
-		final RecheckCapMessage cut = new RecheckCapMessage( "SomeSuite", null, testReplayResult, null, null );
+		final RecheckCapMessage cut = new RecheckCapMessage( "SomeSuite", testReplayResult, null, null );
 
 		ApprovalsUtil.verify( cut );
 	}
-
-	@Test
-	void differences_message_should_be_formatted_properly() throws Exception {
-		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
-		when( identifyingAttributes.getPath() ).thenReturn( "foo/bar/baz" );
-
-		final Element absent = null;
-		final Element present = mock( Element.class );
-		when( present.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
-
-		final InsertedDeletedElementDifference insertion =
-				InsertedDeletedElementDifference.differenceFor( absent, present );
-		final InsertedDeletedElementDifference deletion =
-				InsertedDeletedElementDifference.differenceFor( present, absent );
-		// Only inserted/deleted differences from unique differences should be accounted.
-		final LeafDifference ignore = mock( LeafDifference.class );
-
-		// Use LinkedHashSet to guarantee order.
-		final Set<LeafDifference> uniqueDifferences =
-				new LinkedHashSet<>( Arrays.asList( insertion, deletion, ignore ) );
-
-		final TestReplayResult testReplayResult = new TestReplayResult( "test-name", 1 );
-		testReplayResult.addAction( mock( ActionReplayResult.class ) );
-		testReplayResult.addAction( mock( ActionReplayResult.class ) );
-
-		final TestReplayResultPrinter testReplayResultPrinter = mock( TestReplayResultPrinter.class );
-		when( testReplayResultPrinter.toString( testReplayResult ) ).thenReturn( "\tSome diff\n\tAnother diff" );
-
-		final File resultFile = mock( File.class );
-		when( resultFile.getAbsolutePath() ).thenReturn( "/report/path" );
-
-		final RecheckCapMessage cut = new RecheckCapMessage( "SomeSuite", uniqueDifferences, testReplayResult,
-				testReplayResultPrinter, resultFile );
-
-		ApprovalsUtil.verify( cut );
-	}
-
 }

--- a/src/test/java/de/retest/recheck/RecheckImplIT.java
+++ b/src/test/java/de/retest/recheck/RecheckImplIT.java
@@ -1,0 +1,152 @@
+package de.retest.recheck;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.ignore.Filters;
+import de.retest.recheck.ui.DefaultValueFinder;
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.MutableAttributes;
+import de.retest.recheck.ui.descriptors.PathAttribute;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.StringAttribute;
+import de.retest.recheck.ui.descriptors.SuffixAttribute;
+import de.retest.recheck.ui.descriptors.TextAttribute;
+import de.retest.recheck.util.ApprovalsUtil;
+
+class RecheckImplIT {
+
+	static final String MESSAGE_START_PATTERN = "A detailed report will be created at '.*'";
+	static final String MESSAGE_START_REPLACE = "A detailed report will be created at '*'";
+
+	@Test
+	void diff_should_be_created_accordingly() {
+		execute( "no-filter", Filter.FILTER_NOTHING );
+	}
+
+	@Test
+	void diff_should_be_created_if_filtered() {
+		execute( "filter", Filters.parse( "matcher: retestid=same-id" ) );
+	}
+
+	void execute( final String name, final Filter filter ) {
+		// No differences
+		execute( name, createRootInitial(), filter );
+		// Differences
+		try {
+			execute( name, createRootDifference(), filter );
+			fail( "An assertion error should have been produced" );
+		} catch ( final AssertionError e ) {
+			ApprovalsUtil.verify( removeProjectSpecificPath( e.getMessage() ) );
+		}
+	}
+
+	void execute( final String name, final RootElement toVerify, final Filter filter ) {
+		final RecheckImpl re = new RecheckImpl( RecheckOptions.builder() //
+				.setFilter( filter ) //
+				.build() );
+
+		re.startTest( name );
+		re.check( toVerify, new RootElementAdapter(), "check" );
+		re.capTest();
+
+		re.cap();
+	}
+
+	String removeProjectSpecificPath( final String message ) {
+		return message.replaceFirst( MESSAGE_START_PATTERN, MESSAGE_START_REPLACE );
+	}
+
+	static class RootElementAdapter implements RecheckAdapter {
+
+		@Override
+		public boolean canCheck( final Object toVerify ) {
+			return toVerify instanceof RootElement;
+		}
+
+		@Override
+		public Set<RootElement> convert( final Object toVerify ) {
+			return Collections.singleton( (RootElement) toVerify );
+		}
+
+		@Override
+		public DefaultValueFinder getDefaultValueFinder() {
+			return ( identifyingAttributes, attributeKey, attributeValue ) -> {
+				return "bar-3".equals( attributeKey ) && attributeValue == null; // Force default output for diffs
+			};
+		}
+	}
+
+	static RootElement createRootInitial() {
+		final IdentifyingAttributes id = createIdentifying( "foo[1]/bar[1]", "test" );
+
+		final MutableAttributes attributes = new MutableAttributes();
+		attributes.put( "foo-1", "bar-1" );
+		attributes.put( "foo-2", "bar-2" );
+		attributes.put( "foo-3", "bar-3" );
+
+		final RootElement element = new RootElement( "foo-id", id, attributes.immutable(), null, "screen", 0, "title" );
+		element.addChildren( createSameFirst( element ), createDeleted( element ) );
+		return element;
+	}
+
+	static RootElement createRootDifference() {
+		final IdentifyingAttributes id = createIdentifying( "foo[1]/bar[1]", "test" );
+
+		final MutableAttributes attributes = new MutableAttributes();
+		attributes.put( "foo-1", "bar-3" );
+		attributes.put( "foo-2", "bar-2" );
+		attributes.put( "foo-3", "bar-1" );
+
+		final RootElement element = new RootElement( "foo-id", id, attributes.immutable(), null, "screen", 0, "title" );
+		element.addChildren( createSameDifference( element ), createInserted( element ) );
+		return element;
+	}
+
+	static Element createSameFirst( final Element parent ) {
+		return create( parent, "foo[1]/bar[1]/same[1]", "same", "" );
+	}
+
+	static Element createSameDifference( final Element parent ) {
+		return create( parent, "foo[1]/bar[1]/same[1]", "same", "-change" );
+	}
+
+	static Element createDeleted( final Element parent ) {
+		return create( parent, "foo[1]/bar[1]/remove[1]/delete[1]", "delete", "" );
+	}
+
+	static Element createInserted( final Element parent ) {
+		return create( parent, "foo[1]/bar[1]/add[1]/insert[1]", "insert", "" );
+	}
+
+	static Element create( final Element parent, final String path, final String type, final String prefix ) {
+		final IdentifyingAttributes identifyingAttributes = createIdentifying( path, type );
+
+		final MutableAttributes attributes = new MutableAttributes();
+		attributes.put( "bar-1", "bar-1" + prefix );
+		attributes.put( "bar-2" + prefix, "bar-2" );
+		attributes.put( "bar-3" + prefix, "bar-3" );
+
+		return Element.create( type + "-id", parent, identifyingAttributes, attributes.immutable(), null );
+	}
+
+	private static IdentifyingAttributes createIdentifying( final String path, final String type ) {
+		final Path typed = Path.fromString( path );
+
+		return new IdentifyingAttributes( Arrays.asList( //
+				new PathAttribute( typed ), //
+				new SuffixAttribute( typed.getElement().getSuffix() ), //
+				new StringAttribute( IdentifyingAttributes.TYPE_ATTRIBUTE_KEY, type ), //
+				new TextAttribute( "text", type ), //
+				new TextAttribute( "name", type ) //
+		) );
+	}
+}

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.ui.actions.ExceptionWrapper;
 import de.retest.recheck.ui.actions.TargetNotFoundException;
@@ -25,8 +24,7 @@ class ActionReplayResultPrinterTest {
 
 	@BeforeEach
 	void setUp() {
-		cut = new ActionReplayResultPrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false,
-				Filter.FILTER_NOTHING );
+		cut = new ActionReplayResultPrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/printer/ElementDifferencePrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ElementDifferencePrinterTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.ElementDifference;
 
@@ -20,8 +19,7 @@ class ElementDifferencePrinterTest {
 
 	@BeforeEach
 	void setUp() {
-		cut = new ElementDifferencePrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false,
-				Filter.FILTER_NOTHING );
+		cut = new ElementDifferencePrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/printer/InsertedDeletedElementDifferencePrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/InsertedDeletedElementDifferencePrinterTest.java
@@ -1,0 +1,60 @@
+package de.retest.recheck.printer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
+
+class InsertedDeletedElementDifferencePrinterTest {
+
+	InsertedDeletedElementDifferencePrinter cut;
+
+	@BeforeEach
+	void setUp() {
+		cut = new InsertedDeletedElementDifferencePrinter();
+	}
+
+	@Test
+	void toString_should_identify_inserted() {
+		final InsertedDeletedElementDifference difference = mock( InsertedDeletedElementDifference.class );
+		when( difference.isInserted() ).thenReturn( true );
+
+		final String string = cut.toString( difference );
+
+		assertThat( string ).isEqualTo( "was inserted" );
+	}
+
+	@Test
+	void toString_should_identify_deleted() {
+		final InsertedDeletedElementDifference difference = mock( InsertedDeletedElementDifference.class );
+		when( difference.isInserted() ).thenReturn( false );
+
+		final String string = cut.toString( difference );
+
+		assertThat( string ).isEqualTo( "was deleted" );
+	}
+
+	@Test
+	void toString_should_respect_indent_on_insert() {
+		final InsertedDeletedElementDifference difference = mock( InsertedDeletedElementDifference.class );
+		when( difference.isInserted() ).thenReturn( true );
+
+		final String string = cut.toString( difference, "____" );
+
+		assertThat( string ).startsWith( "____" );
+	}
+
+	@Test
+	void toString_should_respect_indent_on_delete() {
+		final InsertedDeletedElementDifference difference = mock( InsertedDeletedElementDifference.class );
+		when( difference.isInserted() ).thenReturn( false );
+
+		final String string = cut.toString( difference, "____" );
+
+		assertThat( string ).startsWith( "____" );
+	}
+}

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -25,7 +25,7 @@ class TestReplayResultPrinterTest {
 
 	@BeforeEach
 	void setUp() {
-		cut = new TestReplayResultPrinter( s -> ( identAttributes, key, value ) -> false, FILTER_NOTHING );
+		cut = new TestReplayResultPrinter( s -> ( identAttributes, key, value ) -> false );
 	}
 
 	@Test

--- a/src/test/resources/de/retest/recheck/RecheckCapMessageTest.differences_message_should_be_formatted_properly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckCapMessageTest.differences_message_should_be_formatted_properly.approved.txt
@@ -1,7 +1,0 @@
-A detailed report will be created at '/report/path'. You can review the details by using our CLI (https://github.com/retest/recheck.cli/) or GUI (https://retest.de/review/).
-
-2 check(s) in 'SomeSuite' found the following difference(s):
-	Some diff
-	Another diff
-	foo/bar/baz was inserted!
-	foo/bar/baz was deleted!

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
@@ -1,0 +1,16 @@
+A detailed report will be created at '*'. You can review the details by using our CLI (https://github.com/retest/recheck.cli/) or GUI (https://retest.de/review/).
+
+1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
+Test 'no-filter' has 9 difference(s) in 1 state(s):
+check resulted in:
+	test [test] at 'foo[1]/bar[1]':
+		foo-1: expected="bar-1", actual="bar-3"
+		foo-3: expected="bar-3", actual="bar-1"
+	same [same] at 'foo[1]/bar[1]/same[1]':
+		bar-1: expected="bar-1", actual="bar-1-change"
+		bar-2: expected="bar-2", actual="null"
+		bar-3: expected="bar-3", actual="(default or absent)"
+		bar-2-change: expected="(default or absent)", actual="bar-2"
+		bar-3-change: expected="(default or absent)", actual="bar-3"
+	foo[1]/bar[1]/add[1]/insert[1] was inserted!
+	foo[1]/bar[1]/remove[1]/delete[1] was deleted!

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
@@ -12,5 +12,7 @@ check resulted in:
 		bar-3: expected="bar-3", actual="(default or absent)"
 		bar-2-change: expected="(default or absent)", actual="bar-2"
 		bar-3-change: expected="(default or absent)", actual="bar-3"
-	foo[1]/bar[1]/add[1]/insert[1] was inserted!
-	foo[1]/bar[1]/remove[1]/delete[1] was deleted!
+	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
+		was deleted
+	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+		was inserted

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
@@ -6,5 +6,7 @@ check resulted in:
 	test [test] at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"
-	foo[1]/bar[1]/remove[1]/delete[1] was deleted!
-	foo[1]/bar[1]/add[1]/insert[1] was inserted!
+	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
+		was deleted
+	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+		was inserted

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
@@ -1,0 +1,10 @@
+A detailed report will be created at '*'. You can review the details by using our CLI (https://github.com/retest/recheck.cli/) or GUI (https://retest.de/review/).
+
+1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
+Test 'filter' has 4 difference(s) in 1 state(s):
+check resulted in:
+	test [test] at 'foo[1]/bar[1]':
+		foo-1: expected="bar-1", actual="bar-3"
+		foo-3: expected="bar-3", actual="bar-1"
+	foo[1]/bar[1]/remove[1]/delete[1] was deleted!
+	foo[1]/bar[1]/add[1]/insert[1] was inserted!

--- a/src/test/resources/retest/recheck/de.retest.recheck.RecheckImplIT/filter.check.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.recheck.RecheckImplIT/filter.check.recheck/retest.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="${pom.parent.version}" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="foo-id" screenId="0" screen="screen" title="title">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="name" xsi:type="textAttribute">test</attribute>
+					<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="text" xsi:type="textAttribute">test</attribute>
+					<attribute key="type" xsi:type="stringAttribute">test</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>foo-1</key>
+						<value xsi:type="xsd:string">bar-1</value>
+					</entry>
+					<entry>
+						<key>foo-2</key>
+						<value xsi:type="xsd:string">bar-2</value>
+					</entry>
+					<entry>
+						<key>foo-3</key>
+						<value xsi:type="xsd:string">bar-3</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="same-id">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="name" xsi:type="textAttribute">same</attribute>
+						<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]/same[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="text" xsi:type="textAttribute">same</attribute>
+						<attribute key="type" xsi:type="stringAttribute">same</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>bar-1</key>
+							<value xsi:type="xsd:string">bar-1</value>
+						</entry>
+						<entry>
+							<key>bar-2</key>
+							<value xsi:type="xsd:string">bar-2</value>
+						</entry>
+						<entry>
+							<key>bar-3</key>
+							<value xsi:type="xsd:string">bar-3</value>
+						</entry>
+					</attributes>
+				</attributes>
+			</containedElements>
+			<containedElements retestId="delete-id">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="name" xsi:type="textAttribute">delete</attribute>
+						<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]/remove[1]/delete[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="text" xsi:type="textAttribute">delete</attribute>
+						<attribute key="type" xsi:type="stringAttribute">delete</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>bar-1</key>
+							<value xsi:type="xsd:string">bar-1</value>
+						</entry>
+						<entry>
+							<key>bar-2</key>
+							<value xsi:type="xsd:string">bar-2</value>
+						</entry>
+						<entry>
+							<key>bar-3</key>
+							<value xsi:type="xsd:string">bar-3</value>
+						</entry>
+					</attributes>
+				</attributes>
+			</containedElements>
+		</descriptors>
+	</data>
+</reTestXmlDataContainer>

--- a/src/test/resources/retest/recheck/de.retest.recheck.RecheckImplIT/no-filter.check.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.recheck.RecheckImplIT/no-filter.check.recheck/retest.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="${pom.parent.version}" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="foo-id" screenId="0" screen="screen" title="title">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="name" xsi:type="textAttribute">test</attribute>
+					<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="text" xsi:type="textAttribute">test</attribute>
+					<attribute key="type" xsi:type="stringAttribute">test</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>foo-1</key>
+						<value xsi:type="xsd:string">bar-1</value>
+					</entry>
+					<entry>
+						<key>foo-2</key>
+						<value xsi:type="xsd:string">bar-2</value>
+					</entry>
+					<entry>
+						<key>foo-3</key>
+						<value xsi:type="xsd:string">bar-3</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="same-id">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="name" xsi:type="textAttribute">same</attribute>
+						<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]/same[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="text" xsi:type="textAttribute">same</attribute>
+						<attribute key="type" xsi:type="stringAttribute">same</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>bar-1</key>
+							<value xsi:type="xsd:string">bar-1</value>
+						</entry>
+						<entry>
+							<key>bar-2</key>
+							<value xsi:type="xsd:string">bar-2</value>
+						</entry>
+						<entry>
+							<key>bar-3</key>
+							<value xsi:type="xsd:string">bar-3</value>
+						</entry>
+					</attributes>
+				</attributes>
+			</containedElements>
+			<containedElements retestId="delete-id">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="name" xsi:type="textAttribute">delete</attribute>
+						<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]/remove[1]/delete[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="text" xsi:type="textAttribute">delete</attribute>
+						<attribute key="type" xsi:type="stringAttribute">delete</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>bar-1</key>
+							<value xsi:type="xsd:string">bar-1</value>
+						</entry>
+						<entry>
+							<key>bar-2</key>
+							<value xsi:type="xsd:string">bar-2</value>
+						</entry>
+						<entry>
+							<key>bar-3</key>
+							<value xsi:type="xsd:string">bar-3</value>
+						</entry>
+					</attributes>
+				</attributes>
+			</containedElements>
+		</descriptors>
+	</data>
+</reTestXmlDataContainer>


### PR DESCRIPTION
Finally remove the workaround for `InsertedDeletedElementDifference` and have the report filtered globally such that there is no filtering logic within the printers.