### PR TITLE
Remove unsupported yaml header

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,3 @@
----
-name: Custom
-about: Create a custom pull request.
----
-
 *Before submission, please check that ...*
 
 - [ ] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.


### PR DESCRIPTION
*Before submission, please check that ...*

- [X] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [X] the necessary tests are either created or updated.
- [X] all status checks (Travis CI, SonarCloud, etc.) pass.
- [X] your commit history is cleaned up.
- [X] you updated the changelog.
- [X] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

The provided yaml header is only supported with named templates, i.e. that reside in `.github/PULL_REQUEST_TEMPLATE`. Since this is a generic template, the header is not supported and thus removed.

This then should look similarly to this comment.