### PR TITLE
Ignore elements based on retestId rather than XPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Table of Contents
 
 ### Improvements
 
+* Change the default element identification mechanism within the `recheck.ignore` file (i.e. when using CLI or GUI) from XPath to retestId.
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/recheck/review/GlobalIgnoreApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalIgnoreApplier.java
@@ -9,7 +9,7 @@ import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.review.counter.Counter;
 import de.retest.recheck.review.ignore.ElementAttributeFilter;
 import de.retest.recheck.review.ignore.ElementFilter;
-import de.retest.recheck.review.ignore.matcher.ElementXPathMatcher;
+import de.retest.recheck.review.ignore.matcher.ElementRetestIdMatcher;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.diff.AttributeDifference;
 
@@ -37,7 +37,7 @@ public class GlobalIgnoreApplier implements Filter {
 	}
 
 	public void ignoreAttribute( final Element element, final AttributeDifference difference ) {
-		add( new ElementAttributeFilter( new ElementXPathMatcher( element ), difference.getKey() ) );
+		add( new ElementAttributeFilter( new ElementRetestIdMatcher( element ), difference.getKey() ) );
 	}
 
 	public void unignoreAttribute( final Element element, final AttributeDifference difference ) {
@@ -50,7 +50,7 @@ public class GlobalIgnoreApplier implements Filter {
 	}
 
 	public void ignoreElement( final Element element ) {
-		add( new ElementFilter( new ElementXPathMatcher( element ) ) );
+		add( new ElementFilter( new ElementRetestIdMatcher( element ) ) );
 	}
 
 	public void unignoreElement( final Element element ) {

--- a/src/test/java/de/retest/recheck/review/GlobalIgnoreApplierTest.java
+++ b/src/test/java/de/retest/recheck/review/GlobalIgnoreApplierTest.java
@@ -1,12 +1,12 @@
 package de.retest.recheck.review;
 
 import static de.retest.recheck.review.counter.NopCounter.getInstance;
+import static de.retest.recheck.ui.Path.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.descriptors.MutableAttributes;
@@ -21,8 +21,8 @@ class GlobalIgnoreApplierTest {
 	void ignoreElement_should_add_filter() {
 		final GlobalIgnoreApplier cut = GlobalIgnoreApplier.create( getInstance() );
 
-		final Element element = Element.create( "myRetestId", Mockito.mock( Element.class ),
-				IdentifyingAttributes.create( Path.fromString( "/other[1]/some[1]" ), some.class ),
+		final Element element = Element.create( "myRetestId", mock( Element.class ),
+				IdentifyingAttributes.create( fromString( "/other[1]/some[1]" ), some.class ),
 				new MutableAttributes().immutable() );
 
 		cut.ignoreElement( element );
@@ -34,8 +34,8 @@ class GlobalIgnoreApplierTest {
 	void ignoreAttribute_should_add_filter() {
 		final GlobalIgnoreApplier cut = GlobalIgnoreApplier.create( getInstance() );
 
-		final Element element = Element.create( "myRetestId", Mockito.mock( Element.class ),
-				IdentifyingAttributes.create( Path.fromString( "/other[1]/some[1]" ), some.class ),
+		final Element element = Element.create( "myRetestId", mock( Element.class ),
+				IdentifyingAttributes.create( fromString( "/other[1]/some[1]" ), some.class ),
 				new MutableAttributes().immutable() );
 
 		cut.ignoreAttribute( element, new AttributeDifference( "myAttribute", "expected", "actual" ) );

--- a/src/test/java/de/retest/recheck/review/GlobalIgnoreApplierTest.java
+++ b/src/test/java/de/retest/recheck/review/GlobalIgnoreApplierTest.java
@@ -1,0 +1,46 @@
+package de.retest.recheck.review;
+
+import static de.retest.recheck.review.counter.NopCounter.getInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.MutableAttributes;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class GlobalIgnoreApplierTest {
+
+	private static class some {
+	}
+
+	@Test
+	void ignoreElement_should_add_filter() {
+		final GlobalIgnoreApplier cut = GlobalIgnoreApplier.create( getInstance() );
+
+		final Element element = Element.create( "myRetestId", Mockito.mock( Element.class ),
+				IdentifyingAttributes.create( Path.fromString( "/other[1]/some[1]" ), some.class ),
+				new MutableAttributes().immutable() );
+
+		cut.ignoreElement( element );
+
+		assertThat( cut.persist().getIgnores().toString() ).isEqualTo( "[matcher: retestid=myRetestId]" );
+	}
+
+	@Test
+	void ignoreAttribute_should_add_filter() {
+		final GlobalIgnoreApplier cut = GlobalIgnoreApplier.create( getInstance() );
+
+		final Element element = Element.create( "myRetestId", Mockito.mock( Element.class ),
+				IdentifyingAttributes.create( Path.fromString( "/other[1]/some[1]" ), some.class ),
+				new MutableAttributes().immutable() );
+
+		cut.ignoreAttribute( element, new AttributeDifference( "myAttribute", "expected", "actual" ) );
+
+		assertThat( cut.persist().getIgnores().toString() )
+				.isEqualTo( "[matcher: retestid=myRetestId, attribute: myAttribute]" );
+	}
+}


### PR DESCRIPTION
We postulate that the retestId is the best possible matching method.
Thus we should default to that when ignoring stuff.

Not to be included in the pending release...