### PR TITLE
Update MOXy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,8 +177,7 @@
 		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>org.eclipse.persistence.moxy</artifactId>
-			<!-- later versions cause JAXBExceptions -->
-			<version>2.5.2</version>
+			<version>2.7.4</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/de/retest/recheck/ui/descriptors/AttributeStringValueAdapter.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/AttributeStringValueAdapter.java
@@ -1,0 +1,33 @@
+package de.retest.recheck.ui.descriptors;
+
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import de.retest.recheck.ui.descriptors.AttributeStringValueAdapter.StringValue;
+
+public class AttributeStringValueAdapter extends XmlAdapter<StringValue, String> {
+
+	public static class StringValue {
+
+		@XmlValue
+		public String value;
+
+		// For JAXB.
+		protected StringValue() {}
+
+		public StringValue( final String value ) {
+			this.value = value;
+		}
+	}
+
+	@Override
+	public String unmarshal( final StringValue v ) throws Exception {
+		return v.value;
+	}
+
+	@Override
+	public StringValue marshal( final String v ) throws Exception {
+		return new StringValue( v );
+	}
+
+}

--- a/src/main/java/de/retest/recheck/ui/descriptors/PathAttribute.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/PathAttribute.java
@@ -5,7 +5,9 @@ import static de.retest.recheck.util.ObjectUtil.checkNull;
 import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.eclipse.persistence.oxm.annotations.XmlPath;
 
 import de.retest.recheck.ui.Path;
 import de.retest.recheck.util.StringSimilarity;
@@ -28,7 +30,8 @@ public class PathAttribute extends ParameterizedAttribute {
 
 	public static final String PATH_KEY = "path";
 
-	@XmlValue
+	@XmlPath( "." )
+	@XmlJavaTypeAdapter( AttributeStringValueAdapter.class )
 	private final String path;
 
 	private transient Path cachedPath;

--- a/src/main/java/de/retest/recheck/ui/descriptors/StringAttribute.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/StringAttribute.java
@@ -3,9 +3,10 @@ package de.retest.recheck.ui.descriptors;
 import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.oxm.annotations.XmlPath;
 
 import de.retest.recheck.util.StringSimilarity;
 
@@ -57,7 +58,8 @@ public class StringAttribute extends ParameterizedAttribute {
 
 	private static final long serialVersionUID = 1L;
 
-	@XmlValue
+	@XmlPath( "." )
+	@XmlJavaTypeAdapter( AttributeStringValueAdapter.class )
 	private final String value;
 
 	// Used by JaxB


### PR DESCRIPTION
Built on top of #403. The `JAXBContext` remains the same, looks like we still cannot reuse it.