### PR TITLE
Put the file content correctly into the body

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/CloudPersistence.java
+++ b/src/main/java/de/retest/recheck/persistence/CloudPersistence.java
@@ -3,9 +3,9 @@ package de.retest.recheck.persistence;
 import static de.retest.recheck.XmlTransformerUtil.getXmlTransformer;
 import static org.apache.commons.lang3.StringUtils.abbreviate;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -70,7 +70,7 @@ public class CloudPersistence<T extends Persistable> implements Persistence<T> {
 
 		final HttpResponse<?> uploadResponse = Unirest.put( metadata.getUploadUrl() ) //
 				.header( "x-amz-meta-report-name", abbreviate( reportName, MAX_REPORT_NAME_LENGTH ) ) //
-				.field( "upload", new File( metadata.getLocation() ) ) //
+				.body( Files.readAllBytes( Paths.get( metadata.getLocation() ) ) ) //
 				.asEmpty();
 
 		if ( uploadResponse.isSuccess() ) {


### PR DESCRIPTION
since put does not take POST like header parameters, we need to save the actual content into the body.

This was tested manually as writing a proper test seems quite difficult. Since this was introduced with this version, we do not need a changelog.