### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,40 @@
+---
+name: Bug
+about: Create a bug report to help us improve
+labels: bug
+---
+
+*Before submission, please check that ...*
+
+- [ ] this is related specifically to recheck and not its extension (e.g. [recheck-web](https://github.com/retest/recheck-web)).
+- [ ] the [documentation](https://docs.retest.de/) does not mention a fix (e.g. wrong API usage, ...).
+- [ ] the bug is not related to a customization (e.g. custom implementations).
+- [ ] there are no open or closed issues that are related to this problem.
+
+<!-- Note: You can always ask a maintainer to help you with the above tasks. -->
+
+## Describe the Bug
+
+<!-- A clear and concise description of what the bug is. Note the expected and actual behavior of the problem and provide some context in which your bug occurs (e.g. what are you trying to achieve). -->
+
+### How to Reproduce?
+
+<!-- Did it occur through the usage of a extension (e.g. recheck-web)? -->
+
+Steps to reproduce the behavior:
+1. ... 
+2. ...
+3. ...
+
+### Setup
+
+<!-- Please describe your setup. Include any configuration taken place (e.g. through RecheckOptions). -->
+
+- recheck: [e.g. 1.6.0]
+- Testing framework: [e.g. JUnit5 5.5.2, TestNG 7.0.0]
+- OS: [e.g. MacOS 14, Windows 10]
+- Java version: [e.g. OpenJDK 11]
+
+### Additional Context
+
+<!-- A screenshot, report or Golden Master or minimal test setup can be helpful for reproducing this bug. Please check that you do not expose any secrets. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature
+about: Create a issue that suggests or improves a feature
+labels: enhancement
+---
+
+*Before submission, please check that ...*
+
+- [ ] this is related specifically to recheck and not its extension (e.g. [recheck-web](https://github.com/retest/recheck-web)).
+- [ ] the [documentation](https://docs.retest.de/) does not mention a similar solution (e.g. possible configurations).
+- [ ] there are no open or closed issues that are related to this idea.
+- [ ] this, to my best knowledge, will not break something else.
+  
+<!-- Note: You can always ask a maintainer to help you with the above tasks. -->
+
+## Problem
+
+<!-- A clear and concise description of what the problem is that you are trying to solve. Please provide some context in which it may be used (e.g. what are you trying to achieve). -->
+
+### Solution
+
+<!-- Do you have a solution in mind? If yes, please provide a clear and concise description of what you want to happen. If not, you may work together with the maintainers towards a solution.  -->
+
+### Additional Context
+
+<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+---
+name: Custom
+about: Create a custom pull request.
+---
+
+*Before submission, please check that ...*
+
+- [ ] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
+- [ ] the necessary tests are either created or updated.
+- [ ] all status checks (Travis CI, SonarCloud, etc.) pass.
+- [ ] your commit history is cleaned up.
+- [ ] you updated the changelog.
+- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).
+
+<!-- Note: You can always ask a maintainer to help you with the above tasks. -->
+
+## Description
+
+> TL;DR <!-- Please provide some short description here -->
+
+<!-- Please provide additional description with this PR. If there are any related issues, please link them here too. -->
+
+### State of this PR
+
+<!-- If there is any work left (see above) or things to consider -->
+
+### Additional Context
+
+<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->


### PR DESCRIPTION
This will add two issue templates when creating issues: Bug and Feature. Additionally, one can still create a blank issue.

Secondly, per default pull requests now contain a body, where one should check that the PR in question is reflected with our DoD. The contributor is prompted to provide some description which should remove this `No description provided` messages from PRs.

This should help with the initial feedback on issues and PRs so that it is clear what we expect of an issue and PR.

### Screenshots

Issue creation:
![issue-template-creation](https://user-images.githubusercontent.com/10256143/68382721-952f3100-0154-11ea-9065-75215aadffca.png)

Issue Template:
![issue_bug](https://user-images.githubusercontent.com/10256143/68382726-96f8f480-0154-11ea-8e4b-6ff78f9b5f28.png)

Pull Request template:
![pr_template](https://user-images.githubusercontent.com/10256143/68382732-98c2b800-0154-11ea-9249-87daa1de6ecc.png)
