### PR TITLE
Have public save and load methods, such that they can be used by Babelfish

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/bin/KryoPersistence.java
+++ b/src/main/java/de/retest/recheck/persistence/bin/KryoPersistence.java
@@ -90,10 +90,10 @@ public class KryoPersistence<T extends Persistable> implements Persistence<T> {
 		final Path path = Paths.get( identifier );
 		final File file = path.toFile();
 		FileUtil.ensureFolder( path.toFile() );
-		try ( OutputStream outputStream = newOutputStream( path ) ) {
+		try {
 			log.debug( "Writing {} to {}. Do not write to same identifier or interrupt until done.", element,
 					identifier );
-			save( outputStream, element );
+			save( newOutputStream( path ), element );
 			log.debug( "Done writing {} to {}", element, identifier );
 		} catch ( final Throwable t ) {
 			log.error( "Error writing to file {}. Deleting what has been written to not leave corrupt file behind...",
@@ -104,26 +104,22 @@ public class KryoPersistence<T extends Persistable> implements Persistence<T> {
 	}
 
 	public void save( final OutputStream outputStream, final T element ) throws IOException {
-		final Output output = new Output( new LZ4FrameOutputStream( outputStream ) );
-		output.writeString( version );
-		kryo.writeClassAndObject( output, element );
-		output.close();
+		try ( Output output = new Output( new LZ4FrameOutputStream( outputStream ) ) ) {
+			output.writeString( version );
+			kryo.writeClassAndObject( output, element );
+		}
 	}
 
 	@Override
 	public T load( final URI identifier ) throws IOException {
 		final Path path = Paths.get( identifier );
-		try {
-			return load( newInputStream( path ), identifier );
-		} catch ( final IncompatibleReportVersionException | NoSuchFileException e ) {
-			throw e;
-		}
+		return load( newInputStream( path ), identifier );
 	}
 
 	@SuppressWarnings( "unchecked" )
 	public T load( final InputStream in, final URI identifier ) throws IOException {
 		String writerVersion = null;
-		try ( final Input input = new Input( new LZ4FrameInputStream( in ) ) ) {
+		try ( Input input = new Input( new LZ4FrameInputStream( in ) ) ) {
 			writerVersion = input.readString();
 			final T persistable = (T) kryo.readClassAndObject( input );
 			if ( !isCompatible( persistable ) ) {


### PR DESCRIPTION
Only a refactoring, shouldn't change impl details.