### PR TITLE
Use Path inside FilterNotFoundException

### DIFF
--- a/src/main/java/de/retest/recheck/ignore/FilterNotFoundException.java
+++ b/src/main/java/de/retest/recheck/ignore/FilterNotFoundException.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.ignore;
 
+import java.nio.file.Path;
 import java.util.Optional;
 
 import lombok.Getter;
@@ -10,7 +11,7 @@ public class FilterNotFoundException extends RuntimeException {
 	private static final long serialVersionUID = 2L;
 
 	private final String filterName;
-	private final String projectFilterDir;
+	private final Path projectFilterDir;
 
 	public FilterNotFoundException( final String filterName ) {
 		super( "No filter with name '" + filterName
@@ -19,14 +20,14 @@ public class FilterNotFoundException extends RuntimeException {
 		projectFilterDir = null;
 	}
 
-	public FilterNotFoundException( final String filterName, final String projectFilterDir ) {
+	public FilterNotFoundException( final String filterName, final Path projectFilterDir ) {
 		super( "No filter with name '" + filterName + "' found in the project filter folder '" + projectFilterDir
 				+ "', the user home and among the predefined default filters." );
 		this.filterName = filterName;
 		this.projectFilterDir = projectFilterDir;
 	}
 
-	public Optional<String> getProjectFilterDir() {
+	public Optional<Path> getProjectFilterDir() {
 		return Optional.ofNullable( projectFilterDir );
 	}
 

--- a/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
+++ b/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -150,12 +149,11 @@ public class SearchFilterFiles {
 	public static Filter getFilterByName( final String name ) {
 		final Filter filter = toFileNameFilterMapping().get( name );
 		if ( filter == null ) {
-			final Optional<String> projectFilterDir = ProjectConfiguration.getInstance().getProjectConfigFolder() //
+			throw ProjectConfiguration.getInstance().getProjectConfigFolder() //
 					.map( path -> path.resolve( FILTER_DIR_NAME ) ) //
 					.map( Path::toAbsolutePath ) //
-					.map( Path::toString );
-			throw projectFilterDir.isPresent() ? new FilterNotFoundException( name, projectFilterDir.get() )
-					: new FilterNotFoundException( name );
+					.map( path -> new FilterNotFoundException( name, path ) )
+					.orElseGet( () -> new FilterNotFoundException( name ) );
 		}
 		return filter;
 	}


### PR DESCRIPTION
To my understanding, this should not break any projects downstream, as this was introduced down wile the release for 1.5.0 was ongoing, thus not on the release branch.