### PR TITLE
Feature/add suite description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Table of Contents
 ### Improvements
 
 * Change the default element identification mechanism within the `recheck.ignore` file (i.e. when using CLI or GUI) from XPath to retestId.
+* Display suite description for test report printing so that tests now can properly be identified with their parent suite.
+
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/SuiteReplayResultPrinter.java
@@ -14,6 +14,17 @@ public class SuiteReplayResultPrinter implements Printer<SuiteReplayResult> {
 
 	@Override
 	public String toString( final SuiteReplayResult difference, final String indent ) {
+		return indent + createDescription( difference ) + "\n" + createDifferences( difference, indent + "\t" );
+	}
+
+	private String createDescription( final SuiteReplayResult difference ) {
+		final String name = difference.getName();
+		final int differences = difference.getDifferencesCount();
+		final int states = difference.getTestReplayResults().size();
+		return String.format( "Suite '%s' has %d difference(s) in %d test(s):", name, differences, states );
+	}
+
+	private String createDifferences( final SuiteReplayResult difference, final String indent ) {
 		return difference.getTestReplayResults().stream() //
 				.filter( testReplayResult -> !testReplayResult.isEmpty() ) //
 				.map( d -> delegate.toString( d, indent ) ) //

--- a/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
@@ -23,6 +23,6 @@ class SuiteReplayResultPrinterTest {
 				new SuiteReplayResult( "suite", 0, mock( GroundState.class ), "uuid", mock( GroundState.class ) );
 		replayResult.addTest( emptyTestResult );
 
-		assertThat( cut.toString( replayResult ) ).isEmpty();
+		assertThat( cut.toString( replayResult ) ).isEqualTo( "Suite 'suite' has 0 difference(s) in 1 test(s):\n" );
 	}
 }

--- a/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
@@ -4,11 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 
+import de.retest.recheck.report.ActionReplayResult;
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
 import de.retest.recheck.ui.descriptors.GroundState;
+import de.retest.recheck.ui.diff.StateDifference;
 
 class SuiteReplayResultPrinterTest {
 
@@ -24,5 +28,36 @@ class SuiteReplayResultPrinterTest {
 		replayResult.addTest( emptyTestResult );
 
 		assertThat( cut.toString( replayResult ) ).isEqualTo( "Suite 'suite' has 0 difference(s) in 1 test(s):\n" );
+	}
+
+	@Test
+	void toString_with_indent_should_not_print_if_no_differences() {
+		final SuiteReplayResultPrinter cut = new SuiteReplayResultPrinter( DefaultValueFinderProvider.none() );
+
+		final SuiteReplayResult replayResult =
+				new SuiteReplayResult( "suite", 0, mock( GroundState.class ), "uuid", mock( GroundState.class ) );
+
+		assertThat( cut.toString( replayResult, "____" ) ).startsWith( "____" );
+	}
+
+	@Test
+	void toString_should_print_test_properly_indented() throws Exception {
+		final SuiteReplayResultPrinter cut = new SuiteReplayResultPrinter( DefaultValueFinderProvider.none() );
+
+		final ActionReplayResult actionResult = mock( ActionReplayResult.class );
+		when( actionResult.hasDifferences() ).thenReturn( true );
+		when( actionResult.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+
+		final TestReplayResult testResult = mock( TestReplayResult.class );
+		when( testResult.isEmpty() ).thenReturn( false );
+		when( testResult.getActionReplayResults() ).thenReturn( Collections.singletonList( actionResult ) );
+
+		final SuiteReplayResult replayResult =
+				new SuiteReplayResult( "suite", 0, mock( GroundState.class ), "uuid", mock( GroundState.class ) );
+		replayResult.addTest( testResult );
+
+		assertThat( cut.toString( replayResult ) ).isEqualTo( "Suite 'suite' has 0 difference(s) in 1 test(s):\n" //
+				+ "\tTest 'null' has 0 difference(s) in 1 state(s):\n" //
+				+ "\tnull resulted in:\n" );
 	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [X] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [X] the necessary tests are either created or updated.
- [X] all status checks (Travis CI, SonarCloud, etc.) pass.
- [X] your commit history is cleaned up.
- [X] you updated the changelog.
- [X] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Printing the whole report (in recheck.cli) does only print the tests, which does not help much with same test names. Thus I added a similar description to the suite.

When having a bunch of tests with the same/similar name and different suites, it is impossible to really map those to the corresponding suites if printed through the recheck.cli. Thus I added a description similar to the test description to the suite and indent the test printing so that those can properly be mapped to the suite.

Empty suites should be filtered through the printer above, thus there will be no empty suite differences present.

A example is provided in the tests.

### State of this PR

1. Since this affects only the test report, there should be minor changes necessary in the recheck.cli.
2. Should we put this additionally in the recheck.cli changelog?

I think the difference counting is broken (what a surprise), but this is better than no description and kept similar to the test description.