### PR TITLE
Let parent of `RootElement` be null

### DIFF
--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -78,7 +78,7 @@ public class Element implements Serializable, Comparable<Element> {
 
 	public static Element create( final String retestId, final Element parent,
 			final IdentifyingAttributes identifyingAttributes, final Attributes attributes ) {
-		return new Element( retestId, parent, identifyingAttributes, attributes, null );
+		return create( retestId, parent, identifyingAttributes, attributes, null );
 	}
 
 	public static Element create( final String retestId, final Element parent,

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -72,8 +72,8 @@ public class Element implements Serializable, Comparable<Element> {
 		this.identifyingAttributes =
 				Objects.requireNonNull( identifyingAttributes, "IdentifyingAttributes must not be null" );
 		this.attributes = Objects.requireNonNull( attributes, "Attributes must not be null" );
-		containedElements = new ArrayList<>();
 		this.screenshot = screenshot;
+		containedElements = new ArrayList<>();
 	}
 
 	public static Element create( final String retestId, final Element parent,

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -1,5 +1,7 @@
 package de.retest.recheck.ui.descriptors;
 
+import static java.util.Objects.requireNonNull;
+
 import java.beans.Transient;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -69,9 +71,8 @@ public class Element implements Serializable, Comparable<Element> {
 		RetestIdUtil.validate( retestId, identifyingAttributes );
 		this.retestId = retestId;
 		this.parent = parent;
-		this.identifyingAttributes =
-				Objects.requireNonNull( identifyingAttributes, "IdentifyingAttributes must not be null" );
-		this.attributes = Objects.requireNonNull( attributes, "Attributes must not be null" );
+		this.identifyingAttributes = requireNonNull( identifyingAttributes, "IdentifyingAttributes must not be null" );
+		this.attributes = requireNonNull( attributes, "Attributes must not be null" );
 		this.screenshot = screenshot;
 		containedElements = new ArrayList<>();
 	}
@@ -84,7 +85,7 @@ public class Element implements Serializable, Comparable<Element> {
 	public static Element create( final String retestId, final Element parent,
 			final IdentifyingAttributes identifyingAttributes, final Attributes attributes,
 			final Screenshot screenshot ) {
-		Objects.requireNonNull( parent, "Parent must not be null" );
+		requireNonNull( parent, "Parent must not be null" );
 		return new Element( retestId, parent, identifyingAttributes, attributes, screenshot );
 	}
 

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -68,7 +68,7 @@ public class Element implements Serializable, Comparable<Element> {
 			final Attributes attributes, final Screenshot screenshot ) {
 		RetestIdUtil.validate( retestId, identifyingAttributes );
 		this.retestId = retestId;
-		this.parent = Objects.requireNonNull( parent, "Parent must not be null" );
+		this.parent = parent;
 		this.identifyingAttributes =
 				Objects.requireNonNull( identifyingAttributes, "IdentifyingAttributes must not be null" );
 		this.attributes = Objects.requireNonNull( attributes, "Attributes must not be null" );
@@ -84,6 +84,7 @@ public class Element implements Serializable, Comparable<Element> {
 	public static Element create( final String retestId, final Element parent,
 			final IdentifyingAttributes identifyingAttributes, final Attributes attributes,
 			final Screenshot screenshot ) {
+		Objects.requireNonNull( parent, "Parent must not be null" );
 		return new Element( retestId, parent, identifyingAttributes, attributes, screenshot );
 	}
 

--- a/src/main/java/de/retest/recheck/ui/descriptors/RootElement.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/RootElement.java
@@ -35,7 +35,7 @@ public class RootElement extends Element {
 	public RootElement( final String retestId, final IdentifyingAttributes identifyingAttributes,
 			final Attributes attributes, final Screenshot screenshot, final String screen, final int screenId,
 			final String title ) {
-		super( retestId, new Element(), identifyingAttributes, attributes, screenshot );
+		super( retestId, null, identifyingAttributes, attributes, screenshot );
 		this.screen = screen;
 		this.screenId = screenId;
 		this.title = title;

--- a/src/test/java/de/retest/recheck/ui/descriptors/RootElementTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/RootElementTest.java
@@ -5,11 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.image.Screenshot;
@@ -18,7 +17,7 @@ import de.retest.recheck.ui.review.ActionChangeSet;
 import de.retest.recheck.ui.review.AttributeChanges;
 import de.retest.recheck.ui.review.ScreenshotChanges;
 
-public class RootElementTest {
+class RootElementTest {
 
 	private static class Window {}
 
@@ -30,12 +29,11 @@ public class RootElementTest {
 			.create( Path.fromString( "Window[1]/Comp[1]" ), Comp.class, "name", "comp 1", "code-loc A" );
 	private final IdentifyingAttributes childIdentAttributes0 = RootIdentifyingAttributes
 			.create( Path.fromString( "Window[1]/Comp[1]/Comp[1]" ), Comp.class, "name", "child 1", "code-loc A" );
-
 	private final Screenshot screenshot = new Screenshot( "", new byte[0], ImageType.PNG );
 
 	@Test
-	public void applyChanges_adds_inserted_components() throws Exception {
-		final RootElement rootElement = descriptorFor( windowIdentAttributes, new Attributes(), screenshot );
+	void applyChanges_should_add_inserted_components() throws Exception {
+		final RootElement rootElement = rootElementFor( windowIdentAttributes, new Attributes(), screenshot );
 		final Element child = Element.create( "wesdf", rootElement, compIdentAttributes, new Attributes() );
 
 		final Element child1 = Element.create( "asdasg", child, childIdentAttributes0, new Attributes() );
@@ -53,9 +51,9 @@ public class RootElementTest {
 	}
 
 	@Test
-	public void applyChanges_removes_deleted_components() throws Exception {
+	void applyChanges_should_remove_deleted_components() throws Exception {
 
-		final RootElement rootElement = descriptorFor( windowIdentAttributes, new Attributes(), screenshot );
+		final RootElement rootElement = rootElementFor( windowIdentAttributes, new Attributes(), screenshot );
 
 		final Element element = Element.create( "fsdfasd", rootElement, compIdentAttributes, new Attributes() );
 		rootElement.addChildren( element );
@@ -70,7 +68,7 @@ public class RootElementTest {
 	}
 
 	@Test
-	public void applyChanges_updates_screenshot() throws Exception {
+	void applyChanges_should_update_screenshot() throws Exception {
 		final Screenshot newScreenshot = mock( Screenshot.class );
 
 		final ScreenshotChanges screenshotChange = mock( ScreenshotChanges.class );
@@ -97,13 +95,12 @@ public class RootElementTest {
 		assertThat( changed.getScreenshot() ).isEqualTo( newScreenshot );
 	}
 
-	private RootElement descriptorFor( final IdentifyingAttributes identifyingAttributes, final Attributes attributes,
+	private RootElement rootElementFor( final IdentifyingAttributes identifyingAttributes, final Attributes attributes,
 			final Screenshot screenshot, final Element... childrenArray ) {
-		final List<Element> children = new ArrayList<>();
-
 		final RootElement rootElement = new RootElement( "asdasd", identifyingAttributes, attributes, screenshot,
 				(String) identifyingAttributes.get( "name" ), identifyingAttributes.get( "name" ).hashCode(),
 				identifyingAttributes.get( "text" ) + "-Window" );
+
 		if ( childrenArray != null ) {
 			rootElement.addChildren( childrenArray );
 		}
@@ -122,13 +119,9 @@ public class RootElementTest {
 			return new RootIdentifyingAttributes( parent );
 		}
 
-		@SuppressWarnings( "unused" )
-		public RootIdentifyingAttributes() {}
-
 		public RootIdentifyingAttributes( final Collection<Attribute> attributes ) {
 			super( attributes );
 		}
-
 	}
 
 }

--- a/src/test/java/de/retest/recheck/ui/descriptors/RootElementTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/RootElementTest.java
@@ -95,6 +95,17 @@ class RootElementTest {
 		assertThat( changed.getScreenshot() ).isEqualTo( newScreenshot );
 	}
 
+	@Test
+	public void parent_should_be_null() throws Exception {
+		final String retestId = "someRetestId";
+		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
+		final Attributes attributes = mock( Attributes.class );
+		final int screenId = 0;
+		final RootElement cut =
+				new RootElement( retestId, identifyingAttributes, attributes, null, null, screenId, null );
+		assertThat( cut.getParent() ).isNull();
+	}
+
 	private RootElement rootElementFor( final IdentifyingAttributes identifyingAttributes, final Attributes attributes,
 			final Screenshot screenshot, final Element... childrenArray ) {
 		final RootElement rootElement = new RootElement( "asdasd", identifyingAttributes, attributes, screenshot,


### PR DESCRIPTION
The previous "Zombie" element caused several issues, because it was basically in an illegal state. I believe having a null parent in this case is the correct, or at least expected behavior (see e.g. #471). This is also what the comment from the empty `Element` ctor suggests: "Warning: Only to be used by JAXB!"

Does anyone know if this may cause issues elsewhere?