### PR TITLE
Feature/ret 1897 add generic metadata providers

### DIFF
--- a/src/main/java/de/retest/recheck/meta/GlobalMetadataProvider.java
+++ b/src/main/java/de/retest/recheck/meta/GlobalMetadataProvider.java
@@ -1,0 +1,24 @@
+package de.retest.recheck.meta;
+
+import java.util.Map;
+
+/**
+ * Provides generic metadata that apply in particular to the current context in which a program is executed. This
+ * includes for example:
+ * <ul>
+ * <li>The operating systems name and version.</li>
+ * <li>The date and time executed.</li>
+ * <li>...</li>
+ * </ul>
+ */
+final class GlobalMetadataProvider implements MetadataProvider {
+
+	private final MetadataProvider globalProvider = MultiMetadataProvider.of(
+	// TODO RET-1898 insert the global metadata providers here
+	);
+
+	@Override
+	public Map<String, String> retrieve() {
+		return globalProvider.retrieve();
+	}
+}

--- a/src/main/java/de/retest/recheck/meta/MetadataProvider.java
+++ b/src/main/java/de/retest/recheck/meta/MetadataProvider.java
@@ -1,0 +1,51 @@
+package de.retest.recheck.meta;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * <p>
+ * Provides metadata for corresponding data. The data provided may be arbitrarily complex, but should note the
+ * limitations below and the limitations of the corresponding implementation in which this provider is used.
+ * 
+ * <p>
+ * This provider does not know any context and therefore must contain such context within the implementation (i.e.
+ * passed into the constructor).
+ * 
+ * <pre>
+ * new MetadataProviderImpl( context1, context2 );
+ * </pre>
+ * 
+ * <p>
+ * This provider may be used with other providers to construct a more extensive metadata object. Therefore following
+ * rules apply:
+ * <ul>
+ * <li><b>No {@code null} values are allowed.</b> Keys that map to non existent values (i.e. {@code null} should not be
+ * added as this may be used as indicator for a missing key. Instead an other representation (e.g. {@code ""}) should be
+ * used.</li>
+ * <li><b>No duplicate keys are allowed.</b> A provider is not permitted to overwrite or alter any metadata of another
+ * provider. Precautions should be taken to avoid (unintended) duplicate keys, such as a namespace for each
+ * provider.</li>
+ * <li><b>Only simple values shall be used.</b> While theoretically any arbitrary data may be provided, it should be
+ * taken care, that each datum is as simple as possible. It should therefore be avoided to parse complex data from a
+ * single datum. Instead, multiple correlated keys shall be used and then constructed as necessary by retrieving the
+ * corresponding keys. For instance, a rectangle should be split up into its raw attributes: x, y, width, height and
+ * saved separately.</li>
+ * </ul>
+ */
+@FunctionalInterface
+public interface MetadataProvider {
+
+	/**
+	 * Collects the metadata into a plain map. This map does not allow for {@code null} values or duplicate keys.
+	 * 
+	 * @return The metadata as plain map with key-value pairs.
+	 * 
+	 * @implSpec Once returned the map shall not be updated.
+	 */
+	Map<String, String> retrieve();
+
+	static MetadataProvider empty() {
+		return Collections::emptyMap;
+	}
+}

--- a/src/main/java/de/retest/recheck/meta/MetadataProviderService.java
+++ b/src/main/java/de/retest/recheck/meta/MetadataProviderService.java
@@ -1,0 +1,13 @@
+package de.retest.recheck.meta;
+
+/**
+ * Combines the {@link GlobalMetadataProvider} and an arbitrary local metadata provider.
+ */
+public final class MetadataProviderService {
+
+	private static final MetadataProvider GLOBAL_METADATA_PROVIDER = new GlobalMetadataProvider();
+
+	public static MetadataProvider of( final MetadataProvider localMetadataProvider ) {
+		return MultiMetadataProvider.of( GLOBAL_METADATA_PROVIDER, localMetadataProvider );
+	}
+}

--- a/src/main/java/de/retest/recheck/meta/MultiMetadataProvider.java
+++ b/src/main/java/de/retest/recheck/meta/MultiMetadataProvider.java
@@ -1,0 +1,37 @@
+package de.retest.recheck.meta;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Combines multiple {@link MetadataProvider} together into a single metadata. This may be used to combine multiple
+ * smaller, specified providers together or simply collect a list of unrelated providers.
+ */
+@RequiredArgsConstructor( access = AccessLevel.PRIVATE )
+public final class MultiMetadataProvider implements MetadataProvider {
+
+	private final List<MetadataProvider> providers;
+
+	public static MetadataProvider of( final MetadataProvider... providers ) {
+		return of( Arrays.asList( providers ) );
+	}
+
+	public static MetadataProvider of( final List<MetadataProvider> providers ) {
+		return new MultiMetadataProvider( providers );
+	}
+
+	@Override
+	public Map<String, String> retrieve() {
+		return providers.stream() //
+				.map( MetadataProvider::retrieve ) //
+				.map( Map::entrySet ) //
+				.flatMap( Set::stream ) //
+				.collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+	}
+}

--- a/src/main/java/de/retest/recheck/persistence/RecheckSutState.java
+++ b/src/main/java/de/retest/recheck/persistence/RecheckSutState.java
@@ -10,7 +10,6 @@ import java.util.Set;
 
 import de.retest.recheck.Properties;
 import de.retest.recheck.RecheckAdapter;
-import de.retest.recheck.meta.MetadataProvider;
 import de.retest.recheck.meta.MetadataProviderService;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
@@ -26,8 +25,7 @@ public class RecheckSutState {
 		if ( converted == null || converted.isEmpty() ) {
 			throw new IllegalStateException( "Cannot check empty state!" );
 		}
-		final MetadataProvider service = MetadataProviderService.of( () -> adapter.retrieveMetadata( toCheck ) );
-		return new SutState( converted, service.retrieve() );
+		return new SutState( converted, MetadataProviderService.of( () -> adapter.retrieveMetadata( toCheck ) ) );
 	}
 
 	public static SutState createNew( final File file, final SutState actual ) {

--- a/src/main/java/de/retest/recheck/persistence/RecheckSutState.java
+++ b/src/main/java/de/retest/recheck/persistence/RecheckSutState.java
@@ -10,6 +10,8 @@ import java.util.Set;
 
 import de.retest.recheck.Properties;
 import de.retest.recheck.RecheckAdapter;
+import de.retest.recheck.meta.MetadataProvider;
+import de.retest.recheck.meta.MetadataProviderService;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
 
@@ -24,7 +26,8 @@ public class RecheckSutState {
 		if ( converted == null || converted.isEmpty() ) {
 			throw new IllegalStateException( "Cannot check empty state!" );
 		}
-		return new SutState( converted, adapter.retrieveMetadata( toCheck ) );
+		final MetadataProvider service = MetadataProviderService.of( () -> adapter.retrieveMetadata( toCheck ) );
+		return new SutState( converted, service.retrieve() );
 	}
 
 	public static SutState createNew( final File file, final SutState actual ) {

--- a/src/main/java/de/retest/recheck/ui/descriptors/SutState.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/SutState.java
@@ -12,6 +12,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import de.retest.recheck.meta.MetadataProvider;
 import de.retest.recheck.persistence.Persistable;
 import de.retest.recheck.ui.review.ActionChangeSet;
 
@@ -37,16 +38,16 @@ public class SutState extends Persistable {
 	}
 
 	public SutState( final Collection<RootElement> set ) {
-		this( set, Collections.emptyMap() );
+		this( set, MetadataProvider.empty() );
 	}
 
-	public SutState( final Collection<RootElement> set, final Map<String, String> metadata ) {
+	public SutState( final Collection<RootElement> set, final MetadataProvider metadata ) {
 		super( PERSISTENCE_VERSION );
 		if ( set == null ) {
 			throw new NullPointerException();
 		}
 		descriptors = new ArrayList<>( set );
-		this.metadata = new HashMap<>( metadata );
+		this.metadata = new HashMap<>( metadata.retrieve() );
 	}
 
 	public List<RootElement> getRootElements() {
@@ -100,6 +101,6 @@ public class SutState extends Persistable {
 		}
 		final Map<String, String> newMetadata = new HashMap<>( metadata );
 		newMetadata.putAll( actionChangeSet.getMetadata() );
-		return new SutState( descriptors, newMetadata );
+		return new SutState( descriptors, () -> newMetadata );
 	}
 }

--- a/src/main/java/de/retest/recheck/ui/descriptors/SutStateFilter.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/SutStateFilter.java
@@ -20,8 +20,7 @@ public class SutStateFilter {
 		final List<RootElement> filteredRootElements = rootElements.stream() //
 				.map( this::filter ) //
 				.collect( Collectors.toList() );
-		final SutState newSutState = new SutState( filteredRootElements, sutState.getMetadata() );
-		return newSutState;
+		return new SutState( filteredRootElements, sutState::getMetadata );
 	}
 
 	public RootElement filter( final RootElement rootElement ) {

--- a/src/test/java/de/retest/recheck/meta/MultiMetadataProviderTest.java
+++ b/src/test/java/de/retest/recheck/meta/MultiMetadataProviderTest.java
@@ -1,0 +1,61 @@
+package de.retest.recheck.meta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+class MultiMetadataProviderTest {
+
+	@Test
+	void retrieve_should_concatenate_data() throws Exception {
+		final MetadataProvider first = mock( MetadataProvider.class );
+		when( first.retrieve() ).thenReturn( Collections.singletonMap( "a", "b" ) );
+
+		final MetadataProvider second = mock( MetadataProvider.class );
+		when( second.retrieve() ).thenReturn( Collections.singletonMap( "b", "c" ) );
+
+		final MetadataProvider cut = MultiMetadataProvider.of( first, second );
+
+		assertThat( cut.retrieve() ) //
+				.hasSize( 2 ) //
+				.contains( Pair.of( "a", "b" ) ) //
+				.contains( Pair.of( "b", "c" ) );
+	}
+
+	@Test
+	void retrieve_should_not_allow_for_null_values() throws Exception {
+		final MetadataProvider first = mock( MetadataProvider.class );
+		when( first.retrieve() ).thenReturn( Collections.singletonMap( "a", null ) );
+
+		final MetadataProvider cut = MultiMetadataProvider.of( first );
+
+		assertThatThrownBy( cut::retrieve ) //
+				.isInstanceOf( NullPointerException.class );
+	}
+
+	@Test
+	void retrieve_should_throw_duplicate_key() throws Exception {
+		final MetadataProvider first = mock( MetadataProvider.class );
+		when( first.retrieve() ).thenReturn( Collections.singletonMap( "a", "b" ) );
+
+		final MetadataProvider second = mock( MetadataProvider.class );
+		when( second.retrieve() ).thenReturn( Collections.singletonMap( "a", "c" ) );
+
+		final MetadataProvider firstSecond = MultiMetadataProvider.of( first, second );
+		final MetadataProvider secondFirst = MultiMetadataProvider.of( second, first );
+
+		assertThatThrownBy( firstSecond::retrieve ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessageContaining( "Duplicate key" );
+
+		assertThatThrownBy( secondFirst::retrieve ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessageContaining( "Duplicate key" );
+	}
+}

--- a/src/test/java/de/retest/recheck/ui/descriptors/SutStateFilterTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/SutStateFilterTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.meta.MetadataProvider;
 import de.retest.recheck.review.ignore.AttributeFilter;
 import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.image.Screenshot;
@@ -291,7 +292,7 @@ class SutStateFilterTest {
 	}
 
 	private SutState createSutState( final Collection<RootElement> rootElements ) {
-		return new SutState( rootElements, Collections.emptyMap() );
+		return new SutState( rootElements, MetadataProvider.empty() );
 	}
 
 	private static class Component {}

--- a/src/test/java/de/retest/recheck/ui/descriptors/SutStateTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/SutStateTest.java
@@ -16,7 +16,7 @@ class SutStateTest {
 		final HashMap<String, String> oldMetadata = new HashMap<>();
 		oldMetadata.put( "unchanged", "oldValue" );
 		oldMetadata.put( "updated", "oldValue" );
-		final SutState old = new SutState( Collections.emptyList(), oldMetadata );
+		final SutState old = new SutState( Collections.emptyList(), () -> oldMetadata );
 
 		final HashMap<String, String> newMetadata = new HashMap<>();
 		newMetadata.put( "updated", "newValue" );


### PR DESCRIPTION
*Before submission, please check that ...*

- [X] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [X] the necessary tests are either created or updated.
- [X] all status checks (Travis CI, SonarCloud, etc.) pass.
- [X] your commit history is cleaned up.
- [X] ~you updated the changelog.~
- [X] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Lay the ground work for global metadata to be added into a `SutState`.

This PR prepares the combination of global (independent) metadata and the local metadata for a check. While combining, it adheres to the given specification of the `MetadataProvider` which mostly is related to the specification of `Collectors.toMap`. More specifically, this includes:

* Key collisions are not handled. Instead a exception is thrown. This is to inform the implementation that they may overwrite an already existing key.
* `null` values are not allowed.

The global metadata will be handled through a list instead as suggested through a `ServiceProvider`. This ensures a simple implementation and that we remain in control for now, on which metadata is added to the Golden Master. However, through the usage of factory methods and delegation, it should be fairly easy if not trivial to replace any implementation specifics.