### PR TITLE
Feature/move props to opts

### DIFF
--- a/src/main/java/de/retest/recheck/RecheckAdapter.java
+++ b/src/main/java/de/retest/recheck/RecheckAdapter.java
@@ -13,6 +13,15 @@ import de.retest.recheck.ui.descriptors.RootElement;
 public interface RecheckAdapter {
 
 	/**
+	 * Returns an instance of the RecheckAdapter, that has been initialized with the given {@link RecheckOptions}. In
+	 * case more specific recheck options are used during initialization of the {@link RecheckImpl}, then these are
+	 * passed on (and need to be cast).
+	 */
+	default RecheckAdapter initialize( final RecheckOptions opts ) {
+		return this;
+	}
+
+	/**
 	 * Returns {@code true} if the given object can be converted by the adapter.
 	 *
 	 * @param toVerify

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -113,7 +113,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 
 	@Override
 	public void check( final Object toVerify, final String currentStep ) {
-		check( toVerify, RecheckAdapters.findAdapterFor( toVerify ), currentStep );
+		check( toVerify, RecheckAdapters.findAdapterFor( toVerify, options ), currentStep );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -17,6 +17,7 @@ import de.retest.recheck.persistence.GradleProjectLayout;
 import de.retest.recheck.persistence.MavenProjectLayout;
 import de.retest.recheck.persistence.NamingStrategy;
 import de.retest.recheck.persistence.ProjectLayout;
+import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class RecheckOptions {
 	private final ProjectLayout projectLayout;
 	private final boolean reportUploadEnabled;
 	private final Filter filter;
+	private final RetestIdProvider retestIdProvider;
 
 	/**
 	 * Creates a shallow copy of the given options. Useful when extending the RecheckOptions to minimize dependencies on
@@ -58,7 +60,7 @@ public class RecheckOptions {
 	 */
 	protected RecheckOptions( final RecheckOptions toCopy ) {
 		this( toCopy.fileNamerStrategy, toCopy.namingStrategy, toCopy.projectLayout, toCopy.reportUploadEnabled,
-				toCopy.filter );
+				toCopy.filter, toCopy.retestIdProvider );
 	}
 
 	/**
@@ -88,6 +90,13 @@ public class RecheckOptions {
 	 */
 	public boolean isReportUploadEnabled() {
 		return reportUploadEnabled;
+	}
+
+	/**
+	 * The {@link RetestIdProvider} to use to generate the retestId for the elements in the Golden Masters.
+	 */
+	public RetestIdProvider getRetestIdProvider() {
+		return retestIdProvider;
 	}
 
 	/**
@@ -122,9 +131,11 @@ public class RecheckOptions {
 		private String suiteName = null;
 		private boolean reportUploadEnabled = false;
 		private Filter ignoreFilter = null;
+		private RetestIdProvider retestIdProvider;
 		private final List<Filter> ignoreFilterToAdd = new ArrayList<>();
 
-		protected RecheckOptionsBuilder() {}
+		protected RecheckOptionsBuilder() {
+		}
 
 		/**
 		 * @deprecated Use {@link #namingStrategy} and {@link #projectLayout} instead.
@@ -241,11 +252,19 @@ public class RecheckOptions {
 			return this;
 		}
 
+		/**
+		 * The {@link RetestIdProvider} to use.
+		 */
+		public RecheckOptionsBuilder retestIdProvider( final RetestIdProvider retestIdProvider ) {
+			this.retestIdProvider = retestIdProvider;
+			return this;
+		}
+
 		public RecheckOptions build() {
 			final String suiteName = getSuiteName();
 			final NamingStrategy namingStrategy = new FixedSuiteNamingStrategy( suiteName, this.namingStrategy );
 			return new RecheckOptions( fileNamerStrategy, namingStrategy, projectLayout, reportUploadEnabled,
-					buildFilter( suiteName ) );
+					buildFilter( suiteName ), retestIdProvider );
 		}
 
 		private String getSuiteName() {

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -18,6 +18,7 @@ import de.retest.recheck.persistence.MavenProjectLayout;
 import de.retest.recheck.persistence.NamingStrategy;
 import de.retest.recheck.persistence.ProjectLayout;
 import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
+import de.retest.recheck.util.RetestIdProviderUtil;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -131,7 +132,7 @@ public class RecheckOptions {
 		private String suiteName = null;
 		private boolean reportUploadEnabled = false;
 		private Filter ignoreFilter = null;
-		private RetestIdProvider retestIdProvider;
+		private RetestIdProvider retestIdProvider = RetestIdProviderUtil.getConfiguredRetestIdProvider();
 		private final List<Filter> ignoreFilterToAdd = new ArrayList<>();
 
 		protected RecheckOptionsBuilder() {

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -135,8 +135,8 @@ public class RecheckOptions {
 		private RetestIdProvider retestIdProvider = RetestIdProviderUtil.getConfiguredRetestIdProvider();
 		private final List<Filter> ignoreFilterToAdd = new ArrayList<>();
 
-		protected RecheckOptionsBuilder() {
-		}
+		protected RecheckOptionsBuilder() {}
+
 
 		/**
 		 * @deprecated Use {@link #namingStrategy} and {@link #projectLayout} instead.

--- a/src/main/java/de/retest/recheck/execution/RecheckAdapters.java
+++ b/src/main/java/de/retest/recheck/execution/RecheckAdapters.java
@@ -4,6 +4,7 @@ import java.util.ServiceLoader;
 import java.util.stream.StreamSupport;
 
 import de.retest.recheck.RecheckAdapter;
+import de.retest.recheck.RecheckOptions;
 
 public class RecheckAdapters {
 
@@ -11,11 +12,12 @@ public class RecheckAdapters {
 
 	private RecheckAdapters() {}
 
-	public static RecheckAdapter findAdapterFor( final Object toVerify ) {
+	public static RecheckAdapter findAdapterFor( final Object toVerify, final RecheckOptions options ) {
 		return StreamSupport.stream( adapters.spliterator(), false ) //
 				.filter( adapter -> adapter.canCheck( toVerify ) ) //
 				.findAny() //
-				.orElseThrow( () -> createHelpfulExceptionForMissingAdapter( toVerify.getClass().getName() ) );
+				.orElseThrow( () -> createHelpfulExceptionForMissingAdapter( toVerify.getClass().getName() ) )
+				.initialize( options );
 	}
 
 	static UnsupportedOperationException createHelpfulExceptionForMissingAdapter( final String className ) {

--- a/src/test/java/de/retest/recheck/execution/RecheckAdaptersTest.java
+++ b/src/test/java/de/retest/recheck/execution/RecheckAdaptersTest.java
@@ -5,11 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
+import de.retest.recheck.RecheckOptions;
+
 class RecheckAdaptersTest {
 
 	@Test
 	void findAdapterFor_should_throw_exception_if_none_found() {
-		assertThatThrownBy( () -> RecheckAdapters.findAdapterFor( new Object() ) ) //
+		assertThatThrownBy( () -> RecheckAdapters.findAdapterFor( new Object(), RecheckOptions.builder().build() ) ) //
 				.isInstanceOf( UnsupportedOperationException.class ) //
 				.hasMessage( "No recheck adapter registered that can handle an object of class java.lang.Object." );
 	}


### PR DESCRIPTION
I oppose to wait for a 2.0 that will cause a big rewriting, introduce a lot of risk and stall improvements until then. Most importantly, it means that all future changes (and I am doing some right now) have to keep doing it the old, wrong way, making it harder, more effort and much riskier to eventually do the big rewriting.
In a 2.0, we can have a ServiceFactory instead of services, which is not _that_ big of a change and start doing it better right away.