### PR TITLE
Feature/ret 1902 print metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Table of Contents
     * Machine name (if available).
     * Date and time.
     * Git branch and commit.
+* Display specific metadata will after test execution when printing the differences. This includes the following:
+    * Operating system name and version.
 
 ### Improvements
 

--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -1,5 +1,6 @@
 package de.retest.recheck.printer;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -15,10 +16,17 @@ import de.retest.recheck.ui.diff.meta.MetadataDifference;
 public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 
 	private final ElementDifferencePrinter printer;
-	private final MetadataDifferencePrinter metadataDifferencePrinter = new MetadataDifferencePrinter();
+	private final MetadataDifferencePrinter metadataDifferencePrinter;
 
 	public ActionReplayResultPrinter( final DefaultValueFinder defaultValueFinder ) {
 		printer = new ElementDifferencePrinter( defaultValueFinder );
+		metadataDifferencePrinter = new MetadataDifferencePrinter();
+	}
+
+	public ActionReplayResultPrinter( final DefaultValueFinder defaultValueFinder,
+			final Set<String> metadataDifferencesToPrint ) {
+		printer = new ElementDifferencePrinter( defaultValueFinder );
+		metadataDifferencePrinter = new MetadataDifferencePrinter( metadataDifferencesToPrint );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
@@ -1,13 +1,23 @@
 package de.retest.recheck.printer;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import de.retest.recheck.meta.global.OSMetadataProvider;
 import de.retest.recheck.ui.diff.meta.MetadataDifference;
 import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
 
 public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 
 	private static final String KEY_EXPECTED_ACTUAL_FORMAT = "%s: expected=\"%s\", actual=\"%s\"";
+
+	// Only print a selected amount of differences that potentially can break a test
+	private static final Set<String> DIFFERENCES_TO_PRINT = new HashSet<>( Arrays.asList( //
+			OSMetadataProvider.OS_NAME, //
+			OSMetadataProvider.OS_VERSION //
+	) );
 
 	@Override
 	public String toString( final MetadataDifference difference, final String indent ) {
@@ -17,11 +27,16 @@ public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 
 	private String printDifferences( final MetadataDifference difference, final String indent ) {
 		return difference.getDifferences().stream() //
+				.filter( this::shouldPrint ) //
 				.map( this::print ) //
 				.collect( Collectors.joining( "\n" + indent, "\n" + indent, "" ) );
 	}
 
-	private <R> String print( final MetadataElementDifference difference ) {
+	private boolean shouldPrint( final MetadataElementDifference difference ) {
+		return DIFFERENCES_TO_PRINT.contains( difference.getKey() );
+	}
+
+	private String print( final MetadataElementDifference difference ) {
 		return String.format( KEY_EXPECTED_ACTUAL_FORMAT, difference.getKey(), difference.getExpected(),
 				difference.getActual() );
 	}

--- a/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
@@ -1,0 +1,28 @@
+package de.retest.recheck.printer;
+
+import java.util.stream.Collectors;
+
+import de.retest.recheck.ui.diff.meta.MetadataDifference;
+import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
+
+public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
+
+	private static final String KEY_EXPECTED_ACTUAL_FORMAT = "%s: expected=\"%s\", actual=\"%s\"";
+
+	@Override
+	public String toString( final MetadataDifference difference, final String indent ) {
+		final String prefix = "Metadata Differences:";
+		return indent + prefix + printDifferences( difference, indent + "\t" );
+	}
+
+	private String printDifferences( final MetadataDifference difference, final String indent ) {
+		return difference.getDifferences().stream() //
+				.map( this::print ) //
+				.collect( Collectors.joining( "\n" + indent, "\n" + indent, "" ) );
+	}
+
+	private <R> String print( final MetadataElementDifference difference ) {
+		return String.format( KEY_EXPECTED_ACTUAL_FORMAT, difference.getKey(), difference.getExpected(),
+				difference.getActual() );
+	}
+}

--- a/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
@@ -8,7 +8,9 @@ import java.util.stream.Collectors;
 import de.retest.recheck.meta.global.OSMetadataProvider;
 import de.retest.recheck.ui.diff.meta.MetadataDifference;
 import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 
 	private static final String KEY_EXPECTED_ACTUAL_FORMAT = "%s: expected=\"%s\", actual=\"%s\"";
@@ -18,6 +20,12 @@ public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 			OSMetadataProvider.OS_NAME, //
 			OSMetadataProvider.OS_VERSION //
 	) );
