### PR TITLE
Fix/js filter log cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Table of Contents
 * Do not parse the CSS attribute `box-shadow` for the filter `pixel-diff`.
 * Update screenshots always instead of never.
 * Matching elements now properly ignores child elements for identifying attributes other than XPath.
+* Fixed that JavaScript filters where not executed again after an error has been thrown.
 
 ### New Features
 
@@ -58,6 +59,7 @@ Table of Contents
 * `RecheckImpl` can now be initialized as a member variable without additional parameters if inside a test class.
 * The screenshot does now have a fixed filename. This makes it much easier to work with VCS.
 * Add sensible default values to the recheck.ignore file that is installed. This will only be created with new project.
+* Improved log messages of faulty JavaScript filters to show the file where the error actually happened.
 
 
 --------------------------------------------------------------------------------

--- a/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
+++ b/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
@@ -83,6 +83,7 @@ public class JSFilterImpl implements Filter {
 			if ( !(callResult instanceof Boolean) ) {
 				logger.error( "'{}' of {} cannot be cast to java.lang.Boolean in file {}.", callResult,
 						callResult.getClass(), filePath );
+				return false;
 			}
 			return (boolean) callResult;
 		} catch ( final ScriptException e ) {

--- a/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
+++ b/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
@@ -44,14 +44,14 @@ public class JSFilterImpl implements Filter {
 		}
 	}
 
