### PR TITLE
Feature/printer optimize insert delete

### DIFF
--- a/src/main/java/de/retest/recheck/NoGoldenMasterActionReplayResult.java
+++ b/src/main/java/de/retest/recheck/NoGoldenMasterActionReplayResult.java
@@ -80,4 +80,8 @@ public class NoGoldenMasterActionReplayResult extends ActionReplayResult {
 		return MSG_SHORT;
 	}
 
+	@Override
+	public boolean hasDifferences() {
+		return true;
+	}
 }

--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -34,9 +34,6 @@ public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 		if ( difference instanceof NoGoldenMasterActionReplayResult ) {
 			return prefix + nextIndent + NoGoldenMasterActionReplayResult.MSG_LONG;
 		}
-		if ( !difference.hasDifferences() ) {
-			return prefix + nextIndent + "no differences";
-		}
 		return prefix + createDifferences( difference.getStateDifference(), nextIndent );
 	}
 

--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -1,12 +1,15 @@
 package de.retest.recheck.printer;
 
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.ui.DefaultValueFinder;
 import de.retest.recheck.ui.actions.ExceptionWrapper;
 import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.recheck.ui.diff.RootElementDifference;
+import de.retest.recheck.ui.diff.StateDifference;
 
 public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 
@@ -39,9 +42,22 @@ public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 	}
 
 	private String createDifferences( final ActionReplayResult difference, final String indent ) {
-		return difference.getAllElementDifferences().stream() //
+		final StateDifference stateDifference = difference.getStateDifference();
+		return stateDifference.getRootElementDifferences().stream() //
+				.map( RootElementDifference::getElementDifference ) //
+				.flatMap( this::getDifference ) //
 				.filter( ElementDifference::hasAnyDifference ) //
 				.map( diff -> printer.toString( diff, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
+	}
+
+	private Stream<ElementDifference> getDifference( final ElementDifference origin ) {
+		if ( origin.isInsertionOrDeletion() ) { // Do not traverse deeper, since those should only be inserted or deleted
+			return Stream.of( origin );
+		}
+		return Stream.concat( // 
+				Stream.of( origin ), // 
+				origin.getChildDifferences().stream() //
+						.flatMap( this::getDifference ) );
 	}
 }

--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -34,16 +34,18 @@ public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 		if ( difference instanceof NoGoldenMasterActionReplayResult ) {
 			return prefix + nextIndent + NoGoldenMasterActionReplayResult.MSG_LONG;
 		}
-		return prefix + createDifferences( difference, nextIndent );
+		if ( !difference.hasDifferences() ) {
+			return prefix + nextIndent + "no differences";
+		}
+		return prefix + createDifferences( difference.getStateDifference(), nextIndent );
 	}
 
 	private String createDescription( final ActionReplayResult difference ) {
 		return difference.getDescription() + " resulted in:";
 	}
 
