### PR TITLE
Add a convenience method to return the value of an attribute

### DIFF
--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -219,13 +219,17 @@ public class Element implements Serializable, Comparable<Element> {
 	 * @return The {@link java.io.Serializable} value of the attribute.
 	 */
 	public Object getAttributeValue( final String attributeName ) {
-		if ( getIdentifyingAttributes().get( attributeName ) != null ) {
-			return getIdentifyingAttributes().getAttribute( attributeName ).getValue();
-		} else if ( getAttributes().get( attributeName ) != null ) {
-			return getAttributes().get( attributeName );
-		} else {
-			return null;
+		final Attribute identifyingAttribute = getIdentifyingAttributes().getAttribute( attributeName );
+		if ( identifyingAttribute != null ) {
+			return identifyingAttribute.getValue();
 		}
+
+		final Object ordinaryAttribute = getAttributes().get( attributeName );
+		if ( ordinaryAttribute != null ) {
+			return ordinaryAttribute;
+		}
+
+		return null;
 	}
 
 	public String getRetestId() {

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -213,6 +213,21 @@ public class Element implements Serializable, Comparable<Element> {
 		return attributes;
 	}
 
+	/**
+	 * Returns the value of the given attribute, whether this is an identifying attribute or not.
+	 *
+	 * @return The {@link java.io.Serializable} value of the attribute.
+	 */
+	public Object getAttributeValue( final String attributeName ) {
+		if ( getIdentifyingAttributes().get( attributeName ) != null ) {
+			return getIdentifyingAttributes().getAttribute( attributeName ).getValue();
+		} else if ( getAttributes().get( attributeName ) != null ) {
+			return getAttributes().get( attributeName );
+		} else {
+			return null;
+		}
+	}
+
 	public String getRetestId() {
 		return retestId;
 	}

--- a/src/test/java/de/retest/recheck/ui/descriptors/ElementTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/ElementTest.java
@@ -1,6 +1,7 @@
 package de.retest.recheck.ui.descriptors;
 
 import static de.retest.recheck.ui.Path.fromString;
+import static de.retest.recheck.ui.descriptors.IdentifyingAttributes.PATH_ATTRIBUTE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -258,6 +259,31 @@ public class ElementTest {
 
 		assertThat( e0 ).isNotEqualTo( e1 );
 		assertThat( e0.hashCode() ).isNotEqualTo( e1.hashCode() );
+	}
+
+	@Test
+	public void getAttributeValue_should_return_IdentifyingAttribute_if_present() {
+		final Element element = Element.create( "retestId", mock( Element.class ),
+				IdentifyingAttributes.create( Path.fromString( "SomePath[0]" ), "SomeType" ),
+				new MutableAttributes().immutable() );
+		assertThat( element.getAttributeValue( PATH_ATTRIBUTE_KEY ) ).isNotNull();
+	}
+
+	@Test
+	public void getAttributeValue_should_return_Attribute_if_present() {
+		final MutableAttributes attributes = new MutableAttributes();
+		attributes.put( "key", "value" );
+		final Element element = Element.create( "retestId", mock( Element.class ),
+				IdentifyingAttributes.create( Path.fromString( "SomePath[0]" ), "SomeType" ), attributes.immutable() );
+		assertThat( element.getAttributeValue( "key" ) ).isEqualTo( "value" );
+	}
+
+	@Test
+	public void getAttributeValue_should_return_null_if_not_present() {
+		final Element element = Element.create( "retestId", mock( Element.class ),
+				IdentifyingAttributes.create( Path.fromString( "SomePath[0]" ), "SomeType" ),
+				new MutableAttributes().immutable() );
+		assertThat( element.getAttributeValue( "key" ) ).isNull();
 	}
 
 	// Copy & paste from ElementBuilder due to cyclic dependency.

--- a/src/test/java/de/retest/recheck/ui/descriptors/ElementTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/ElementTest.java
@@ -5,6 +5,7 @@ import static de.retest.recheck.ui.descriptors.IdentifyingAttributes.PATH_ATTRIB
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -266,7 +267,19 @@ public class ElementTest {
 		final Element element = Element.create( "retestId", mock( Element.class ),
 				IdentifyingAttributes.create( Path.fromString( "SomePath[0]" ), "SomeType" ),
 				new MutableAttributes().immutable() );
-		assertThat( element.getAttributeValue( PATH_ATTRIBUTE_KEY ) ).isNotNull();
+		assertThat( element.getAttributeValue( PATH_ATTRIBUTE_KEY ).toString() ).isEqualTo( "SomePath[0]" );
+	}
+
+	@Test
+	public void getAttributeValue_should_prefer_identifying_over_ordinary_attribute() {
+		final Collection<Attribute> identCrit = IdentifyingAttributes.createList( fromString( "html[1]/a[1]" ), "a" );
+		identCrit.add( new StringAttribute( "text", "my identifying text" ) );
+		final MutableAttributes attributes = new MutableAttributes();
+		attributes.put( "text", "my ordinary text" );
+		final Element element = Element.create( "retestId", mock( Element.class ),
+				new IdentifyingAttributes( identCrit ), attributes.immutable() );
+
+		assertThat( element.getAttributeValue( "text" ) ).isEqualTo( "my identifying text" );
 	}
 
 	@Test


### PR DESCRIPTION
no matter whether it's an identifying or "regular" attribute. I've stumbled across similar code a couple of times, and this simplifies it.