### PR TITLE
Replace okhttp with unirest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,14 +161,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>okhttp</artifactId>
-			<!-- last version compatible with Selenium v3.141.59 in recheck-web -->
-			<!-- see https://github.com/SeleniumHQ/selenium/issues/7373 -->
-			<version>3.14.3</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-installed-adapter</artifactId>
 			<version>7.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.konghq</groupId>
+			<artifactId>unirest-java</artifactId>
+			<version>3.0.00</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-installed-adapter</artifactId>
 			<version>7.0.0</version>

--- a/src/main/java/de/retest/recheck/auth/RetestAuthentication.java
+++ b/src/main/java/de/retest/recheck/auth/RetestAuthentication.java
@@ -10,8 +10,13 @@ import java.io.PrintWriter;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.adapters.KeycloakDeployment;
@@ -27,7 +32,6 @@ import org.keycloak.representations.adapters.config.AdapterConfig;
 
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.HttpUrl;
 
 @Slf4j
 public class RetestAuthentication {
@@ -177,13 +181,16 @@ public class RetestAuthentication {
 	}
 
 	static KeycloakResult getRequestParameters( final String request ) {
-		final HttpUrl url = HttpUrl.parse( "http://localhost/" ).resolve( request.split( " " )[1] );
+		final String url = "http://localhost/" + request.split( " " )[1];
+		final Map<String, String> parameters = URLEncodedUtils.parse( URI.create( url ), StandardCharsets.UTF_8 ) //
+				.stream() //
+				.collect( Collectors.toMap( NameValuePair::getName, NameValuePair::getValue ) );
 
 		return KeycloakResult.builder() //
-				.code( url.queryParameter( OAuth2Constants.CODE ) ) //
-				.error( url.queryParameter( OAuth2Constants.ERROR ) ) //
-				.errorDescription( url.queryParameter( "error-description" ) ) //
-				.state( url.queryParameter( OAuth2Constants.STATE ) )//
+				.code( parameters.get( OAuth2Constants.CODE ) ) //
+				.error( parameters.get( OAuth2Constants.ERROR ) ) //
+				.errorDescription( parameters.get( "error-description" ) ) //
+				.state( parameters.get( OAuth2Constants.STATE ) ) //
 				.build();
 	}
 


### PR DESCRIPTION
The current version (4.x) of okhttp is shipped as a Kotlin library. While this generally is a good thing, it blows up some internal parts of recheck and recheck-web due to dependency issues. As we do not heavily rely on okhttp it was and will be pretty easy to replace it with unirest.