### PR TITLE
Do not wrap NoSuchFileException inside a IncompatibleReportVersionExc…

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/bin/KryoPersistence.java
+++ b/src/main/java/de/retest/recheck/persistence/bin/KryoPersistence.java
@@ -6,6 +6,7 @@ import static java.nio.file.Files.newOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -113,7 +114,7 @@ public class KryoPersistence<T extends Persistable> implements Persistence<T> {
 				throw new IncompatibleReportVersionException( writerVersion, version, identifier );
 			}
 			return persistable;
-		} catch ( final IncompatibleReportVersionException e ) {
+		} catch ( final IncompatibleReportVersionException | NoSuchFileException e ) {
 			throw e;
 		} catch ( final Exception e ) {
 			if ( version.equals( writerVersion ) ) {

--- a/src/test/java/de/retest/recheck/persistence/bin/KryoPersistenceTest.java
+++ b/src/test/java/de/retest/recheck/persistence/bin/KryoPersistenceTest.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -125,5 +126,13 @@ class KryoPersistenceTest {
 		final KryoPersistence<Persistable> cut = new KryoPersistence<>();
 
 		assertThat( cut.isCompatible( Persistable.class, 1 ) ).isTrue();
+	}
+
+	@Test
+	void non_existent_file_should_properly_throw_correct_exception() throws Exception {
+		final KryoPersistence<TestReport> cut = new KryoPersistence<>();
+
+		assertThatThrownBy( () -> cut.load( Paths.get( "/non/existent/file" ).toUri() ) ) //
+				.isInstanceOf( NoSuchFileException.class );
 	}
 }


### PR DESCRIPTION
…eption

*Before submission, please check that ...*

- [X] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [X] the necessary tests are either created or updated.
- [X] all status checks (Travis CI, SonarCloud, etc.) pass.
- [X] your commit history is cleaned up.
- [X] ~you updated the changelog.~
- [X] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR We do not want to wrap all exception and instead rethrow them. Any exceptions missing?

This happened with the recheck.cli update branch.