### PR TITLE
Define a non-public constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.retest</groupId>
 	<artifactId>recheck</artifactId>
-	<version>1.6.0-beta.1</version>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>recheck</name>
@@ -72,7 +72,7 @@
 		<url>https://github.com/retest/recheck/</url>
 		<connection>scm:git:git@github.com:retest/recheck.git</connection>
 		<developerConnection>scm:git:git@github.com:retest/recheck.git</developerConnection>
-		<tag>v1.6.0-beta.1</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.retest</groupId>
 	<artifactId>recheck</artifactId>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.6.0-beta.1</version>
 	<packaging>jar</packaging>
 
 	<name>recheck</name>
@@ -72,7 +72,7 @@
 		<url>https://github.com/retest/recheck/</url>
 		<connection>scm:git:git@github.com:retest/recheck.git</connection>
 		<developerConnection>scm:git:git@github.com:retest/recheck.git</developerConnection>
-		<tag>HEAD</tag>
+		<tag>v1.6.0-beta.1</tag>
 	</scm>
 
 	<distributionManagement>

--- a/src/main/java/de/retest/recheck/persistence/xml/XmlPersistenceUtil.java
+++ b/src/main/java/de/retest/recheck/persistence/xml/XmlPersistenceUtil.java
@@ -11,6 +11,8 @@ import de.retest.recheck.util.NamedBufferedInputStream;
 
 public class XmlPersistenceUtil {
 
+	private XmlPersistenceUtil() {}
+
 	static <T extends Persistable> ReTestXmlDataContainer<T> migrateAndRead( final XmlTransformer xml,
 			final NamedBufferedInputStream inputStream, final Listener unmarshallListener ) throws IOException {
 		NamedBufferedInputStream bin = inputStream;


### PR DESCRIPTION
Utility classes are not meant to be instantiated.

PR for the rebazer issue https://retest.atlassian.net/browse/RET-1844 for testing.