### PR TITLE
Feature/rework filter loader mechanism

### DIFF
--- a/src/main/java/de/retest/recheck/ignore/CacheFilter.java
+++ b/src/main/java/de/retest/recheck/ignore/CacheFilter.java
@@ -2,6 +2,7 @@ package de.retest.recheck.ignore;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -43,13 +44,8 @@ public class CacheFilter implements Filter {
 	public static class FilterLoader implements Loader<CacheFilter> {
 
 		@Override
-		public boolean canLoad( final String line ) {
-			return false;
-		}
-
-		@Override
-		public CacheFilter load( final String line ) {
-			return null;
+		public Optional<CacheFilter> load( final String line ) {
+			return Optional.empty();
 		}
 
 		@Override

--- a/src/main/java/de/retest/recheck/ignore/CacheFilter.java
+++ b/src/main/java/de/retest/recheck/ignore/CacheFilter.java
@@ -50,7 +50,7 @@ public class CacheFilter implements Filter {
 
 		@Override
 		public String save( final CacheFilter ignore ) {
-			return Loaders.save( ignore.base );
+			return Loaders.filter().save( ignore.base );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/ignore/Filters.java
+++ b/src/main/java/de/retest/recheck/ignore/Filters.java
@@ -11,7 +11,7 @@ import de.retest.recheck.review.ignore.io.Loaders;
 
 public class Filters {
 
-	private Filters() {};
+	private Filters() {}
 
 	public static Filter load( final Path path ) throws IOException {
 		try ( final Stream<String> filterFileLines = Files.lines( path ) ) {
@@ -28,9 +28,7 @@ public class Filters {
 	}
 
 	public static Filter parse( final Stream<String> lines ) {
-		return Loaders.load( lines ) //
-				.filter( Filter.class::isInstance ) //
-				.map( Filter.class::cast ) //
+		return Loaders.filter().load( lines ) //
 				.collect( Collectors.collectingAndThen( Collectors.toList(), CompoundFilter::new ) );
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/AttributeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/AttributeFilter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -48,7 +49,7 @@ public class AttributeFilter implements Filter {
 		}
 
 		@Override
-		protected AttributeFilter load( final MatchResult regex ) {
+		protected Optional<AttributeFilter> load( final MatchResult regex ) {
 			final String attribute = regex.group( 1 );
 			if ( attribute.contains( POSSIBLE_REGEX ) ) {
 				final String actualLine = KEY + attribute;
@@ -56,7 +57,7 @@ public class AttributeFilter implements Filter {
 				log.warn( "'{}' contains '{}'. For regular expressions, please use '{}'.", actualLine, POSSIBLE_REGEX,
 						suggestedLine );
 			}
-			return new AttributeFilter( attribute );
+			return Optional.of( new AttributeFilter( attribute ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/AttributeRegexFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/AttributeRegexFilter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -43,9 +44,9 @@ public class AttributeRegexFilter implements Filter {
 		}
 
 		@Override
-		protected AttributeRegexFilter load( final MatchResult regex ) {
+		protected Optional<AttributeRegexFilter> load( final MatchResult regex ) {
 			final String attributeRegex = regex.group( 1 );
-			return new AttributeRegexFilter( attributeRegex );
+			return Optional.of( new AttributeRegexFilter( attributeRegex ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
@@ -49,9 +49,9 @@ public class ElementAttributeFilter implements Filter {
 
 		@Override
 		protected ElementAttributeFilter load( final MatchResult regex ) {
-			final String matcher = regex.group( 1 );
+			final Matcher<Element> matcher = Loaders.elementMatcher().load( regex.group( 1 ) ).get();
 			final String key = regex.group( 2 );
-			return new ElementAttributeFilter( Loaders.load( matcher ), key );
+			return new ElementAttributeFilter( matcher, key );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -48,10 +49,11 @@ public class ElementAttributeFilter implements Filter {
 		}
 
 		@Override
-		protected ElementAttributeFilter load( final MatchResult regex ) {
-			final Matcher<Element> matcher = Loaders.elementMatcher().load( regex.group( 1 ) ).get();
+		protected Optional<ElementAttributeFilter> load( final MatchResult regex ) {
+			final String matcher = regex.group( 1 );
 			final String key = regex.group( 2 );
-			return new ElementAttributeFilter( matcher, key );
+			return Loaders.elementMatcher().load( matcher ) //
+					.map( match -> new ElementAttributeFilter( match, key ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
@@ -4,7 +4,6 @@ import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.review.ignore.io.Loader;
 import de.retest.recheck.review.ignore.io.Loaders;
 import de.retest.recheck.review.ignore.io.RegexLoader;
 import de.retest.recheck.review.ignore.matcher.Matcher;
@@ -51,9 +50,8 @@ public class ElementAttributeFilter implements Filter {
 		@Override
 		protected ElementAttributeFilter load( final MatchResult regex ) {
 			final String matcher = regex.group( 1 );
-			final Loader<Matcher> loader = Loaders.get( matcher );
 			final String key = regex.group( 2 );
-			return new ElementAttributeFilter( loader.load( matcher ), key );
+			return new ElementAttributeFilter( Loaders.load( matcher ), key );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
@@ -49,9 +49,9 @@ public class ElementAttributeRegexFilter implements Filter {
 
 		@Override
 		protected ElementAttributeRegexFilter load( final MatchResult regex ) {
-			final String matcher = regex.group( 1 );
+			final Matcher<Element> matcher = Loaders.elementMatcher().load( regex.group( 1 ) ).get();
 			final String key = regex.group( 2 );
-			return new ElementAttributeRegexFilter( Loaders.load( matcher ), key );
+			return new ElementAttributeRegexFilter( matcher, key );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -48,10 +49,11 @@ public class ElementAttributeRegexFilter implements Filter {
 		}
 
 		@Override
-		protected ElementAttributeRegexFilter load( final MatchResult regex ) {
-			final Matcher<Element> matcher = Loaders.elementMatcher().load( regex.group( 1 ) ).get();
+		protected Optional<ElementAttributeRegexFilter> load( final MatchResult regex ) {
+			final String matcher = regex.group( 1 );
 			final String key = regex.group( 2 );
-			return new ElementAttributeRegexFilter( matcher, key );
+			return Loaders.elementMatcher().load( matcher ) //
+					.map( match -> new ElementAttributeRegexFilter( match, key ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
@@ -4,7 +4,6 @@ import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.review.ignore.io.Loader;
 import de.retest.recheck.review.ignore.io.Loaders;
 import de.retest.recheck.review.ignore.io.RegexLoader;
 import de.retest.recheck.review.ignore.matcher.Matcher;
@@ -51,9 +50,8 @@ public class ElementAttributeRegexFilter implements Filter {
 		@Override
 		protected ElementAttributeRegexFilter load( final MatchResult regex ) {
 			final String matcher = regex.group( 1 );
-			final Loader<Matcher> loader = Loaders.get( matcher );
 			final String key = regex.group( 2 );
-			return new ElementAttributeRegexFilter( loader.load( matcher ), key );
+			return new ElementAttributeRegexFilter( Loaders.load( matcher ), key );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
@@ -45,8 +45,8 @@ public class ElementFilter implements Filter {
 
 		@Override
 		protected ElementFilter load( final MatchResult regex ) {
-			final String matcher = regex.group( 1 );
-			return new ElementFilter( Loaders.load( matcher ) );
+			final Matcher<Element> matcher = Loaders.elementMatcher().load( regex.group( 1 ) ).get();
+			return new ElementFilter( matcher );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
@@ -4,7 +4,6 @@ import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.review.ignore.io.Loader;
 import de.retest.recheck.review.ignore.io.Loaders;
 import de.retest.recheck.review.ignore.io.RegexLoader;
 import de.retest.recheck.review.ignore.matcher.Matcher;
@@ -47,8 +46,7 @@ public class ElementFilter implements Filter {
 		@Override
 		protected ElementFilter load( final MatchResult regex ) {
 			final String matcher = regex.group( 1 );
-			final Loader<Matcher> loader = Loaders.get( matcher );
-			return new ElementFilter( loader.load( matcher ) );
+			return new ElementFilter( Loaders.load( matcher ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementFilter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -44,9 +45,10 @@ public class ElementFilter implements Filter {
 		}
 
 		@Override
-		protected ElementFilter load( final MatchResult regex ) {
-			final Matcher<Element> matcher = Loaders.elementMatcher().load( regex.group( 1 ) ).get();
-			return new ElementFilter( matcher );
+		protected Optional<ElementFilter> load( final MatchResult regex ) {
+			final String matcher = regex.group( 1 );
+			return Loaders.elementMatcher().load( matcher ) //
+					.map( ElementFilter::new );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/FilterPreserveLineLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/FilterPreserveLineLoader.java
@@ -1,5 +1,7 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
+
 import org.apache.commons.lang3.StringUtils;
 
 import de.retest.recheck.ignore.Filter;
@@ -28,8 +30,7 @@ public class FilterPreserveLineLoader implements Loader<FilterPreserveLine> {
 		}
 
 		@Override
-		public boolean matches( final Element element,
-				final AttributeDifference attributeDifference ) {
+		public boolean matches( final Element element, final AttributeDifference attributeDifference ) {
 			return false;
 		}
 
@@ -40,8 +41,7 @@ public class FilterPreserveLineLoader implements Loader<FilterPreserveLine> {
 
 	}
 
-	@Override
-	public boolean canLoad( final String line ) {
+	private boolean canLoad( final String line ) {
 		final boolean comment = line.startsWith( FilterPreserveLine.COMMENT );
 		if ( comment ) {
 			return true;
@@ -62,8 +62,11 @@ public class FilterPreserveLineLoader implements Loader<FilterPreserveLine> {
 	}
 
 	@Override
-	public FilterPreserveLine load( final String line ) {
-		return new FilterPreserveLine( line );
+	public Optional<FilterPreserveLine> load( final String line ) {
+		if ( canLoad( line ) ) {
+			return Optional.of( new FilterPreserveLine( line ) );
+		}
+		return Optional.empty();
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/review/ignore/JSFilterLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/JSFilterLoader.java
@@ -1,23 +1,20 @@
 package de.retest.recheck.review.ignore;
 
+import java.util.Optional;
+
 import de.retest.recheck.ignore.JSFilterImpl;
 import de.retest.recheck.review.ignore.io.Loader;
 
 public class JSFilterLoader implements Loader<JSFilterImpl> {
 
 	@Override
-	public JSFilterImpl load( final String line ) {
+	public Optional<JSFilterImpl> load( final String line ) {
 		// XXX This causes exceptions when something is loaded which other loaders can't load.
-		return new JSFilterImpl( null );
+		return Optional.empty();
 	}
 
 	@Override
 	public String save( final JSFilterImpl ignore ) {
 		return "";
-	}
-
-	@Override
-	public boolean canLoad( final String line ) {
-		return false;
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/PixelDiffFilter.java
@@ -4,6 +4,7 @@ import java.awt.Rectangle;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
@@ -114,11 +115,11 @@ public class PixelDiffFilter implements Filter {
 		}
 
 		@Override
-		protected PixelDiffFilter load( final MatchResult regex ) {
+		protected Optional<PixelDiffFilter> load( final MatchResult regex ) {
 			final String value = regex.group( 1 );
 			final boolean specifiedAsDouble = value.contains( "." );
 			final double pixelDiff = Double.parseDouble( value );
-			return new PixelDiffFilter( specifiedAsDouble, pixelDiff );
+			return Optional.of( new PixelDiffFilter( specifiedAsDouble, pixelDiff ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/io/ErrorHandlingLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/ErrorHandlingLoader.java
@@ -1,5 +1,7 @@
 package de.retest.recheck.review.ignore.io;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,12 +12,7 @@ public final class ErrorHandlingLoader implements Loader<FilterPreserveLine> {
 	private static final Logger logger = LoggerFactory.getLogger( ErrorHandlingLoader.class );
 
 	@Override
-	public boolean canLoad( final String line ) {
-		return true;
-	}
-
-	@Override
-	public FilterPreserveLine load( final String line ) {
+	public Optional<FilterPreserveLine> load( final String line ) {
 		if ( line.startsWith( "attribute:" ) ) {
 			logger.error(
 					"For ignoring an attribute globally, please use 'attribute=' (to ensure weired line breaks do not break your ignore file)." );
@@ -24,7 +21,7 @@ public final class ErrorHandlingLoader implements Loader<FilterPreserveLine> {
 					"No loader defined for line '{}'. Read more at https://docs.retest.de/recheck/how-ignore-works/",
 					line );
 		}
-		return new FilterPreserveLine( line );
+		return Optional.of( new FilterPreserveLine( line ) );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/review/ignore/io/InheritanceLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/InheritanceLoader.java
@@ -1,0 +1,40 @@
+package de.retest.recheck.review.ignore.io;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public final class InheritanceLoader<T> implements Loader<T> {
+
+	private final List<Pair<Class<? extends T>, Loader<? extends T>>> registeredLoaders;
+
+	@Override
+	public Optional<T> load( final String line ) {
+		return registeredLoaders.stream() //
+				.<Loader<? extends T>> map( Pair::getRight ) //
+				.map( loader -> loader.load( line ) ) //
+				.filter( Optional::isPresent ) //
+				.findFirst() //
+				.map( Optional::get );
+	}
+
+	@Override
+	@SuppressWarnings( "unchecked" )
+	public String save( final T object ) {
+		final Class<?> clazz = object.getClass();
+		return registeredLoaders.stream() //
+				.filter( pair -> pair.getLeft().isAssignableFrom( clazz ) ) //
+				.findFirst() //
+				.map( pair -> (Loader<T>) pair.getRight() ) // We must cast here, since we get a Loader<? extends T>
+				.map( loader -> loader.save( object ) ) // otherwise this is not accepted by save( ? extends T )
+				.orElseThrow( () -> noLoaderFor( object ) );
+	}
+
+	private UnsupportedOperationException noLoaderFor( final T object ) {
+		return new UnsupportedOperationException( String.format( "Did not find a loader for %s.", object ) );
+	}
+}

--- a/src/main/java/de/retest/recheck/review/ignore/io/Loader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/Loader.java
@@ -1,10 +1,22 @@
 package de.retest.recheck.review.ignore.io;
 
 import java.util.Optional;
+import java.util.stream.Stream;
+
+import de.retest.recheck.util.StreamUtil;
 
 public interface Loader<T> {
 
 	Optional<T> load( String line );
 
+	default Stream<T> load( final Stream<String> lines ) {
+		return lines.map( this::load ) //
+				.flatMap( StreamUtil::optionalToStream );
+	}
+
 	String save( T ignore );
+
+	default Stream<String> save( final Stream<T> objects ) {
+		return objects.map( this::save );
+	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/io/Loader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/Loader.java
@@ -1,11 +1,10 @@
 package de.retest.recheck.review.ignore.io;
 
+import java.util.Optional;
+
 public interface Loader<T> {
 
-	boolean canLoad( final String line );
-
-	T load( String line );
+	Optional<T> load( String line );
 
 	String save( T ignore );
-
 }

--- a/src/main/java/de/retest/recheck/review/ignore/io/RegexLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/RegexLoader.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore.io;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -13,17 +14,12 @@ public abstract class RegexLoader<T> implements Loader<T> {
 	}
 
 	@Override
-	public boolean canLoad( final String line ) {
-		return regex.matcher( line ).matches();
-	}
-
-	@Override
-	public T load( final String line ) {
+	public Optional<T> load( final String line ) {
 		final Matcher matcher = regex.matcher( line );
-		if ( !matcher.find() ) {
-			throw new IllegalArgumentException( "The line '" + line + "' does not match '" + regex.pattern() + "'." );
+		if ( !matcher.matches() ) {
+			return Optional.empty();
 		}
-		return load( matcher.toMatchResult() );
+		return Optional.of( load( matcher.toMatchResult() ) );
 	}
 
 	protected abstract T load( final MatchResult matcher );

--- a/src/main/java/de/retest/recheck/review/ignore/io/RegexLoader.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/RegexLoader.java
@@ -19,10 +19,10 @@ public abstract class RegexLoader<T> implements Loader<T> {
 		if ( !matcher.matches() ) {
 			return Optional.empty();
 		}
-		return Optional.of( load( matcher.toMatchResult() ) );
+		return load( matcher.toMatchResult() );
 	}
 
-	protected abstract T load( final MatchResult matcher );
+	protected abstract Optional<T> load( final MatchResult matcher );
 
 	@Override
 	public String save( final T ignore ) {

--- a/src/main/java/de/retest/recheck/review/ignore/matcher/ElementClassMatcher.java
+++ b/src/main/java/de/retest/recheck/review/ignore/matcher/ElementClassMatcher.java
@@ -3,6 +3,7 @@ package de.retest.recheck.review.ignore.matcher;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -51,9 +52,9 @@ public class ElementClassMatcher implements Matcher<Element> {
 		}
 
 		@Override
-		protected ElementClassMatcher load( final MatchResult matcher ) {
+		protected Optional<ElementClassMatcher> load( final MatchResult matcher ) {
 			final String classValue = matcher.group( 1 );
-			return new ElementClassMatcher( toClassValuesList( classValue ) );
+			return Optional.of( new ElementClassMatcher( toClassValuesList( classValue ) ) );
 		}
 	}
 

--- a/src/main/java/de/retest/recheck/review/ignore/matcher/ElementIdMatcher.java
+++ b/src/main/java/de/retest/recheck/review/ignore/matcher/ElementIdMatcher.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore.matcher;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -42,9 +43,9 @@ public class ElementIdMatcher implements Matcher<Element> {
 		}
 
 		@Override
-		protected ElementIdMatcher load( final MatchResult matcher ) {
+		protected Optional<ElementIdMatcher> load( final MatchResult matcher ) {
 			final String id = matcher.group( 1 );
-			return new ElementIdMatcher( id );
+			return Optional.of( new ElementIdMatcher( id ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/matcher/ElementRetestIdMatcher.java
+++ b/src/main/java/de/retest/recheck/review/ignore/matcher/ElementRetestIdMatcher.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore.matcher;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -15,7 +16,7 @@ public class ElementRetestIdMatcher implements Matcher<Element> {
 	}
 
 	private ElementRetestIdMatcher( final String id ) {
-		this.retestid = id;
+		retestid = id;
 	}
 
 	@Override
@@ -40,9 +41,9 @@ public class ElementRetestIdMatcher implements Matcher<Element> {
 		}
 
 		@Override
-		protected ElementRetestIdMatcher load( final MatchResult matcher ) {
+		protected Optional<ElementRetestIdMatcher> load( final MatchResult matcher ) {
 			final String id = matcher.group( 1 );
-			return new ElementRetestIdMatcher( id );
+			return Optional.of( new ElementRetestIdMatcher( id ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/matcher/ElementTypeMatcher.java
+++ b/src/main/java/de/retest/recheck/review/ignore/matcher/ElementTypeMatcher.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore.matcher;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -41,9 +42,9 @@ public class ElementTypeMatcher implements Matcher<Element> {
 		}
 
 		@Override
-		protected ElementTypeMatcher load( final MatchResult matcher ) {
+		protected Optional<ElementTypeMatcher> load( final MatchResult matcher ) {
 			final String type = matcher.group( 1 );
-			return new ElementTypeMatcher( type );
+			return Optional.of( new ElementTypeMatcher( type ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/ignore/matcher/ElementXPathMatcher.java
+++ b/src/main/java/de/retest/recheck/review/ignore/matcher/ElementXPathMatcher.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.review.ignore.matcher;
 
+import java.util.Optional;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -40,9 +41,9 @@ public class ElementXPathMatcher implements Matcher<Element> {
 		}
 
 		@Override
-		protected ElementXPathMatcher load( final MatchResult matcher ) {
+		protected Optional<ElementXPathMatcher> load( final MatchResult matcher ) {
 			final String xpath = matcher.group( 1 );
-			return new ElementXPathMatcher( xpath );
+			return Optional.of( new ElementXPathMatcher( xpath ) );
 		}
 	}
 }

--- a/src/main/java/de/retest/recheck/review/workers/LoadFilterWorker.java
+++ b/src/main/java/de/retest/recheck/review/workers/LoadFilterWorker.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import de.retest.recheck.ignore.CacheFilter;
-import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.JSFilterImpl;
 import de.retest.recheck.ignore.RecheckIgnoreUtil;
 import de.retest.recheck.review.GlobalIgnoreApplier;
@@ -38,9 +37,7 @@ public class LoadFilterWorker {
 		final Optional<Path> ignoreFile = getIgnoreFile();
 		final Stream<String> ignoreFileLines = Files.lines(
 				ignoreFile.orElseThrow( () -> new NoSuchFileException( "No '" + RECHECK_IGNORE + "' found." ) ) );
-		final PersistableGlobalIgnoreApplier ignoreApplier = Loaders.load( ignoreFileLines ) //
-				.filter( Filter.class::isInstance ) //
-				.map( Filter.class::cast ) //
+		final PersistableGlobalIgnoreApplier ignoreApplier = Loaders.filter().load( ignoreFileLines ) //
 				.collect( Collectors.collectingAndThen( Collectors.toList(), PersistableGlobalIgnoreApplier::new ) );
 		final GlobalIgnoreApplier result = GlobalIgnoreApplier.create( counter, ignoreApplier );
 
@@ -55,7 +52,8 @@ public class LoadFilterWorker {
 	}
 
 	private Optional<Path> getIgnoreRuleFile() {
-		return ignoreFilesBasePath != null ? resolveAndCheckFile( RECHECK_IGNORE_JSRULES ) : RecheckIgnoreUtil.getIgnoreRuleFile();
+		return ignoreFilesBasePath != null ? resolveAndCheckFile( RECHECK_IGNORE_JSRULES )
+				: RecheckIgnoreUtil.getIgnoreRuleFile();
 	}
 
 	private Optional<Path> resolveAndCheckFile( final String ignoreFilename ) {

--- a/src/main/java/de/retest/recheck/review/workers/SaveFilterWorker.java
+++ b/src/main/java/de/retest/recheck/review/workers/SaveFilterWorker.java
@@ -31,7 +31,7 @@ public class SaveFilterWorker {
 		final Stream<Filter> filters = persist.getIgnores().stream() //
 				.map( this::extractCachedFilter ) //
 				.filter( filter -> !(filter instanceof JSFilterImpl) );
-		final Stream<String> save = Loaders.save( filters );
+		final Stream<String> save = Loaders.filter().save( filters );
 
 		try ( final PrintStream writer = new PrintStream( Files.newOutputStream(
 				ignoreFile.orElseThrow( () -> new IllegalArgumentException( "No recheck.ignore found." ) ) ) ) ) {

--- a/src/test/java/de/retest/recheck/review/ignore/ElementAttributeFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ElementAttributeFilterLoaderTest.java
@@ -33,6 +33,6 @@ class ElementAttributeFilterLoaderTest {
 	@Test
 	void load_should_produce_correct_ignore() {
 		final String line = "matcher: retestid=abc, attribute: 123";
-		assertThat( cut.save( cut.load( line ) ) ).isEqualTo( line );
+		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
 }

--- a/src/test/java/de/retest/recheck/review/ignore/ElementAttributeFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ElementAttributeFilterLoaderTest.java
@@ -35,4 +35,10 @@ class ElementAttributeFilterLoaderTest {
 		final String line = "matcher: retestid=abc, attribute: 123";
 		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
+
+	@Test
+	void load_with_invalid_matcher_should_not_load_parent() throws Exception {
+		final String line = "matcher: foo=bar, attribute: 123";
+		assertThat( cut.load( line ) ).isNotPresent();
+	}
 }

--- a/src/test/java/de/retest/recheck/review/ignore/ElementFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ElementFilterLoaderTest.java
@@ -60,4 +60,10 @@ class ElementFilterLoaderTest {
 		final String line = "matcher: id=abc";
 		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
+
+	@Test
+	void load_with_invalid_matcher_should_not_load_parent() throws Exception {
+		final String line = "matcher: foo=bar";
+		assertThat( cut.load( line ) ).isNotPresent();
+	}
 }

--- a/src/test/java/de/retest/recheck/review/ignore/ElementFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ElementFilterLoaderTest.java
@@ -35,7 +35,7 @@ class ElementFilterLoaderTest {
 	@Test
 	void ignore_element_by_tag_should_work() {
 		cut = new ElementFilterLoader();
-		final ElementFilter filter = cut.load( "matcher: type=meta" );
+		final ElementFilter filter = cut.load( "matcher: type=meta" ).get();
 
 		final IdentifyingAttributes attributes = mock( IdentifyingAttributes.class );
 		when( attributes.get( "type" ) ).thenReturn( "meta" );
@@ -58,6 +58,6 @@ class ElementFilterLoaderTest {
 	@Test
 	void load_should_produce_correct_ignore() {
 		final String line = "matcher: id=abc";
-		assertThat( cut.save( cut.load( line ) ) ).isEqualTo( line );
+		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
 }

--- a/src/test/java/de/retest/recheck/review/ignore/FilterPreserveLineTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/FilterPreserveLineTest.java
@@ -18,7 +18,7 @@ public class FilterPreserveLineTest {
 	public void should_load_comments() throws Exception {
 		final String comment = FilterPreserveLine.COMMENT + " some comment";
 		final Loader<FilterPreserveLine> cut = new FilterPreserveLineLoader();
-		assertThat( cut.canLoad( comment ) ).isTrue();
+		assertThat( cut.load( comment ) ).isPresent();
 	}
 
 	@Test
@@ -28,17 +28,17 @@ public class FilterPreserveLineTest {
 		final String whitespace2 = "\n";
 		final String whitespace3 = "\t";
 		final Loader<FilterPreserveLine> cut = new FilterPreserveLineLoader();
-		assertThat( cut.canLoad( whitespace0 ) ).isTrue();
-		assertThat( cut.canLoad( whitespace1 ) ).isTrue();
-		assertThat( cut.canLoad( whitespace2 ) ).isTrue();
-		assertThat( cut.canLoad( whitespace3 ) ).isTrue();
+		assertThat( cut.load( whitespace0 ) ).isPresent();
+		assertThat( cut.load( whitespace1 ) ).isPresent();
+		assertThat( cut.load( whitespace2 ) ).isPresent();
+		assertThat( cut.load( whitespace3 ) ).isPresent();
 	}
 
 	@Test
 	public void should_load_leading_whitespace_and_warn() throws Exception {
 		final String line = " foo bar baz";
 		final Loader<FilterPreserveLine> cut = new FilterPreserveLineLoader();
-		assertThat( cut.canLoad( line ) ).isTrue();
+		assertThat( cut.load( line ) ).isPresent();
 		assertThat( systemOut.getLog() )
 				.contains( "Please remove leading whitespace from the following line:\n" + line );
 	}

--- a/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/PixelDiffFilterLoaderTest.java
@@ -12,12 +12,12 @@ class PixelDiffFilterLoaderTest {
 	void should_not_load_non_integer_and_non_double() throws Exception {
 		final PixelDiffFilterLoader cut = new PixelDiffFilterLoader();
 
-		assertThat( cut.canLoad( "foo=bar" ) ).isFalse();
-		assertThat( cut.canLoad( "pixel-diff=baz" ) ).isFalse();
-		assertThat( cut.canLoad( "pixel-diff=-5" ) ).isFalse();
-		assertThat( cut.canLoad( "pixel-diff=5." ) ).isFalse();
-		assertThat( cut.canLoad( "pixel-diff=5.0." ) ).isFalse();
-		assertThat( cut.canLoad( "pixel-diff=5,0" ) ).isFalse();
+		assertThat( cut.load( "foo=bar" ) ).isNotPresent();
+		assertThat( cut.load( "pixel-diff=baz" ) ).isNotPresent();
+		assertThat( cut.load( "pixel-diff=-5" ) ).isNotPresent();
+		assertThat( cut.load( "pixel-diff=5." ) ).isNotPresent();
+		assertThat( cut.load( "pixel-diff=5.0." ) ).isNotPresent();
+		assertThat( cut.load( "pixel-diff=5,0" ) ).isNotPresent();
 	}
 
 	@Test
@@ -25,14 +25,14 @@ class PixelDiffFilterLoaderTest {
 		final PixelDiffFilterLoader cut = new PixelDiffFilterLoader();
 
 		final String intDiff = "pixel-diff=5";
-		assertThat( cut.canLoad( intDiff ) ).isTrue();
-		final PixelDiffFilter loadedIntDiff = cut.load( intDiff );
+		assertThat( cut.load( intDiff ) ).isPresent();
+		final PixelDiffFilter loadedIntDiff = cut.load( intDiff ).get();
 		assertThat( loadedIntDiff.isSpecifiedAsDouble() ).isFalse();
 		assertThat( loadedIntDiff.getPixelDiff() ).isEqualTo( 5.0 );
 
 		final String doubleDiff = "pixel-diff=5.0";
-		assertThat( cut.canLoad( doubleDiff ) ).isTrue();
-		final PixelDiffFilter loadedDoubleDiff = cut.load( doubleDiff );
+		assertThat( cut.load( doubleDiff ) ).isPresent();
+		final PixelDiffFilter loadedDoubleDiff = cut.load( doubleDiff ).get();
 		assertThat( loadedDoubleDiff.isSpecifiedAsDouble() ).isTrue();
 		assertThat( loadedDoubleDiff.getPixelDiff() ).isEqualTo( 5.0 );
 	}

--- a/src/test/java/de/retest/recheck/review/ignore/io/InheritanceLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/io/InheritanceLoaderTest.java
@@ -1,0 +1,95 @@
+package de.retest.recheck.review.ignore.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InheritanceLoaderTest {
+
+	Loader<A> cut;
+
+	final A a = new A();
+	final B b = new B();
+	final C c = new C();
+	final Z z = new Z();
+
+	@BeforeEach
+	void setUp() {
+		final Loader<A> aLoader = mock( Loader.class );
+		when( aLoader.load( "a" ) ).thenReturn( Optional.of( a ) );
+		when( aLoader.save( a ) ).thenReturn( "a" );
+
+		final Loader<B> bLoader = mock( Loader.class );
+		when( bLoader.load( "b" ) ).thenReturn( Optional.of( b ) );
+		when( bLoader.save( b ) ).thenReturn( "b" );
+
+		final Loader<C> cLoader = mock( Loader.class );
+		when( cLoader.load( "c" ) ).thenReturn( Optional.of( c ) );
+		when( cLoader.save( c ) ).thenReturn( "c" );
+
+		cut = new InheritanceLoader<>( Arrays.asList( //
+				Pair.of( B.class, bLoader ), //	
+				Pair.of( C.class, cLoader ), // 	
+				Pair.of( A.class, aLoader ) //
+		) );
+	}
+
+	@Test
+	void load_should_parse_correct_strings() throws Exception {
+		assertThat( cut.load( "a" ) ).hasValue( a );
+		assertThat( cut.load( "b" ) ).hasValue( b );
+		assertThat( cut.load( "c" ) ).hasValue( c );
+		assertThat( cut.load( "d" ) ).isNotPresent();
+	}
+
+	@Test
+	void load_stream_should_parse_correct_strings() throws Exception {
+		assertThat( cut.load( Stream.of( "a", "b", "c", "d" ) ) ).contains( a, b, c );
+		assertThat( cut.load( Stream.of( "a", "a", "b", "c" ) ) ).contains( a, a, b, c );
+	}
+
+	@Test
+	void save_should_produce_correct_strings() throws Exception {
+		assertThat( cut.save( a ) ).isEqualTo( "a" );
+		assertThat( cut.save( b ) ).isEqualTo( "b" );
+		assertThat( cut.save( c ) ).isEqualTo( "c" );
+	}
+
+	@Test
+	void save_stream_should_produce_correct_strings() throws Exception {
+		assertThat( cut.save( Stream.of( a, b, c ) ) ).contains( "a", "b", "c" );
+		assertThat( cut.save( Stream.of( a, a, b, c ) ) ).contains( "a", "a", "b", "c" );
+	}
+
+	@Test
+	void save_with_unsupported_loader_should_produce_exception() throws Exception {
+		assertThatThrownBy( () -> cut.save( z ) ) //
+				.isInstanceOf( UnsupportedOperationException.class ) //
+				.hasMessage( String.format( "Did not find a loader for %s.", z ) );
+	}
+
+	@Test
+	void save_stream_with_unsupported_loader_should_produce_exception() throws Exception {
+		// We need a finalizer method on the stream here, so that the stream actually evaluates and throws an exception
+		assertThatThrownBy( () -> cut.save( Stream.of( a, z, b ) ).toArray() )
+				.isInstanceOf( UnsupportedOperationException.class ) //
+				.hasMessage( String.format( "Did not find a loader for %s.", z ) );
+	}
+
+	static class A {}
+
+	static class B extends A {}
+
+	static class C extends A {}
+
+	static class Z extends A {}
+}

--- a/src/test/java/de/retest/recheck/review/ignore/io/LoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/io/LoaderTest.java
@@ -1,0 +1,58 @@
+package de.retest.recheck.review.ignore.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LoaderTest {
+
+	Loader<String> cut;
+
+	@BeforeEach
+	void setUp() {
+		cut = new StringLoader();
+	}
+
+	@Test
+	void load_should_return_string() throws Exception {
+		assertThat( cut.load( "foo" ) ).hasValue( "foo" );
+	}
+
+	@Test
+	void load_should_return_empty_when_ignore() throws Exception {
+		assertThat( cut.load( "ignore" ) ).isNotPresent();
+	}
+
+	@Test
+	void save_should_return_the_same_string() throws Exception {
+		assertThat( cut.save( "foo" ) ).isEqualTo( "foo" );
+		assertThat( cut.save( "ignore" ) ).isEqualTo( "ignore" );
+	}
+
+	@Test
+	void load_should_properly_ignore_failed_attempts() throws Exception {
+		assertThat( cut.load( Stream.of( "foo", "ignore", "bar" ) ) ).contains( "foo", "bar" );
+	}
+
+	@Test
+	void save_with_stream_should_properly_delegate() throws Exception {
+		assertThat( cut.save( Stream.of( "foo", "ignore", "bar" ) ) ).contains( "foo", "ignore", "bar" );
+	}
+
+	static class StringLoader implements Loader<String> {
+
+		@Override
+		public Optional<String> load( final String line ) {
+			return line.equals( "ignore" ) ? Optional.empty() : Optional.of( line );
+		}
+
+		@Override
+		public String save( final String ignore ) {
+			return ignore;
+		}
+	}
+}

--- a/src/test/java/de/retest/recheck/review/ignore/matcher/ElementClassMatcherLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/matcher/ElementClassMatcherLoaderTest.java
@@ -32,7 +32,7 @@ class ElementClassMatcherLoaderTest {
 	@Test
 	void load_should_produce_correct_ignore_for_single_class_value() {
 		final String line = toLine( classValue );
-		assertThat( cut.save( cut.load( line ) ) ).isEqualTo( line );
+		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
 
 	@Test
@@ -45,7 +45,7 @@ class ElementClassMatcherLoaderTest {
 	@Test
 	void load_should_produce_correct_ignore_for_multiple_class_values() {
 		final String line = toLine( "one two" );
-		assertThat( cut.save( cut.load( line ) ) ).isEqualTo( line );
+		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
 
 	private String toLine( final String classValue ) {

--- a/src/test/java/de/retest/recheck/review/ignore/matcher/ElementIdMatcherLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/matcher/ElementIdMatcherLoaderTest.java
@@ -35,6 +35,6 @@ class ElementIdMatcherLoaderTest {
 	@Test
 	void load_should_produce_correct_ignore() {
 		final String line = "id=abc";
-		assertThat( cut.save( cut.load( line ) ) ).isEqualTo( line );
+		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
 }

--- a/src/test/java/de/retest/recheck/review/ignore/matcher/ElementRetestIdMatcherLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/matcher/ElementRetestIdMatcherLoaderTest.java
@@ -32,6 +32,6 @@ class ElementRetestIdMatcherLoaderTest {
 	@Test
 	void load_should_produce_correct_ignore() {
 		final String line = "retestid=abc";
-		assertThat( cut.save( cut.load( line ) ) ).isEqualTo( line );
+		assertThat( cut.load( line ).map( cut::save ) ).hasValue( line );
 	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [X] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [X] your commit history is cleaned up.
- [x] ~you updated the changelog.~
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This PR addresses several issues with the current implementation of the _Loading_ API with respects to type safety, API and error handling.

#### Type Safety

The `Loaders` implementation has automatic generics which get adjusted accordingly to the left hand of the expression (see below). Together with stuffing all possible loaders into one List this resulted in a "I have to guess the respective type" and if the guess was wrong, in a weird `ClassCastException`, since the last would always be a `PreserveLineFilter`.
```
String loaded = Loaders.load( "foo bar" );
```

To work around this issue, several independent lists of loaders per type have been created. Since those are essentially a loader for the common super type, a new Loader was created that does the delegation as it was used to by `Loaders`. The respective type specific Loaders are accessible in `Loaders`.

This change even allows for wrapped generics (e.g. `Matcher<Element>`) to be resolved properly.

#### API

The `Loader`-API featured two methods that had to be called when trying to load something. Firstly, `canLoad` which essentially did a dry run and if successful the actual `load` which does the same logic again.

These methods have been merged to return an `Optional` which directly contains the value if successful, or empty if unsuccessful. While this now has the advantages and disadvantages of `Optional`, it essentially provides a performance benefit. In particular, this is true for the `RegexLoader` which must only match once (updating the internal status) and instantly retrieve the result with `group`.

The stream loading has been moved into the `Loader` as default methods.

#### Error Handling

As noted above, determining when a filter can load the line is tedious. The same goes for error handling. What happens, if the loader wraps another one (like `ElementAttributeFilterLoader`) and it fails to load the child? The loader already claimed that it could load the line, but then fails to, which prevents other loaders to take effect.
```
matcher: foo=bar, attribute: bar
```

Due to the API changes, this is now possible. The child will try to load the respective subset (e.g. `foo=bar`) and be chained to the parent loader. If the child fails, the parent does to, which gives access to other loaders or the fallback, if all loaders fail.

### State of this PR

This should only be an internal refactoring, since `Loaders` should not be addressed from an external API. Instead the `Filters` and `*FilterWorker` should be used, which have been updated accordingly.

All necessary tests should have been updated and fixed accordingly. However with SonarCloud currently down, there is no certain way to tell.

### Additional Context

Please read the commit messages for additional information.