-	private String createDifferences( final ActionReplayResult difference, final String indent ) {
-		final StateDifference stateDifference = difference.getStateDifference();
-		return stateDifference.getRootElementDifferences().stream() //
+	private String createDifferences( final StateDifference difference, final String indent ) {
+		return difference.getRootElementDifferences().stream() //
 				.map( RootElementDifference::getElementDifference ) //
 				.flatMap( this::getDifference ) //
 				.filter( ElementDifference::hasAnyDifference ) //

--- a/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
@@ -15,7 +15,9 @@ public class SuiteReplayResultPrinter implements Printer<SuiteReplayResult> {
 	@Override
 	public String toString( final SuiteReplayResult difference, final String indent ) {
 		return difference.getTestReplayResults().stream() //
+				.filter( testReplayResult -> !testReplayResult.isEmpty() ) //
 				.map( d -> delegate.toString( d, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
 	}
+
 }

--- a/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
@@ -27,8 +27,13 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 
 	private String createDifferences( final TestReplayResult difference, final String indent ) {
 		return difference.getActionReplayResults().stream() //
+				.filter( this::shouldPrint ) //
 				.map( a -> formatAction( a, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
+	}
+
+	private boolean shouldPrint( final ActionReplayResult actionReplayResult ) {
+		return actionReplayResult.hasDifferences() || actionReplayResult.hasError();
 	}
 
 	private String formatAction( final ActionReplayResult result, final String indent ) {

--- a/src/main/java/de/retest/recheck/printer/TestReportPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReportPrinter.java
@@ -15,6 +15,7 @@ public class TestReportPrinter implements Printer<TestReport> {
 	@Override
 	public String toString( final TestReport testReport, final String indent ) {
 		return testReport.getSuiteReplayResults().stream() //
+				.filter( suiteReplayResult -> !suiteReplayResult.isEmpty() ) //
 				.map( suiteReplayResult -> delegate.toString( suiteReplayResult, indent ) ) //
 				.collect( Collectors.joining( "\n" ) );
 	}

--- a/src/test/java/de/retest/recheck/NoGoldenMasterActionReplayResultTest.java
+++ b/src/test/java/de/retest/recheck/NoGoldenMasterActionReplayResultTest.java
@@ -1,0 +1,28 @@
+package de.retest.recheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.SutState;
+
+class NoGoldenMasterActionReplayResultTest {
+
+	@Test
+	void hasDifference_should_always_return_true() {
+		final RootElement rootElement = mock( RootElement.class, RETURNS_MOCKS );
+
+		final SutState sutState = mock( SutState.class );
+		when( sutState.getRootElements() ).thenReturn( Collections.singletonList( rootElement ) );
+
+		final NoGoldenMasterActionReplayResult cut = new NoGoldenMasterActionReplayResult( "result", sutState, "path" );
+
+		assertThat( cut.hasDifferences() ).isTrue();
+	}
+}

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -29,6 +29,7 @@ import de.retest.recheck.ui.diff.AttributesDifference;
 import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
 import de.retest.recheck.ui.diff.RootElementDifference;
+import de.retest.recheck.ui.diff.StateDifference;
 import de.retest.recheck.util.ApprovalsUtil;
 
 class ActionReplayResultPrinterTest {
@@ -81,9 +82,15 @@ class ActionReplayResultPrinterTest {
 		when( rootDifference.getElementDifferences() ).thenReturn( Collections.singletonList( childDifference ) );
 		when( rootDifference.getIdentifyingAttributes() ).thenReturn( mock );
 
+		final RootElementDifference root = mock( RootElementDifference.class );
+		when( root.getElementDifference() ).thenReturn( rootDifference );
+
+		final StateDifference stateDifference = mock( StateDifference.class );
+		when( stateDifference.getRootElementDifferences() ).thenReturn( Collections.singletonList( root ) );
+
 		final ActionReplayResult result = mock( ActionReplayResult.class );
 		when( result.getDescription() ).thenReturn( "foo" );
-		when( result.getAllElementDifferences() ).thenReturn( Collections.singletonList( rootDifference ) );
+		when( result.getStateDifference() ).thenReturn( stateDifference );
 
 		final String string = cut.toString( result );
 
@@ -93,7 +100,7 @@ class ActionReplayResultPrinterTest {
 	@Test
 	void toString_should_respect_indent() {
 		final ActionReplayResult result = mock( ActionReplayResult.class );
-		when( result.getAllElementDifferences() ).thenReturn( Collections.emptyList() );
+		when( result.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 
 		final String string = cut.toString( result, "____" );
 

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -119,6 +119,26 @@ class ActionReplayResultPrinterTest {
 	}
 
 	@Test
+	void toString_should_not_print_differences_if_no_state() {
+		final ActionReplayResult replayResult = mock( ActionReplayResult.class );
+		when( replayResult.getDescription() ).thenReturn( "foo" );
+		when( replayResult.hasDifferences() ).thenCallRealMethod();
+		when( replayResult.getStateDifference() ).thenReturn( null );
+
+		assertThat( cut.toString( replayResult ) ).isEqualTo( "foo resulted in:\n\tno differences" );
+	}
+
+	@Test
+	void toString_should_respect_indent_if_no_state() {
+		final ActionReplayResult replayResult = mock( ActionReplayResult.class );
+		when( replayResult.getDescription() ).thenReturn( "foo" );
+		when( replayResult.hasDifferences() ).thenCallRealMethod();
+		when( replayResult.getStateDifference() ).thenReturn( null );
+
+		assertThat( cut.toString( replayResult, "____" ) ).isEqualTo( "____foo resulted in:\n____\tno differences" );
+	}
+
+	@Test
 	void toString_should_not_print_child_differences_if_insertion_or_deletion() {
 		final List<ElementDifference> empty = Collections.emptyList();
 

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -4,19 +4,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
 import de.retest.recheck.report.ActionReplayResult;
+import de.retest.recheck.report.action.ActionReplayData;
+import de.retest.recheck.report.action.DifferenceRetriever;
+import de.retest.recheck.report.action.WindowRetriever;
+import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.actions.ExceptionWrapper;
 import de.retest.recheck.ui.actions.TargetNotFoundException;
+import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.PathAttribute;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
+import de.retest.recheck.ui.diff.AttributeDifference;
+import de.retest.recheck.ui.diff.AttributesDifference;
 import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
+import de.retest.recheck.ui.diff.RootElementDifference;
+import de.retest.recheck.util.ApprovalsUtil;
 
 class ActionReplayResultPrinterTest {
 
@@ -103,5 +116,67 @@ class ActionReplayResultPrinterTest {
 		final String string = cut.toString( result );
 
 		assertThat( string ).contains( NoGoldenMasterActionReplayResult.MSG_LONG );
+	}
+
+	@Test
+	void toString_should_not_print_child_differences_if_insertion_or_deletion() {
+		final List<ElementDifference> empty = Collections.emptyList();
+
+		final ElementDifference differences = change( Path.fromString( "html[1]/body[1]" ), Arrays.asList( //
+				delete( Path.fromString( "html[1]/body[1]/div[1]" ), Arrays.asList( // 
+						delete( Path.fromString( "html[1]/body[1]/div[1]/div[1]" ), Arrays.asList( // 
+								delete( Path.fromString( "html[1]/body[1]/div[1]/div[1]/div[1]" ), empty ), // 
+								delete( Path.fromString( "html[1]/body[1]/div[1]/div[1]/div[2]" ), empty ) //
+						) ), //
+						delete( Path.fromString( "html[1]/body[1]/div[1]/div[2]" ), empty ) //
+				) ), //
+				change( Path.fromString( "html[1]/body[1]/div[2]" ), Arrays.asList( // 
+						delete( Path.fromString( "html[1]/body[1]/div[2]/div[1]" ), Arrays.asList( // 
+								delete( Path.fromString( "html[1]/body[1]/div[2]/div[1]/div[1]" ), empty ), //
+								delete( Path.fromString( "html[1]/body[1]/div[2]/div[1]/div[2]" ), empty ) //
+						) ), //
+						change( Path.fromString( "html[1]/body[1]/div[2]/div[2]" ), empty ) ) //
+				) ) );
+
+		final RootElementDifference rootDifference =
+				new RootElementDifference( differences, mock( RootElement.class ), mock( RootElement.class ) );
+
+		final ActionReplayResult replayResult = ActionReplayResult.withDifference( ActionReplayData.ofSutStart(),
+				WindowRetriever.empty(), DifferenceRetriever.of( Collections.singletonList( rootDifference ) ), 0L );
+
+		ApprovalsUtil.verify( cut.toString( replayResult ) );
+	}
+
+	private ElementDifference delete( final Path path, final List<ElementDifference> childDifferences ) {
+		final Element element = element( path );
+
+		final InsertedDeletedElementDifference insertion =
+				InsertedDeletedElementDifference.differenceFor( element, null );
+
+		return new ElementDifference( element, null, insertion, null, null, childDifferences );
+	}
+
+	private ElementDifference change( final Path path, final List<ElementDifference> childDifferences ) {
+		final Element element = element( path );
+
+		final AttributesDifference attributes = new AttributesDifference( Arrays.asList( // 
+				new AttributeDifference( "foo-1", "bar-1", "bar1" ), //
+				new AttributeDifference( "foo-2", "bar-2", "bar2" ), //
+				new AttributeDifference( "foo-3", "bar-3", "bar3" ) //
+		) );
+
+		return new ElementDifference( element, attributes, null, null, null, childDifferences );
+	}
+
+	private Element element( final Path path ) {
+		final PathAttribute pathAttribute = new PathAttribute( path );
+
+		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
+		when( identifyingAttributes.getPath() ).thenReturn( path.toString() );
+		when( identifyingAttributes.toString() ).thenReturn( path.getElement().toString() );
+
+		final Element element = mock( Element.class );
+		when( element.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
+		return element;
 	}
 }

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -126,24 +126,6 @@ class ActionReplayResultPrinterTest {
 	}
 
 	@Test
-	void toString_should_not_print_differences_if_no_state() {
-		final ActionReplayResult replayResult = mock( ActionReplayResult.class );
-		when( replayResult.getDescription() ).thenReturn( "foo" );
-		when( replayResult.hasDifferences() ).thenCallRealMethod();
-
-		assertThat( cut.toString( replayResult ) ).isEqualTo( "foo resulted in:\n\tno differences" );
-	}
-
-	@Test
-	void toString_should_respect_indent_if_no_state() {
-		final ActionReplayResult replayResult = mock( ActionReplayResult.class );
-		when( replayResult.getDescription() ).thenReturn( "foo" );
-		when( replayResult.hasDifferences() ).thenCallRealMethod();
-
-		assertThat( cut.toString( replayResult, "____" ) ).isEqualTo( "____foo resulted in:\n____\tno differences" );
-	}
-
-	@Test
 	void toString_should_not_print_child_differences_if_insertion_or_deletion() {
 		final List<ElementDifference> empty = Collections.emptyList();
 

--- a/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
@@ -1,0 +1,28 @@
+package de.retest.recheck.printer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.report.SuiteReplayResult;
+import de.retest.recheck.report.TestReplayResult;
+import de.retest.recheck.ui.descriptors.GroundState;
+
+class SuiteReplayResultPrinterTest {
+
+	@Test
+	void toString_should_not_print_if_no_differences() {
+		final SuiteReplayResultPrinter cut = new SuiteReplayResultPrinter( DefaultValueFinderProvider.none() );
+
+		final TestReplayResult emptyTestResult = mock( TestReplayResult.class );
+		when( emptyTestResult.isEmpty() ).thenReturn( true );
+
+		final SuiteReplayResult replayResult =
+				new SuiteReplayResult( "suite", 0, mock( GroundState.class ), "uuid", mock( GroundState.class ) );
+		replayResult.addTest( emptyTestResult );
+
+		assertThat( cut.toString( replayResult ) ).isEmpty();
+	}
+}

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -4,6 +4,7 @@ import static de.retest.recheck.ignore.Filter.FILTER_NOTHING;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Answers.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,8 +15,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import de.retest.recheck.NoGoldenMasterActionReplayResult;
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.TestReplayResult;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.recheck.ui.diff.LeafDifference;
 import de.retest.recheck.ui.diff.StateDifference;
 
@@ -97,5 +101,32 @@ class TestReplayResultPrinterTest {
 		final String string = cut.toString( result );
 
 		assertThat( string ).isEqualTo( "Test 'null' has 1 difference(s) in 2 state(s):\n" );
+	}
+
+	@Test
+	void toString_should_not_print_if_no_differences() {
+		final ActionReplayResult emptyActionResult = mock( ActionReplayResult.class );
+		when( emptyActionResult.hasDifferences() ).thenReturn( false );
+
+		final TestReplayResult testResult = mock( TestReplayResult.class );
+		when( testResult.getActionReplayResults() ).thenReturn( Collections.singletonList( emptyActionResult ) );
+
+		assertThat( cut.toString( testResult ) ).isEqualTo( "Test 'null' has 0 difference(s) in 1 state(s):\n" );
+	}
+
+	@Test
+	void toString_should_print_if_no_golden_master() {
+		final RootElement rootElement = mock( RootElement.class, RETURNS_MOCKS );
+
+		final SutState sutState = mock( SutState.class );
+		when( sutState.getRootElements() ).thenReturn( Collections.singletonList( rootElement ) );
+
+		final NoGoldenMasterActionReplayResult noGoldenMaster =
+				new NoGoldenMasterActionReplayResult( "step", sutState, "path" );
+
+		final TestReplayResult testResult = mock( TestReplayResult.class );
+		when( testResult.getActionReplayResults() ).thenReturn( Collections.singletonList( noGoldenMaster ) );
+
+		assertThat( cut.toString( testResult ) ).isNotNull();
 	}
 }

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -16,8 +16,8 @@ import org.mockito.Mockito;
 
 import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.TestReplayResult;
-import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.LeafDifference;
+import de.retest.recheck.ui.diff.StateDifference;
 
 class TestReplayResultPrinterTest {
 
@@ -54,7 +54,7 @@ class TestReplayResultPrinterTest {
 	void toString_should_print_difference() {
 		final ActionReplayResult a1 = mock( ActionReplayResult.class );
 		when( a1.getDescription() ).thenReturn( "foo" );
-		when( a1.getAllElementDifferences() ).thenReturn( singletonList( mock( ElementDifference.class ) ) );
+		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferencesCount() ).thenReturn( 1 );
@@ -63,13 +63,14 @@ class TestReplayResultPrinterTest {
 
 		final String string = cut.toString( result );
 
-		assertThat( string ).isEqualTo( "Test 'null' has 1 difference(s) in 1 state(s):\nfoo resulted in:\n" );
+		assertThat( string ).startsWith( "Test 'null' has 1 difference(s) in 1 state(s):\nfoo resulted in:\n" );
 	}
 
 	@Test
 	void toString_should_print_difference_with_indent() {
 		final ActionReplayResult a1 = mock( ActionReplayResult.class );
 		when( a1.getDescription() ).thenReturn( "foo" );
+		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
@@ -85,8 +86,10 @@ class TestReplayResultPrinterTest {
 	void toString_should_print_multiple_differences() {
 		final ActionReplayResult a1 = mock( ActionReplayResult.class );
 		when( a1.getDescription() ).thenReturn( "foo" );
+		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 		final ActionReplayResult a2 = mock( ActionReplayResult.class );
 		when( a2.getDescription() ).thenReturn( "bar" );
+		when( a2.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferences( FILTER_NOTHING ) ).thenReturn( singleton( mock( LeafDifference.class ) ) );
@@ -94,7 +97,7 @@ class TestReplayResultPrinterTest {
 
 		final String string = cut.toString( result );
 
-		assertThat( string )
-				.isEqualTo( "Test 'null' has 1 difference(s) in 2 state(s):\nfoo resulted in:\n\nbar resulted in:\n" );
+		assertThat( string ).isEqualTo(
+				"Test 'null' has 1 difference(s) in 2 state(s):\nfoo resulted in:\n\tno differences\nbar resulted in:\n\tno differences" );
 	}
 }

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -97,7 +97,7 @@ class TestReplayResultPrinterTest {
 
 		final String string = cut.toString( result );
 
-		assertThat( string ).isEqualTo(
-				"Test 'null' has 1 difference(s) in 2 state(s):\nfoo resulted in:\n\tno differences\nbar resulted in:\n\tno differences" );
+		assertThat( string ).isEqualTo( "Test 'null' has 1 difference(s) in 2 state(s):\n" + "foo resulted in:\n"
+				+ "\t\n" + "bar resulted in:\n" + "\tno differences" );
 	}
 }

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -63,7 +63,7 @@ class TestReplayResultPrinterTest {
 
 		final String string = cut.toString( result );
 
-		assertThat( string ).startsWith( "Test 'null' has 1 difference(s) in 1 state(s):\nfoo resulted in:\n" );
+		assertThat( string ).startsWith( "Test 'null' has 1 difference(s) in 1 state(s):" );
 	}
 
 	@Test
@@ -79,7 +79,6 @@ class TestReplayResultPrinterTest {
 		final String string = cut.toString( result, "____" );
 
 		assertThat( string ).startsWith( "____" );
-		assertThat( string ).contains( "\n____" );
 	}
 
 	@Test
@@ -97,7 +96,6 @@ class TestReplayResultPrinterTest {
 
 		final String string = cut.toString( result );
 
-		assertThat( string ).isEqualTo( "Test 'null' has 1 difference(s) in 2 state(s):\n" + "foo resulted in:\n"
-				+ "\t\n" + "bar resulted in:\n" + "\tno differences" );
+		assertThat( string ).isEqualTo( "Test 'null' has 1 difference(s) in 2 state(s):\n" );
 	}
 }

--- a/src/test/java/de/retest/recheck/printer/TestReportPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReportPrinterTest.java
@@ -1,0 +1,28 @@
+package de.retest.recheck.printer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.report.SuiteReplayResult;
+import de.retest.recheck.report.TestReport;
+
+class TestReportPrinterTest {
+
+	@Test
+	void toString_should_not_print_if_no_differences() {
+		final SuiteReplayResult emptySuite = mock( SuiteReplayResult.class );
+		when( emptySuite.isEmpty() ).thenReturn( true );
+
+		final TestReport testReport = mock( TestReport.class );
+		when( testReport.getSuiteReplayResults() ).thenReturn( Collections.singletonList( emptySuite ) );
+
+		final TestReportPrinter cut = new TestReportPrinter( DefaultValueFinderProvider.none() );
+
+		assertThat( cut.toString( testReport ) ).isEmpty();
+	}
+}

--- a/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
+++ b/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
@@ -1,0 +1,29 @@
+Start Sut resulted in:
+	body[1] at 'html[1]/body[1]':
+		foo-1: expected="bar-1", actual="bar1"
+		foo-2: expected="bar-2", actual="bar2"
+		foo-3: expected="bar-3", actual="bar3"
+	div[1] at 'html[1]/body[1]/div[1]':
+		was deleted
+	div[1] at 'html[1]/body[1]/div[1]/div[1]':
+		was deleted
+	div[1] at 'html[1]/body[1]/div[1]/div[1]/div[1]':
+		was deleted
+	div[2] at 'html[1]/body[1]/div[1]/div[1]/div[2]':
+		was deleted
+	div[2] at 'html[1]/body[1]/div[1]/div[2]':
+		was deleted
+	div[2] at 'html[1]/body[1]/div[2]':
+		foo-1: expected="bar-1", actual="bar1"
+		foo-2: expected="bar-2", actual="bar2"
+		foo-3: expected="bar-3", actual="bar3"
+	div[1] at 'html[1]/body[1]/div[2]/div[1]':
+		was deleted
+	div[1] at 'html[1]/body[1]/div[2]/div[1]/div[1]':
+		was deleted
+	div[2] at 'html[1]/body[1]/div[2]/div[1]/div[2]':
+		was deleted
+	div[2] at 'html[1]/body[1]/div[2]/div[2]':
+		foo-1: expected="bar-1", actual="bar1"
+		foo-2: expected="bar-2", actual="bar2"
+		foo-3: expected="bar-3", actual="bar3"

--- a/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
+++ b/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
@@ -5,23 +5,11 @@ Start Sut resulted in:
 		foo-3: expected="bar-3", actual="bar3"
 	div[1] at 'html[1]/body[1]/div[1]':
 		was deleted
-	div[1] at 'html[1]/body[1]/div[1]/div[1]':
-		was deleted
-	div[1] at 'html[1]/body[1]/div[1]/div[1]/div[1]':
-		was deleted
-	div[2] at 'html[1]/body[1]/div[1]/div[1]/div[2]':
-		was deleted
-	div[2] at 'html[1]/body[1]/div[1]/div[2]':
-		was deleted
 	div[2] at 'html[1]/body[1]/div[2]':
 		foo-1: expected="bar-1", actual="bar1"
 		foo-2: expected="bar-2", actual="bar2"
 		foo-3: expected="bar-3", actual="bar3"
 	div[1] at 'html[1]/body[1]/div[2]/div[1]':
-		was deleted
-	div[1] at 'html[1]/body[1]/div[2]/div[1]/div[1]':
-		was deleted
-	div[2] at 'html[1]/body[1]/div[2]/div[1]/div[2]':
 		was deleted
 	div[2] at 'html[1]/body[1]/div[2]/div[2]':
 		foo-1: expected="bar-1", actual="bar1"


### PR DESCRIPTION
When there are elements inserted/deleted with many children, each child prints its own insertions/deletion message. This can be simplified, if only the parent prints its message and suppresses the child differences. However, we therefore need to traverse manually through the difference tree.