+
+	private final Set<String> filter;
+
+	public MetadataDifferencePrinter() {
+		this( DIFFERENCES_TO_PRINT );
+	}
 
 	@Override
 	public String toString( final MetadataDifference difference, final String indent ) {
@@ -33,7 +41,7 @@ public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 	}
 
 	private boolean shouldPrint( final MetadataElementDifference difference ) {
-		return DIFFERENCES_TO_PRINT.contains( difference.getKey() );
+		return filter.isEmpty() || DIFFERENCES_TO_PRINT.contains( difference.getKey() );
 	}
 
 	private String print( final MetadataElementDifference difference ) {

--- a/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/TestReplayResultPrinter.java
@@ -32,7 +32,9 @@ public class TestReplayResultPrinter implements Printer<TestReplayResult> {
 	}
 
 	private boolean shouldPrint( final ActionReplayResult actionReplayResult ) {
-		return actionReplayResult.hasDifferences() || actionReplayResult.hasError();
+		return actionReplayResult.hasDifferences() //
+				|| !actionReplayResult.getMetadataDifference().isEmpty() //
+				|| actionReplayResult.hasError();
 	}
 
 	private String formatAction( final ActionReplayResult result, final String indent ) {

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -129,6 +129,44 @@ class ActionReplayResultPrinterTest {
 	}
 
 	@Test
+	void toString_should_print_meta_before_state_differences() throws Exception {
+		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
+		when( identifyingAttributes.toString() ).thenReturn( "Identifying" );
+		when( identifyingAttributes.getPath() ).thenReturn( "path/to/element" );
+
+		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
+		when( attributeDifference.getKey() ).thenReturn( "key" );
+		when( attributeDifference.getActual() ).thenReturn( "actual" );
+		when( attributeDifference.getExpected() ).thenReturn( "expected" );
+
+		final ElementDifference rootDifference = mock( ElementDifference.class );
+		when( rootDifference.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
+		when( rootDifference.hasAnyDifference() ).thenReturn( true );
+		when( rootDifference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
+
+		final RootElementDifference root = mock( RootElementDifference.class );
+		when( root.getElementDifference() ).thenReturn( rootDifference );
+
+		final StateDifference stateDifference = mock( StateDifference.class );
+		when( stateDifference.getRootElementDifferences() ).thenReturn( Collections.singletonList( root ) );
+
+		final MetadataDifference metadataDifference =
+				MetadataDifference.of( new HashSet<>( Arrays.asList( new MetadataElementDifference( "a", "b", "c" ), //
+						new MetadataElementDifference( "b", "c", "d" ) //
+				) ) );
+
+		final ActionReplayResult actionResult = mock( ActionReplayResult.class );
+		when( actionResult.getDescription() ).thenReturn( "foo" );
+		when( actionResult.getStateDifference() ).thenReturn( stateDifference );
+		when( actionResult.hasDifferences() ).thenReturn( true );
+		when( actionResult.getMetadataDifference() ).thenReturn( metadataDifference );
+
+		assertThat( cut.toString( actionResult ) ).isEqualTo( "foo resulted in:\n" + "\tMetadata Differences:\n"
+				+ "\t\ta: expected=\"b\", actual=\"c\"\n" + "\t\tb: expected=\"c\", actual=\"d\"\n"
+				+ "\tIdentifying at 'path/to/element':\n" + "\t\tkey: expected=\"expected\", actual=\"actual\"" );
+	}
+
+	@Test
 	void toString_should_respect_indent() {
 		final ActionReplayResult result = mock( ActionReplayResult.class );
 		when( result.getStateDifference() ).thenReturn( mock( StateDifference.class ) );

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -71,17 +71,20 @@ class ActionReplayResultPrinterTest {
 	}
 
 	@Test
-	void toString_with_no_exception_should_print_differences() {
-		final IdentifyingAttributes mock = mock( IdentifyingAttributes.class );
-		when( mock.toString() ).thenReturn( "Identifying" );
-		when( mock.getPath() ).thenReturn( "path/to/element" );
+	void toString_should_print_state_differences_if_no_meta_differences() {
+		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
+		when( identifyingAttributes.toString() ).thenReturn( "Identifying" );
+		when( identifyingAttributes.getPath() ).thenReturn( "path/to/element" );
 
-		final ElementDifference childDifference = mock( ElementDifference.class );
-		when( childDifference.getIdentifyingAttributes() ).thenReturn( mock );
+		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
+		when( attributeDifference.getKey() ).thenReturn( "key" );
+		when( attributeDifference.getActual() ).thenReturn( "actual" );
+		when( attributeDifference.getExpected() ).thenReturn( "expected" );
 
 		final ElementDifference rootDifference = mock( ElementDifference.class );
-		when( rootDifference.getElementDifferences() ).thenReturn( Collections.singletonList( childDifference ) );
-		when( rootDifference.getIdentifyingAttributes() ).thenReturn( mock );
+		when( rootDifference.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
+		when( rootDifference.hasAnyDifference() ).thenReturn( true );
+		when( rootDifference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
 
 		final RootElementDifference root = mock( RootElementDifference.class );
 		when( root.getElementDifference() ).thenReturn( rootDifference );

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -41,7 +41,8 @@ class ActionReplayResultPrinterTest {
 
 	@BeforeEach
 	void setUp() {
-		cut = new ActionReplayResultPrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false );
+		cut = new ActionReplayResultPrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false,
+				Collections.emptySet() );
 	}
 
 	@Test
@@ -161,9 +162,12 @@ class ActionReplayResultPrinterTest {
 		when( actionResult.hasDifferences() ).thenReturn( true );
 		when( actionResult.getMetadataDifference() ).thenReturn( metadataDifference );
 
-		assertThat( cut.toString( actionResult ) ).isEqualTo( "foo resulted in:\n" + "\tMetadata Differences:\n"
-				+ "\t\ta: expected=\"b\", actual=\"c\"\n" + "\t\tb: expected=\"c\", actual=\"d\"\n"
-				+ "\tIdentifying at 'path/to/element':\n" + "\t\tkey: expected=\"expected\", actual=\"actual\"" );
+		assertThat( cut.toString( actionResult ) ).isEqualTo( "foo resulted in:\n" // 
+				+ "\tMetadata Differences:\n" //
+				+ "\t\ta: expected=\"b\", actual=\"c\"\n" // 
+				+ "\t\tb: expected=\"c\", actual=\"d\"\n" //
+				+ "\tIdentifying at 'path/to/element':\n" // 
+				+ "\t\tkey: expected=\"expected\", actual=\"actual\"" );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -30,6 +30,7 @@ import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
 import de.retest.recheck.ui.diff.RootElementDifference;
 import de.retest.recheck.ui.diff.StateDifference;
+import de.retest.recheck.ui.diff.meta.MetadataDifference;
 import de.retest.recheck.util.ApprovalsUtil;
 
 class ActionReplayResultPrinterTest {
@@ -91,6 +92,7 @@ class ActionReplayResultPrinterTest {
 		final ActionReplayResult result = mock( ActionReplayResult.class );
 		when( result.getDescription() ).thenReturn( "foo" );
 		when( result.getStateDifference() ).thenReturn( stateDifference );
+		when( result.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final String string = cut.toString( result );
 
@@ -101,6 +103,7 @@ class ActionReplayResultPrinterTest {
 	void toString_should_respect_indent() {
 		final ActionReplayResult result = mock( ActionReplayResult.class );
 		when( result.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		when( result.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final String string = cut.toString( result, "____" );
 

--- a/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
@@ -1,6 +1,7 @@
 package de.retest.recheck.printer;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 import org.assertj.core.api.Assertions;
@@ -18,7 +19,7 @@ class MetadataDifferencePrinterTest {
 				new MetadataElementDifference( "b", "c", "d" ) //
 		) ) );
 
-		final MetadataDifferencePrinter cut = new MetadataDifferencePrinter();
+		final MetadataDifferencePrinter cut = new MetadataDifferencePrinter( Collections.emptySet() );
 
 		Assertions.assertThat( cut.toString( differences, "____" ) ).isEqualTo( "____Metadata Differences:\n" //
 				+ "____\ta: expected=\"b\", actual=\"c\"\n" //

--- a/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
@@ -1,0 +1,27 @@
+package de.retest.recheck.printer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.diff.meta.MetadataDifference;
+import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
+
+class MetadataDifferencePrinterTest {
+
+	@Test
+	void toString_should_properly_format_differences() throws Exception {
+		final MetadataDifference differences = MetadataDifference.of( new HashSet<>( Arrays.asList( //
+				new MetadataElementDifference( "a", "b", "c" ), //
+				new MetadataElementDifference( "b", "c", "d" ) //
+		) ) );
+
+		final MetadataDifferencePrinter cut = new MetadataDifferencePrinter();
+
+		Assertions.assertThat( cut.toString( differences, "____" ) ).isEqualTo( "____Metadata Differences:\n" //
+				+ "____\ta: expected=\"b\", actual=\"c\"\n" //
+				+ "____\tb: expected=\"c\", actual=\"d\"" );
+	}
+}

--- a/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/SuiteReplayResultPrinterTest.java
@@ -13,6 +13,7 @@ import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
 import de.retest.recheck.ui.descriptors.GroundState;
 import de.retest.recheck.ui.diff.StateDifference;
+import de.retest.recheck.ui.diff.meta.MetadataDifference;
 
 class SuiteReplayResultPrinterTest {
 
@@ -47,6 +48,7 @@ class SuiteReplayResultPrinterTest {
 		final ActionReplayResult actionResult = mock( ActionReplayResult.class );
 		when( actionResult.hasDifferences() ).thenReturn( true );
 		when( actionResult.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		when( actionResult.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final TestReplayResult testResult = mock( TestReplayResult.class );
 		when( testResult.isEmpty() ).thenReturn( false );

--- a/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/TestReplayResultPrinterTest.java
@@ -20,6 +20,7 @@ import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.recheck.ui.diff.LeafDifference;
 import de.retest.recheck.ui.diff.StateDifference;
+import de.retest.recheck.ui.diff.meta.MetadataDifference;
 
 class TestReplayResultPrinterTest {
 
@@ -54,13 +55,14 @@ class TestReplayResultPrinterTest {
 
 	@Test
 	void toString_should_print_difference() {
-		final ActionReplayResult a1 = mock( ActionReplayResult.class );
-		when( a1.getDescription() ).thenReturn( "foo" );
-		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		final ActionReplayResult actionReplayResult = mock( ActionReplayResult.class );
+		when( actionReplayResult.getDescription() ).thenReturn( "foo" );
+		when( actionReplayResult.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		when( actionReplayResult.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferencesCount() ).thenReturn( 1 );
-		when( result.getActionReplayResults() ).thenReturn( singletonList( a1 ) );
+		when( result.getActionReplayResults() ).thenReturn( singletonList( actionReplayResult ) );
 		when( result.getDifferences() ).thenReturn( singleton( mock( LeafDifference.class ) ) );
 
 		final String string = cut.toString( result );
@@ -70,13 +72,14 @@ class TestReplayResultPrinterTest {
 
 	@Test
 	void toString_should_print_difference_with_indent() {
-		final ActionReplayResult a1 = mock( ActionReplayResult.class );
-		when( a1.getDescription() ).thenReturn( "foo" );
-		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		final ActionReplayResult actionReplayResult = mock( ActionReplayResult.class );
+		when( actionReplayResult.getDescription() ).thenReturn( "foo" );
+		when( actionReplayResult.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		when( actionReplayResult.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferences() ).thenReturn( singleton( mock( LeafDifference.class ) ) );
-		when( result.getActionReplayResults() ).thenReturn( Collections.singletonList( a1 ) );
+		when( result.getActionReplayResults() ).thenReturn( Collections.singletonList( actionReplayResult ) );
 
 		final String string = cut.toString( result, "____" );
 
@@ -88,9 +91,12 @@ class TestReplayResultPrinterTest {
 		final ActionReplayResult a1 = mock( ActionReplayResult.class );
 		when( a1.getDescription() ).thenReturn( "foo" );
 		when( a1.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		when( a1.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
+
 		final ActionReplayResult a2 = mock( ActionReplayResult.class );
 		when( a2.getDescription() ).thenReturn( "bar" );
 		when( a2.getStateDifference() ).thenReturn( mock( StateDifference.class ) );
+		when( a2.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final TestReplayResult result = mock( TestReplayResult.class );
 		when( result.getDifferences() ).thenReturn( singleton( mock( LeafDifference.class ) ) );
@@ -105,6 +111,7 @@ class TestReplayResultPrinterTest {
 	void toString_should_not_print_if_no_differences() {
 		final ActionReplayResult emptyActionResult = mock( ActionReplayResult.class );
 		when( emptyActionResult.hasDifferences() ).thenReturn( false );
+		when( emptyActionResult.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 
 		final TestReplayResult testResult = mock( TestReplayResult.class );
 		when( testResult.getActionReplayResults() ).thenReturn( Collections.singletonList( emptyActionResult ) );

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
@@ -3,6 +3,9 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
 Test 'no-filter' has 9 difference(s) in 1 state(s):
 check resulted in:
+	Metadata Differences:
+		os.name: expected="Linux", actual="null"
+		os.version: expected="4.4.0-101-generic", actual="null"
 	test [test] at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
@@ -3,6 +3,9 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
 Test 'filter' has 4 difference(s) in 1 state(s):
 check resulted in:
+	Metadata Differences:
+		os.name: expected="Linux", actual="null"
+		os.version: expected="4.4.0-101-generic", actual="null"
 	test [test] at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
@@ -3,6 +3,9 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT legacy spaces' found the following difference(s):
 Test 'with legacy spaces' has 9 difference(s) in 1 state(s):
 check resulted in:
+	Metadata Differences:
+		os.name: expected="Linux", actual="null"
+		os.version: expected="4.4.0-101-generic", actual="null"
 	test [test] at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
@@ -3,6 +3,9 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT spaces' found the following difference(s):
 Test 'with spaces' has 9 difference(s) in 1 state(s):
 check resulted in:
+	Metadata Differences:
+		os.name: expected="Linux", actual="null"
+		os.version: expected="4.4.0-101-generic", actual="null"
 	test [test] at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This will print the metadata differences captured within a report.

This PR is loosely follows the already existing attribute difference printer. However, as with #545 we do not need the complexity involved, looking for default differences.

As seen in the test, this will produce something similar to:
```
Metadata Differences:
	os.name: expected="Linux", actual="null"
	os.version: expected="4.4.0-101-generic", actual="null"
```

Following cases have been looked at:

| State Differences | Metadata Differences | Notes                                                                             |
| ----------------- | -------------------- | --------------------------------------------------------------------------------- |
| empty             | empty                | Do not display metadata.                                                          |
| empty             | present              | Display only metadata, that means the check will be displayed with 0 differences. |
| present           | empty                | Do not display metadata.                                                          |
| present           | present              | Display metadata before state differences.                                        |

### State of this PR

Since we have approval tests that do such a complete recheck test, we need to make these tests reproducible. Because the metadata changes every time, and for a test report are not that interesting, @beatngu13 and I decided to just limit this to a fixed whitelist that, in our opinion, may really have an impact on the test execution. We chose this approach to limit the complexity for now. Properties specified by recheck-web will be included here too. Additional PRs may look at integration in `RecheckOptions` or recheck.cli flags to hide or verbosely print the metadata differences.

As this then destroyed the initial tests, a test may then define a empty filter, such that all differences will be printed.

### Things to discuss

How to handle differences, where anything but the specified differences occur. This is due to the filter being defined in the `MetadataDifferencePrinter`, which is not available inside the `ActionReplayResultPrinter`. I would advice against filtering within the MetadataDifference to keep the dependencies low.

This for example may happen when executing a test on the same system at different times. The metadata differences will not be empty (since the time has changed), but printing it will result in a empty list (since only the os is relevant):
```
Test 'with spaces' has 9 difference(s) in 1 state(s):
check resulted in:
	Metadata Differences:

	test [test] at 'foo[1]/bar[1]':
		foo-1: expected="bar-1", actual="bar-3"
```

#### Solutions

1. Display a fallback message, e.g. `"No visible differences."`. This would be the easiest solution, but goes against the standard that states: If there are no differences, do not print the tree.
2. Check with with filtering if the metadata is empty. This would require the filter to be available above (i.e. `ActionReplayResultPrinter`) or would require filtering logic inside `MetadataDifferences` which we tried to avoid.
3. Do the filtering in `TestReportFilter` which will reduce the differences to the visible. That would be the place to filter. But with a hard coded filter, it might produce unexpected results on other ends. I would suggest this method only, if we plan to provide a filter syntax for these anyways.