-	Reader readScriptFile( final Path ignoreFilePath ) {
+	Reader readScriptFile( final Path filterFilePath ) {
 		try {
-			logger.info( "Reading JS filter rules file from {}.", ignoreFilePath );
-			return Files.newBufferedReader( ignoreFilePath, StandardCharsets.UTF_8 );
+			logger.info( "Reading JS filter rules file from {}.", filterFilePath );
+			return Files.newBufferedReader( filterFilePath, StandardCharsets.UTF_8 );
 		} catch ( final NoSuchFileException e ) {
-			logger.warn( "No JS filter file found at '{}': ", ignoreFilePath, e.getMessage() );
+			logger.warn( "No JS filter file found at '{}': ", filterFilePath, e.getMessage() );
 		} catch ( final Exception e ) {
-			logger.error( "Error opening JS file from '{}': ", ignoreFilePath, e );
+			logger.error( "Error opening JS file from '{}': ", filterFilePath, e );
 		}
 		return new StringReader( "" );
 	}

--- a/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
+++ b/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
@@ -26,10 +26,12 @@ public class JSFilterImpl implements Filter {
 
 	private static final String JS_ENGINE_NAME = "JavaScript";
 
+	private final String filePath;
 	private final ScriptEngine engine;
 	private final Set<String> errorFunctions = new HashSet<>();
 
-	public JSFilterImpl( final Path ignoreFilePath ) {
+	public JSFilterImpl( final Path filterFilePath ) {
+		filePath = filterFilePath.toString();
 		final ScriptEngineManager manager = new ScriptEngineManager();
 		engine = manager.getEngineByName( JS_ENGINE_NAME );
 		if ( engine == null ) {
@@ -39,15 +41,15 @@ public class JSFilterImpl implements Filter {
 			return;
 		}
 		try {
-			engine.eval( readScriptFile( ignoreFilePath ) );
+			engine.eval( readScriptFile( filterFilePath ) );
 		} catch ( final Exception e ) {
-			logger.error( "Reading script file '{}' caused exception: ", ignoreFilePath, e );
+			logger.error( "Reading script file '{}' caused exception: ", filterFilePath, e );
 		}
 	}
 
 	Reader readScriptFile( final Path ignoreFilePath ) {
 		try {
-			logger.info( "Reading JS ignore rules file from {}.", ignoreFilePath );
+			logger.info( "Reading JS filter rules file from {}.", ignoreFilePath );
 			return Files.newBufferedReader( ignoreFilePath, StandardCharsets.UTF_8 );
 		} catch ( final NoSuchFileException e ) {
 			logger.warn( "No JS filter file found at '{}': ", ignoreFilePath, e.getMessage() );
@@ -77,22 +79,24 @@ public class JSFilterImpl implements Filter {
 		try {
 			final Object callResult = inv.invokeFunction( functionName, args );
 			if ( callResult == null ) {
-				logger.warn( "{} returned 'null' instead of a boolean value. Interpreting that as 'false'.",
-						functionName );
+				logger.warn( "{} returned 'null' instead of a boolean value in file {}. Interpreting that as 'false'.",
+						filePath, functionName );
 				return false;
 			}
 			if ( !(callResult instanceof Boolean) ) {
-				logger.error( "'{}' of {} cannot be cast to java.lang.Boolean.", callResult, callResult.getClass() );
 				errorFunctions.add( functionName );
+				logger.error( "'{}' of {} cannot be cast to java.lang.Boolean in file {}.", callResult,
+						callResult.getClass(), filePath );
 			}
 			return (boolean) callResult;
 		} catch ( final ScriptException e ) {
-			logger.error( "JS '{}' method caused an exception: {}", functionName, e.getMessage() );
 			errorFunctions.add( functionName );
+			logger.error( "JS '{}' method caused an exception: {} in file {}.", functionName, e.getMessage(),
+					filePath );
 		} catch ( final NoSuchMethodException e ) {
 			if ( !functionName.startsWith( "shouldIgnore" ) ) {
-				logger.warn( "Specified JS ignore file has no '{}' function.", functionName );
 				errorFunctions.add( functionName );
+				logger.warn( "Specified JS filter file {} has no '{}' function.", filePath, functionName );
 			}
 		}
 		return false;

--- a/src/test/java/de/retest/recheck/ignore/JSFilterImplTest.java
+++ b/src/test/java/de/retest/recheck/ignore/JSFilterImplTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Rectangle;
-import java.io.File;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -17,7 +17,7 @@ import de.retest.recheck.ui.diff.AttributeDifference;
 
 class JSFilterImplTest {
 
-	Path ctorArg = new File( "unused" ).toPath();
+	Path ctorArg = Paths.get( "nonExistentFilterFile" );
 
 	@Test
 	void no_matches_function_should_not_cause_exception() {

--- a/src/test/java/de/retest/recheck/ignore/JSFilterImplTest.java
+++ b/src/test/java/de/retest/recheck/ignore/JSFilterImplTest.java
@@ -1,7 +1,6 @@
 package de.retest.recheck.ignore;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Rectangle;
 import java.io.Reader;
@@ -116,7 +115,7 @@ class JSFilterImplTest {
 	}
 
 	@Test
-	void matches_return_non_boolean_should_throw_exc() {
+	void matches_return_non_boolean_should_not_throw_exc() {
 		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
@@ -127,8 +126,7 @@ class JSFilterImplTest {
 			}
 		};
 		final Element element = Mockito.mock( Element.class );
-		assertThrows( ClassCastException.class,
-				() -> cut.matches( element, new AttributeDifference( "outline", "580", "578" ) ) );
+		assertThat( cut.matches( element, new AttributeDifference( "outline", "580", "578" ) ) ).isFalse();
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/ignore/JSFilterImplTest.java
+++ b/src/test/java/de/retest/recheck/ignore/JSFilterImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Rectangle;
+import java.io.File;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.file.Path;
@@ -16,9 +17,11 @@ import de.retest.recheck.ui.diff.AttributeDifference;
 
 class JSFilterImplTest {
 
+	Path ctorArg = new File( "unused" ).toPath();
+
 	@Test
 	void no_matches_function_should_not_cause_exception() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( "" );
@@ -29,7 +32,7 @@ class JSFilterImplTest {
 
 	@Test
 	void invalid_matches_function_should_not_cause_exception() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( "asdasd.asd.asd();" );
@@ -40,14 +43,14 @@ class JSFilterImplTest {
 
 	@Test
 	void nonexistent_file_should_not_cause_exception() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 		};
 		cut.matches( Mockito.mock( Element.class ) );
 	}
 
 	@Test
 	void matches_should_be_called() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( "function matches(element) { return true; }" );
@@ -58,7 +61,7 @@ class JSFilterImplTest {
 
 	@Test
 	void matches_should_be_called_with_element_param() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( //
@@ -75,7 +78,7 @@ class JSFilterImplTest {
 
 	@Test
 	void matches_example_implementation() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( //
@@ -99,7 +102,7 @@ class JSFilterImplTest {
 
 	@Test
 	void matches_return_null_should_be_false() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( //
@@ -114,7 +117,7 @@ class JSFilterImplTest {
 
 	@Test
 	void matches_return_non_boolean_should_throw_exc() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( //
@@ -130,7 +133,7 @@ class JSFilterImplTest {
 
 	@Test
 	void matches_filter_URL_example_implementation() {
-		final JSFilterImpl cut = new JSFilterImpl( null ) {
+		final JSFilterImpl cut = new JSFilterImpl( ctorArg ) {
 			@Override
 			Reader readScriptFile( final Path path ) {
 				return new StringReader( //


### PR DESCRIPTION
This fix improves logging such that we see which file contains errors and, most importantly, removes a faulty cache. If the matches function fails one time, it will never be called again. AND it's redundant functionality, as this is implemented already by the CacheFilter...