### PR TITLE
Add automatic module name to manifest entries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,9 @@
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 						</manifest>
+						<manifestEntries>
+							<Automatic-Module-Name>de.retest.recheck</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
See:

* http://branchandbound.net/blog/java/2017/12/automatic-module-name/
* https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html