### PR TITLE
Feature/let metadata overwrite others

### DIFF
--- a/src/main/java/de/retest/recheck/meta/MetadataProvider.java
+++ b/src/main/java/de/retest/recheck/meta/MetadataProvider.java
@@ -23,9 +23,6 @@ import java.util.Map;
  * <li><b>No {@code null} values are allowed.</b> Keys that map to non existent values (i.e. {@code null} should not be
  * added as this may be used as indicator for a missing key. Instead an other representation (e.g. {@code ""}) should be
  * used.</li>
- * <li><b>No duplicate keys are allowed.</b> A provider is not permitted to overwrite or alter any metadata of another
- * provider. Precautions should be taken to avoid (unintended) duplicate keys, such as a namespace for each
- * provider.</li>
  * <li><b>Only simple values shall be used.</b> While theoretically any arbitrary data may be provided, it should be
  * taken care, that each datum is as simple as possible. It should therefore be avoided to parse complex data from a
  * single datum. Instead, multiple correlated keys shall be used and then constructed as necessary by retrieving the

--- a/src/main/java/de/retest/recheck/meta/MetadataProviderService.java
+++ b/src/main/java/de/retest/recheck/meta/MetadataProviderService.java
@@ -1,13 +1,26 @@
 package de.retest.recheck.meta;
 
+import java.util.Map;
+
 /**
  * Combines the {@link GlobalMetadataProvider} and an arbitrary local metadata provider.
  */
-public final class MetadataProviderService {
+public final class MetadataProviderService implements MetadataProvider {
 
 	private static final MetadataProvider GLOBAL_METADATA_PROVIDER = new GlobalMetadataProvider();
 
+	private final MetadataProvider provider;
+
+	MetadataProviderService( final MetadataProvider global, final MetadataProvider local ) {
+		provider = MultiMetadataProvider.of( global, local );
+	}
+
 	public static MetadataProvider of( final MetadataProvider localMetadataProvider ) {
-		return MultiMetadataProvider.of( GLOBAL_METADATA_PROVIDER, localMetadataProvider );
+		return new MetadataProviderService( GLOBAL_METADATA_PROVIDER, localMetadataProvider );
+	}
+
+	@Override
+	public Map<String, String> retrieve() {
+		return provider.retrieve();
 	}
 }

--- a/src/main/java/de/retest/recheck/meta/MetadataProviderService.java
+++ b/src/main/java/de/retest/recheck/meta/MetadataProviderService.java
@@ -3,7 +3,12 @@ package de.retest.recheck.meta;
 import java.util.Map;
 
 /**
+ * <p>
  * Combines the {@link GlobalMetadataProvider} and an arbitrary local metadata provider.
+ * 
+ * <p>
+ * This allows for duplicate keys by preferring the local metadata over the global. That means that the local provider
+ * is capable of overwriting metadata from the global provider.
  */
 public final class MetadataProviderService implements MetadataProvider {
 
@@ -15,6 +20,14 @@ public final class MetadataProviderService implements MetadataProvider {
 		provider = MultiMetadataProvider.of( global, local );
 	}
 
+	/**
+	 * Constructs a merging provider, using the {@link GlobalMetadataProvider} and the provided local provider. The
+	 * local provider is able to overwrite keys from the global provider.
+	 * 
+	 * @param localMetadataProvider
+	 *            The local provider.
+	 * @return The merging provider.
+	 */
 	public static MetadataProvider of( final MetadataProvider localMetadataProvider ) {
 		return new MetadataProviderService( GLOBAL_METADATA_PROVIDER, localMetadataProvider );
 	}

--- a/src/main/java/de/retest/recheck/meta/MultiMetadataProvider.java
+++ b/src/main/java/de/retest/recheck/meta/MultiMetadataProvider.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 /**
  * Combines multiple {@link MetadataProvider} together into a single metadata. This may be used to combine multiple
  * smaller, specified providers together or simply collect a list of unrelated providers.
+ * 
+ * Key collisions will be resolved with the last value encountered.
  */
 @RequiredArgsConstructor( access = AccessLevel.PRIVATE )
 public final class MultiMetadataProvider implements MetadataProvider {
@@ -32,6 +34,6 @@ public final class MultiMetadataProvider implements MetadataProvider {
 				.map( MetadataProvider::retrieve ) //
 				.map( Map::entrySet ) //
 				.flatMap( Set::stream ) //
-				.collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+				.collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue, ( left, right ) -> right ) );
 	}
 }

--- a/src/test/java/de/retest/recheck/meta/MetadataProviderServiceTest.java
+++ b/src/test/java/de/retest/recheck/meta/MetadataProviderServiceTest.java
@@ -1,0 +1,28 @@
+package de.retest.recheck.meta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+class MetadataProviderServiceTest {
+
+	@Test
+	void retrieve_should_allow_for_duplicate_keys_and_should_always_prefer_local_over_global() throws Exception {
+		final MetadataProvider global = mock( MetadataProvider.class );
+		when( global.retrieve() ).thenReturn( Collections.singletonMap( "a", "b" ) );
+
+		final MetadataProvider local = mock( MetadataProvider.class );
+		when( local.retrieve() ).thenReturn( Collections.singletonMap( "a", "c" ) );
+
+		final MetadataProviderService cut = new MetadataProviderService( global, local );
+
+		assertThat( cut.retrieve() ) //
+				.hasSize( 1 ) //
+				.contains( Pair.of( "a", "c" ) );
+	}
+}

--- a/src/test/java/de/retest/recheck/meta/MultiMetadataProviderTest.java
+++ b/src/test/java/de/retest/recheck/meta/MultiMetadataProviderTest.java
@@ -40,7 +40,7 @@ class MultiMetadataProviderTest {
 	}
 
 	@Test
-	void retrieve_should_throw_duplicate_key() throws Exception {
+	void retrieve_should_take_last_value_encountered() throws Exception {
 		final MetadataProvider first = mock( MetadataProvider.class );
 		when( first.retrieve() ).thenReturn( Collections.singletonMap( "a", "b" ) );
 
@@ -50,12 +50,12 @@ class MultiMetadataProviderTest {
 		final MetadataProvider firstSecond = MultiMetadataProvider.of( first, second );
 		final MetadataProvider secondFirst = MultiMetadataProvider.of( second, first );
 
-		assertThatThrownBy( firstSecond::retrieve ) //
-				.isInstanceOf( IllegalStateException.class ) //
-				.hasMessageContaining( "Duplicate key" );
+		assertThat( firstSecond.retrieve() ) //
+				.hasSize( 1 ) //
+				.contains( Pair.of( "a", "c" ) );
 
-		assertThatThrownBy( secondFirst::retrieve ) //
-				.isInstanceOf( IllegalStateException.class ) //
-				.hasMessageContaining( "Duplicate key" );
+		assertThat( secondFirst.retrieve() ) //
+				.hasSize( 1 ) //
+				.contains( Pair.of( "a", "b" ) );
 	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Allow merges for `MetadataProvider`. This is only enabled for the `MetadataProviderService` as this allows for the global and local metadata.

Per documentation the `MetadataProvider` is now allowed to allow for duplicate keys by providing a respective merge strategy. This is implemented by the `MultiMetadataProvider` to allow for such a merge strategy to be used. However, the default behavior is still to disallow the merging and throw an exception. That is so that the decision must be willingly taken to allow merges as it conforms to the `Collectors#toMap` functions.

This is further implemented:
1. `GlobalMetadataProvider` should disallow duplicate keys in order to keep the global metadata providers to cancel each other out.
2. `MetadataProviderService` allows duplicate keys by explicitly allowing the local metadata to take priority.