### PR TITLE
Feature/mark methods with filter deprecated

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -24,7 +24,6 @@ import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
 import de.retest.recheck.report.TestReportFilter;
-import de.retest.recheck.review.GlobalIgnoreApplier;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.recheck.ui.diff.LeafDifference;
@@ -173,7 +172,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suite.addTest( currentTestResult );
 		final TestReplayResult finishedTestResult = TestReportFilter.filter( currentTestResult, filter );
 		currentTestResult = null;
-		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences( Filter.FILTER_NOTHING );
+		final Set<LeafDifference> uniqueDifferences = finishedTestResult.getDifferences();
 		logger.info( "Found {} not ignored differences in test {}.", uniqueDifferences.size(),
 				finishedTestResult.getName() );
 		if ( !uniqueDifferences.isEmpty() ) {

--- a/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
@@ -2,7 +2,6 @@ package de.retest.recheck.printer;
 
 import java.util.stream.Collectors;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.ElementDifference;
@@ -33,7 +32,7 @@ public class ElementDifferencePrinter implements Printer<ElementDifference> {
 		}
 		final IdentifyingAttributes attributes = difference.getIdentifyingAttributes();
 		final AttributeDifferencePrinter delegate = new AttributeDifferencePrinter( attributes, finder );
-		return difference.getAttributeDifferences( Filter.FILTER_NOTHING ).stream() //
+		return difference.getAttributeDifferences().stream() //
 				.map( d -> delegate.toString( d, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
@@ -2,7 +2,6 @@ package de.retest.recheck.printer;
 
 import java.util.stream.Collectors;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.TestReplayResult;
 import de.retest.recheck.ui.DefaultValueFinder;
@@ -20,7 +19,7 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private String createDescription( final TestReplayResult result ) {
 		final String name = result.getName();
-		final int differences = result.getDifferences( Filter.FILTER_NOTHING ).size();
+		final int differences = result.getDifferences().size();
 		final int states = result.getActionReplayResults().size();
 		return String.format( "Test '%s' has %d difference(s) in %d state(s):", name, differences, states );
 	}

--- a/src/main/java/de/retest/recheck/report/ActionReplayResult.java
+++ b/src/main/java/de/retest/recheck/report/ActionReplayResult.java
@@ -201,12 +201,26 @@ public class ActionReplayResult implements Serializable {
 		return differences;
 	}
 
+	@Deprecated
 	public Set<LeafDifference> getDifferencesWithout( final Filter filter ) {
 		final Set<LeafDifference> result = new HashSet<>();
 		for ( final ElementDifference elementDifference : getAllElementDifferences() ) {
 			if ( !filter.matches( elementDifference.getElement() ) ) {
 				result.addAll( elementDifference.getAttributeDifferences( filter ) );
 			}
+			final LeafDifference identifyingAttributesDifference =
+					elementDifference.getIdentifyingAttributesDifference();
+			if ( identifyingAttributesDifference instanceof InsertedDeletedElementDifference ) {
+				result.add( identifyingAttributesDifference );
+			}
+		}
+		return result;
+	}
+
+	public Set<LeafDifference> getDifferences() {
+		final Set<LeafDifference> result = new HashSet<>();
+		for ( final ElementDifference elementDifference : getAllElementDifferences() ) {
+			result.addAll( elementDifference.getAttributeDifferences() );
 			final LeafDifference identifyingAttributesDifference =
 					elementDifference.getIdentifyingAttributesDifference();
 			if ( identifyingAttributesDifference instanceof InsertedDeletedElementDifference ) {

--- a/src/main/java/de/retest/recheck/report/TestReplayResult.java
+++ b/src/main/java/de/retest/recheck/report/TestReplayResult.java
@@ -86,10 +86,19 @@ public class TestReplayResult implements Serializable {
 		return uiElementsCount;
 	}
 
+	@Deprecated
 	public Set<LeafDifference> getDifferences( final Filter filter ) {
 		final Set<LeafDifference> diffs = new HashSet<>();
 		for ( final ActionReplayResult actionReplayResult : actionReplayResults ) {
 			diffs.addAll( actionReplayResult.getDifferencesWithout( filter ) );
+		}
+		return diffs;
+	}
+
+	public Set<LeafDifference> getDifferences() {
+		final Set<LeafDifference> diffs = new HashSet<>();
+		for ( final ActionReplayResult actionReplayResult : actionReplayResults ) {
+			diffs.addAll( actionReplayResult.getDifferences() );
 		}
 		return diffs;
 	}

--- a/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
@@ -9,23 +9,20 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.ActionReplayResult;
-import de.retest.recheck.report.TestReport;
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
+import de.retest.recheck.report.TestReport;
+import de.retest.recheck.review.counter.Counter;
+import de.retest.recheck.review.counter.NopCounter;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.AttributeDifference;
 import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
 import de.retest.recheck.ui.review.ActionChangeSet;
-import de.retest.recheck.review.counter.Counter;
-import de.retest.recheck.review.counter.NopCounter;
 
 public class GlobalChangeSetApplier {
-
-	private static final Filter SHOULD_FILTER_NOTHING = null;
 
 	private final Counter counter;
 
@@ -49,8 +46,7 @@ public class GlobalChangeSetApplier {
 
 	// Replay result lookup maps.
 
-	private final Multimap<ImmutablePair<IdentifyingAttributes, AttributeDifference>, ActionReplayResult>
-			attributeDiffsLookupMap;
+	private final Multimap<ImmutablePair<IdentifyingAttributes, AttributeDifference>, ActionReplayResult> attributeDiffsLookupMap;
 	private final Multimap<Element, ActionReplayResult> insertedDiffsLookupMap;
 	private final Multimap<IdentifyingAttributes, ActionReplayResult> deletedDiffsLookupMap;
 
@@ -84,8 +80,7 @@ public class GlobalChangeSetApplier {
 	private void fillAttributeDifferencesLookupMap( final ActionReplayResult actionReplayResult,
 			final ElementDifference elementDiff ) {
 		final IdentifyingAttributes identifyingAttributes = elementDiff.getIdentifyingAttributes();
-		for ( final AttributeDifference attributeDifference : elementDiff.getAttributeDifferences(
-				SHOULD_FILTER_NOTHING ) ) {
+		for ( final AttributeDifference attributeDifference : elementDiff.getAttributeDifferences() ) {
 			attributeDiffsLookupMap.put( ImmutablePair.of( identifyingAttributes, attributeDifference ),
 					actionReplayResult );
 		}
@@ -114,8 +109,8 @@ public class GlobalChangeSetApplier {
 
 	public void addChangeSetForAllEqualIdentAttributeChanges( final IdentifyingAttributes identifyingAttributes,
 			final AttributeDifference attributeDifference ) {
-		final Collection<ActionReplayResult> actionResultsWithDiffs = findAllActionResultsWithEqualDifferences(
-				identifyingAttributes, attributeDifference );
+		final Collection<ActionReplayResult> actionResultsWithDiffs =
+				findAllActionResultsWithEqualDifferences( identifyingAttributes, attributeDifference );
 		assert !actionResultsWithDiffs.isEmpty() : "Should have been added during load and thus not be empty!";
 		for ( final ActionReplayResult actionReplayResult : actionResultsWithDiffs ) {
 			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
@@ -139,8 +134,8 @@ public class GlobalChangeSetApplier {
 			final AttributeDifference attributeDifference ) {
 		for ( final ActionReplayResult actionReplayResult : findAllActionResultsWithEqualDifferences(
 				identifyingAttributes, attributeDifference ) ) {
-			findCorrespondingActionChangeSet( actionReplayResult ).getIdentAttributeChanges().remove(
-					identifyingAttributes, attributeDifference );
+			findCorrespondingActionChangeSet( actionReplayResult ).getIdentAttributeChanges()
+					.remove( identifyingAttributes, attributeDifference );
 		}
 		counter.remove();
 	}

--- a/src/main/java/de/retest/recheck/ui/diff/ElementDifference.java
+++ b/src/main/java/de/retest/recheck/ui/diff/ElementDifference.java
@@ -49,6 +49,7 @@ public class ElementDifference implements Difference, Comparable<ElementDifferen
 		this.childDifferences.addAll( childDifferences );
 	}
 
+	@Deprecated
 	public Screenshot mark( final Screenshot screenshot, final Filter filter ) {
 		if ( screenshot == null ) {
 			return null;
@@ -57,10 +58,25 @@ public class ElementDifference implements Difference, Comparable<ElementDifferen
 		if ( childDifferences != null ) {
 			for ( final Difference childDifference : childDifferences ) {
 				for ( final ElementDifference compDiff : childDifference.getNonEmptyDifferences() ) {
-					if ( !filter.matches( element )
-							&& !compDiff.getAttributeDifferences( filter ).isEmpty() ) {
+					if ( !filter.matches( element ) && !compDiff.getAttributeDifferences( filter ).isEmpty() ) {
 						marks.add( AttributeUtil.getAbsoluteOutline( compDiff.getIdentifyingAttributes() ) );
 					}
+				}
+			}
+		}
+		return image2Screenshot( screenshot.getPersistenceIdPrefix(),
+				ImageUtils.mark( screenshot2Image( screenshot ), marks ) );
+	}
+
+	public Screenshot mark( final Screenshot screenshot ) {
+		if ( screenshot == null ) {
+			return null;
+		}
+		final List<Rectangle> marks = new ArrayList<>();
+		if ( childDifferences != null ) {
+			for ( final Difference childDifference : childDifferences ) {
+				for ( final ElementDifference compDiff : childDifference.getNonEmptyDifferences() ) {
+					marks.add( AttributeUtil.getAbsoluteOutline( compDiff.getIdentifyingAttributes() ) );
 				}
 			}
 		}
@@ -93,22 +109,28 @@ public class ElementDifference implements Difference, Comparable<ElementDifferen
 		return differences;
 	}
 
+	@Deprecated
 	public List<AttributeDifference> getAttributeDifferences( final Filter filter ) {
-		final List<AttributeDifference> differences = new ArrayList<>();
-		if ( identifyingAttributesDifference instanceof IdentifyingAttributesDifference ) {
-			final List<AttributeDifference> attributeDifferences =
-					((IdentifyingAttributesDifference) identifyingAttributesDifference).getAttributeDifferences();
-			differences.addAll( attributeDifferences );
-		}
-		if ( attributesDifference != null ) {
-			differences.addAll( attributesDifference.getDifferences() );
-		}
+		final List<AttributeDifference> differences = getAttributeDifferences();
 		if ( filter == null ) {
 			return differences;
 		}
 		return differences.stream() //
 				.filter( d -> !filter.matches( element, d ) ) //
 				.collect( Collectors.toList() );
+	}
+
+	public List<AttributeDifference> getAttributeDifferences() {
+		final List<AttributeDifference> differences = new ArrayList<>();
+		if ( identifyingAttributesDifference instanceof IdentifyingAttributesDifference ) {
+			final IdentifyingAttributesDifference identifyingAttributesDifference =
+					(IdentifyingAttributesDifference) this.identifyingAttributesDifference;
+			differences.addAll( identifyingAttributesDifference.getAttributeDifferences() );
+		}
+		if ( attributesDifference != null ) {
+			differences.addAll( attributesDifference.getDifferences() );
+		}
+		return differences;
 	}
 
 	public String getIdentifier() {

--- a/src/test/java/de/retest/recheck/execution/RecheckDifferenceFinderTest.java
+++ b/src/test/java/de/retest/recheck/execution/RecheckDifferenceFinderTest.java
@@ -1,6 +1,5 @@
 package de.retest.recheck.execution;
 
-import static de.retest.recheck.ignore.Filter.FILTER_NOTHING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,7 +40,7 @@ class RecheckDifferenceFinderTest {
 		final ActionReplayResult differences = cut.findDifferences( actual, expected );
 
 		assertThat( differences.hasDifferences() ).isTrue();
-		assertThat( differences.getDifferencesWithout( FILTER_NOTHING ) ).hasSize( 1 );
+		assertThat( differences.getDifferences() ).hasSize( 1 );
 		assertThat( differences.getStateDifference() ).isNotNull();
 		assertThat( differences.getWindows() ).isEmpty();
 	}
@@ -69,7 +68,7 @@ class RecheckDifferenceFinderTest {
 		final ActionReplayResult differences = cut.findDifferences( actual, expected );
 
 		assertThat( differences.hasDifferences() ).isFalse();
-		assertThat( differences.getDifferencesWithout( FILTER_NOTHING ) ).hasSize( 0 );
+		assertThat( differences.getDifferences() ).hasSize( 0 );
 		assertThat( differences.getStateDifference() ).isNull();
 		assertThat( differences.getWindows() ).isNotEmpty();
 	}

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -1,6 +1,5 @@
 package de.retest.recheck.printer;
 
-import static de.retest.recheck.ignore.Filter.FILTER_NOTHING;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +12,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
 import de.retest.recheck.report.ActionReplayResult;
@@ -35,7 +33,7 @@ class TestReplayResultPrinterTest {
 	@Test
 	void toString_should_print_differences_if_empty() {
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( Collections.emptySet() );
+		when( result.getDifferences() ).thenReturn( Collections.emptySet() );
 		when( result.getActionReplayResults() ).thenReturn( Collections.emptyList() );
 
 		final String string = cut.toString( result );
@@ -46,7 +44,7 @@ class TestReplayResultPrinterTest {
 	@Test
 	void toString_should_respect_indent_if_empty() {
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( Collections.emptySet() );
+		when( result.getDifferences() ).thenReturn( Collections.emptySet() );
 		when( result.getActionReplayResults() ).thenReturn( Collections.emptyList() );
 
 		final String string = cut.toString( result, "____" );
@@ -63,7 +61,7 @@ class TestReplayResultPrinterTest {
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferencesCount() ).thenReturn( 1 );
 		when( result.getActionReplayResults() ).thenReturn( singletonList( a1 ) );
-		when( result.getDifferences( Mockito.any() ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
+		when( result.getDifferences() ).thenReturn( singleton( mock( LeafDifference.class ) ) );
 
 		final String string = cut.toString( result );
 
@@ -77,7 +75,7 @@ class TestReplayResultPrinterTest {
 		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
+		when( result.getDifferences() ).thenReturn( singleton( mock( LeafDifference.class ) ) );
 		when( result.getActionReplayResults() ).thenReturn( Collections.singletonList( a1 ) );
 
 		final String string = cut.toString( result, "____" );
@@ -95,7 +93,7 @@ class TestReplayResultPrinterTest {
 		when( a2.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
-		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
+		when( result.getDifferences() ).thenReturn( singleton( mock( LeafDifference.class ) ) );
 		when( result.getActionReplayResults() ).thenReturn( Arrays.asList( a1, a2 ) );
 
 		final String string = cut.toString( result );

--- a/src/test/java/de/retest/recheck/report/ActionReplayResultTest.java
+++ b/src/test/java/de/retest/recheck/report/ActionReplayResultTest.java
@@ -1,6 +1,5 @@
 package de.retest.recheck.report;
 
-import static de.retest.recheck.ignore.Filter.FILTER_NOTHING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -51,7 +50,7 @@ class ActionReplayResultTest {
 		final AttributeFilter filter = new AttributeFilter( "path" );
 
 		assertThat( differences.hasDifferences() ).isTrue();
-		assertThat( differences.getDifferencesWithout( FILTER_NOTHING ) ).hasSize( 1 );
+		assertThat( differences.getDifferences() ).hasSize( 1 );
 		assertThat( differences.getDifferencesWithout( filter ) ).hasSize( 0 );
 		assertThat( differences.getStateDifference() ).isNotNull();
 		assertThat( differences.getWindows() ).isEmpty();
@@ -99,7 +98,7 @@ class ActionReplayResultTest {
 
 		assertThat( differences.hasDifferences() ).isTrue();
 
-		assertThat( differences.getDifferencesWithout( FILTER_NOTHING ) ).hasSize( 4 );
+		assertThat( differences.getDifferences() ).hasSize( 4 );
 		assertThat( differences.getDifferencesWithout( filterAll ) ).hasSize( 0 );
 
 		assertThat( differences.getDifferencesWithout( filterFont ) ).hasSize( 3 );

--- a/src/test/java/de/retest/recheck/report/TestReplayResultTest.java
+++ b/src/test/java/de/retest/recheck/report/TestReplayResultTest.java
@@ -6,6 +6,12 @@ import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import de.retest.recheck.ui.diff.LeafDifference;
 
 class TestReplayResultTest {
 
@@ -33,5 +39,22 @@ class TestReplayResultTest {
 		cut.addAction( mock( NoGoldenMasterActionReplayResult.class ) );
 
 		assertThat( cut.hasNoGoldenMaster() ).isTrue();
+	}
+
+	@Test
+	void getDifferences_should_retrieve_all_child_differences() {
+		final TestReplayResult cut = new TestReplayResult( "foo", 5 );
+		cut.addAction( action() );
+		cut.addAction( action() );
+		cut.addAction( action() );
+
+		assertThat( cut.getDifferences() ).hasSize( 15 );
+	}
+
+	private ActionReplayResult action() {
+		final ActionReplayResult replayResult = mock( ActionReplayResult.class );
+		when( replayResult.getDifferences() ).thenReturn(
+				Stream.generate( () -> mock( LeafDifference.class ) ).limit( 5 ).collect( Collectors.toSet() ) );
+		return replayResult;
 	}
 }

--- a/src/test/java/de/retest/recheck/review/GlobalChangeSetApplierTest.java
+++ b/src/test/java/de/retest/recheck/review/GlobalChangeSetApplierTest.java
@@ -16,11 +16,10 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.report.ActionReplayResult;
-import de.retest.recheck.report.TestReport;
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
+import de.retest.recheck.report.TestReport;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.AttributeDifference;
@@ -33,8 +32,6 @@ import de.retest.recheck.ui.review.SuiteChangeSet;
 import de.retest.recheck.ui.review.TestChangeSet;
 
 class GlobalChangeSetApplierTest {
-
-	private final static Filter SHOULD_FILTER_NOTHING = null;
 
 	private GlobalChangeSetApplier globalApplier;
 
@@ -92,15 +89,13 @@ class GlobalChangeSetApplierTest {
 		final List<ElementDifference> elementDifferences1 =
 				Arrays.asList( elementDifference1, insertedDifference, deletedDifference );
 		when( actionReplayResult1.getAllElementDifferences() ).thenReturn( elementDifferences1 );
-		when( elementDifference1.getAttributeDifferences( SHOULD_FILTER_NOTHING ) )
-				.thenReturn( Arrays.asList( attributeDifference ) );
+		when( elementDifference1.getAttributeDifferences() ).thenReturn( Arrays.asList( attributeDifference ) );
 		when( elementDifference1.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
 
 		final List<ElementDifference> elementDifferences2 =
 				Arrays.asList( elementDifference2, insertedDifference, deletedDifference );
 		when( actionReplayResult2.getAllElementDifferences() ).thenReturn( elementDifferences2 );
-		when( elementDifference2.getAttributeDifferences( SHOULD_FILTER_NOTHING ) )
-				.thenReturn( Arrays.asList( attributeDifference ) );
+		when( elementDifference2.getAttributeDifferences() ).thenReturn( Arrays.asList( attributeDifference ) );
 		when( elementDifference2.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
 
 		when( component.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
@@ -144,7 +139,7 @@ class GlobalChangeSetApplierTest {
 		verify( suiteReplayResult, only() ).getTestReplayResults();
 		verify( testReplayResult, only() ).getActionReplayResults();
 		verify( actionReplayResult1, only() ).getAllElementDifferences();
-		verify( elementDifference1, times( 1 ) ).getAttributeDifferences( SHOULD_FILTER_NOTHING );
+		verify( elementDifference1, times( 1 ) ).getAttributeDifferences();
 		verify( elementDifference1, times( 1 ) ).getIdentifyingAttributes();
 		verify( elementDifference1, times( 1 ) ).isInsertionOrDeletion();
 		verifyNoMoreInteractions( elementDifference1 );

--- a/src/test/java/de/retest/recheck/ui/diff/ElementDifferenceTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/ElementDifferenceTest.java
@@ -81,4 +81,65 @@ class ElementDifferenceTest {
 		assertThat( e5.hasAnyDifference() ).isTrue();
 		assertThat( e6.hasAnyDifference() ).isTrue();
 	}
+
+	@Test
+	void getAttributeDifferences_should_gather_all_differences() {
+		final AttributeDifference difference = mock( AttributeDifference.class );
+
+		final AttributesDifference attributesDifference = mock( AttributesDifference.class );
+		when( attributesDifference.getDifferences() ).thenReturn( Collections.nCopies( 5, difference ) );
+
+		final IdentifyingAttributesDifference idDifference = mock( IdentifyingAttributesDifference.class );
+		when( idDifference.getAttributeDifferences() ).thenReturn( Collections.nCopies( 3, difference ) );
+
+		final ElementDifference cut = new ElementDifference( mock( Element.class ), attributesDifference, idDifference,
+				null, null, Collections.emptyList() );
+
+		assertThat( cut.getAttributeDifferences() ).hasSize( 8 );
+	}
+
+	@Test
+	void getAttributeDifferences_should_gather_all_differences_from_identifying() {
+		final AttributeDifference difference = mock( AttributeDifference.class );
+
+		final IdentifyingAttributesDifference idDifference = mock( IdentifyingAttributesDifference.class );
+		when( idDifference.getAttributeDifferences() ).thenReturn( Collections.nCopies( 3, difference ) );
+
+		final ElementDifference cut =
+				new ElementDifference( mock( Element.class ), null, idDifference, null, null, Collections.emptyList() );
+
+		assertThat( cut.getAttributeDifferences() ).hasSize( 3 );
+	}
+
+	@Test
+	void getAttributeDifferences_should_gather_all_differences_from_attributes() {
+		final AttributeDifference difference = mock( AttributeDifference.class );
+
+		final AttributesDifference attributesDifference = mock( AttributesDifference.class );
+		when( attributesDifference.getDifferences() ).thenReturn( Collections.nCopies( 5, difference ) );
+
+		final ElementDifference cut = new ElementDifference( mock( Element.class ), attributesDifference, null, null,
+				null, Collections.emptyList() );
+
+		assertThat( cut.getAttributeDifferences() ).hasSize( 5 );
+	}
+
+	@Test
+	void getAttributeDifferences_should_gather_all_differences_should_not_use_child_differences() {
+		final AttributeDifference difference = mock( AttributeDifference.class );
+
+		final AttributesDifference attributesDifference = mock( AttributesDifference.class );
+		when( attributesDifference.getDifferences() ).thenReturn( Collections.nCopies( 5, difference ) );
+
+		final IdentifyingAttributesDifference idDifference = mock( IdentifyingAttributesDifference.class );
+		when( idDifference.getAttributeDifferences() ).thenReturn( Collections.nCopies( 3, difference ) );
+
+		final ElementDifference childDifference = new ElementDifference( mock( Element.class ), attributesDifference,
+				idDifference, null, null, Collections.emptyList() );
+
+		final ElementDifference cut = new ElementDifference( mock( Element.class ), null, null, null, null,
+				Collections.nCopies( 5, childDifference ) );
+
+		assertThat( cut.getAttributeDifferences() ).isEmpty();
+	}
 }


### PR DESCRIPTION
Since we have now the `TestReportFilter`, we do not need this code twice. I removed the general usages with `FILTER_NOTHING` so that the methods should not be used within recheck anymore (except some tests).

Do we want to mark those deprecated or completely remove those methods? I suggest deprecated, because we can evaluate what may break in review and cli.