### PR TITLE
Fix/screenshot changes without differences

### DIFF
--- a/src/main/java/de/retest/recheck/ui/review/ScreenshotChanges.java
+++ b/src/main/java/de/retest/recheck/ui/review/ScreenshotChanges.java
@@ -9,6 +9,7 @@ import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.RootElementDifference;
+import de.retest.recheck.ui.diff.StateDifference;
 import de.retest.recheck.ui.image.Screenshot;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,11 @@ public class ScreenshotChanges {
 	}
 
 	public static ScreenshotChanges actual( final ActionReplayResult result ) {
-		return new ScreenshotChanges( result.getStateDifference().getRootElementDifferences().stream() //
+		final StateDifference stateDifference = result.getStateDifference();
+		if ( stateDifference == null ) {
+			return EMPTY_SCREENSHOTS;
+		}
+		return new ScreenshotChanges( stateDifference.getRootElementDifferences().stream() //
 				.filter( actualScreenshotNotNull() ) //
 				.map( RootElementDifference::getElementDifference ) //
 				.collect( Collectors.toMap( ElementDifference::getIdentifyingAttributes,

--- a/src/test/java/de/retest/recheck/ui/review/ScreenshotChangesTest.java
+++ b/src/test/java/de/retest/recheck/ui/review/ScreenshotChangesTest.java
@@ -19,7 +19,7 @@ import de.retest.recheck.ui.image.Screenshot;
 
 class ScreenshotChangesTest {
 
-	ActionReplayResult actionReplayResult;
+	ActionReplayResult actionWithDifferences;
 
 	Screenshot screenshot;
 
@@ -50,13 +50,13 @@ class ScreenshotChangesTest {
 		when( stateDifference.getRootElementDifferences() )
 				.thenReturn( Arrays.asList( rootElementWithScreenshot, rootElementWithoutScreenshot ) );
 
-		actionReplayResult = mock( ActionReplayResult.class );
-		when( actionReplayResult.getStateDifference() ).thenReturn( stateDifference );
+		actionWithDifferences = mock( ActionReplayResult.class );
+		when( actionWithDifferences.getStateDifference() ).thenReturn( stateDifference );
 	}
 
 	@Test
 	void actual_should_properly_lookup_element_screenshots() throws Exception {
-		final ScreenshotChanges cut = ScreenshotChanges.actual( actionReplayResult );
+		final ScreenshotChanges cut = ScreenshotChanges.actual( actionWithDifferences );
 
 		assertThat( cut.getScreenshot( identifyingForPresentScreenshot ) ).isEqualTo( screenshot );
 		assertThat( cut.getScreenshot( identifyingForMissingScreenshot ) ).isNull();
@@ -64,6 +64,6 @@ class ScreenshotChangesTest {
 
 	@Test
 	void actual_should_not_produce_null_pointer_with_null_screenshots() throws Exception {
-		assertThatCode( () -> ScreenshotChanges.actual( actionReplayResult ) ).doesNotThrowAnyException();
+		assertThatCode( () -> ScreenshotChanges.actual( actionWithDifferences ) ).doesNotThrowAnyException();
 	}
 }

--- a/src/test/java/de/retest/recheck/ui/review/ScreenshotChangesTest.java
+++ b/src/test/java/de/retest/recheck/ui/review/ScreenshotChangesTest.java
@@ -66,4 +66,11 @@ class ScreenshotChangesTest {
 	void actual_should_not_produce_null_pointer_with_null_screenshots() throws Exception {
 		assertThatCode( () -> ScreenshotChanges.actual( actionWithDifferences ) ).doesNotThrowAnyException();
 	}
+
+	@Test
+	void actual_should_not_throw_if_difference_is_null() throws Exception {
+		final ActionReplayResult actionWithoutDifferences = mock( ActionReplayResult.class );
+
+		assertThatCode( () -> ScreenshotChanges.actual( actionWithoutDifferences ) ).doesNotThrowAnyException();
+	}
 }


### PR DESCRIPTION
When trying to open a report without differences (happened with tests.report), there was a NPE since the `StateDifference` can be null.