### PR TITLE
Feature/make printer ignore instead of allow

### DIFF
--- a/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ActionReplayResultPrinter.java
@@ -1,6 +1,5 @@
 package de.retest.recheck.printer;
 
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,12 +20,6 @@ public class ActionReplayResultPrinter implements Printer<ActionReplayResult> {
 	public ActionReplayResultPrinter( final DefaultValueFinder defaultValueFinder ) {
 		printer = new ElementDifferencePrinter( defaultValueFinder );
 		metadataDifferencePrinter = new MetadataDifferencePrinter();
-	}
-
-	public ActionReplayResultPrinter( final DefaultValueFinder defaultValueFinder,
-			final Set<String> metadataDifferencesToPrint ) {
-		printer = new ElementDifferencePrinter( defaultValueFinder );
-		metadataDifferencePrinter = new MetadataDifferencePrinter( metadataDifferencesToPrint );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
@@ -29,12 +29,6 @@ public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 			TimeMetadataProvider.OFFSET //
 	) );
 
-	private final Set<String> filter;
-
-	public MetadataDifferencePrinter() {
-		this( DIFFERENCES_TO_PRINT );
-	}
-
 	@Override
 	public String toString( final MetadataDifference difference, final String indent ) {
 		final String prefix = "Metadata Differences:";

--- a/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
@@ -5,7 +5,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import de.retest.recheck.meta.global.GitMetadataProvider;
 import de.retest.recheck.meta.global.OSMetadataProvider;
+import de.retest.recheck.meta.global.TimeMetadataProvider;
 import de.retest.recheck.ui.diff.meta.MetadataDifference;
 import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
 import lombok.RequiredArgsConstructor;
@@ -16,9 +18,15 @@ public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 	private static final String KEY_EXPECTED_ACTUAL_FORMAT = "%s: expected=\"%s\", actual=\"%s\"";
 
 	// Only print a selected amount of differences that potentially can break a test
-	private static final Set<String> DIFFERENCES_TO_PRINT = new HashSet<>( Arrays.asList( //
-			OSMetadataProvider.OS_NAME, //
-			OSMetadataProvider.OS_VERSION //
+	private static final Set<String> DIFFERENCES_TO_IGNORE = new HashSet<>( Arrays.asList( //
+			GitMetadataProvider.VCS_NAME, //
+			GitMetadataProvider.BRANCH_NAME, //
+			GitMetadataProvider.COMMIT_NAME, //
+			OSMetadataProvider.OS_ARCH, //
+			TimeMetadataProvider.DATE, //
+			TimeMetadataProvider.TIME, //
+			TimeMetadataProvider.ZONE, //
+			TimeMetadataProvider.OFFSET //
 	) );
 
 	private final Set<String> filter;
@@ -41,7 +49,7 @@ public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 	}
 
 	private boolean shouldPrint( final MetadataElementDifference difference ) {
-		return filter.isEmpty() || DIFFERENCES_TO_PRINT.contains( difference.getKey() );
+		return !DIFFERENCES_TO_IGNORE.contains( difference.getKey() );
 	}
 
 	private String print( final MetadataElementDifference difference ) {

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -41,8 +41,7 @@ class ActionReplayResultPrinterTest {
 
 	@BeforeEach
 	void setUp() {
-		cut = new ActionReplayResultPrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false,
-				Collections.emptySet() );
+		cut = new ActionReplayResultPrinter( ( identifyingAttributes, attributeKey, attributeValue ) -> false );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
@@ -1,7 +1,6 @@
 package de.retest.recheck.printer;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 
 import org.assertj.core.api.Assertions;
@@ -19,7 +18,7 @@ class MetadataDifferencePrinterTest {
 				new MetadataElementDifference( "b", "c", "d" ) //
 		) ) );
 
-		final MetadataDifferencePrinter cut = new MetadataDifferencePrinter( Collections.emptySet() );
+		final MetadataDifferencePrinter cut = new MetadataDifferencePrinter();
 
 		Assertions.assertThat( cut.toString( differences, "____" ) ).isEqualTo( "____Metadata Differences:\n" //
 				+ "____\ta: expected=\"b\", actual=\"c\"\n" //


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Invert the filter from `MetadataDifferencePrinter` to ignore instead of allow.

As retest/recheck-web#450 introduces new metadata, the filter list of the `MetadataDifferencePrinter` would have needed an update. However, since I assume that almost every metadata is noteworthy to be printed, I propose that it is easier to invert this list to ignore instead of allow the keys.

This improves the following steps:

1. We promote capturing everything and then ignoring. This is an extension of said mechanism: We want to ignore the ever changing attributes.
2. This avoids recheck-web metadata keys within recheck (although that would be nothing new).
3. It removes constructors that has been only introduced due to tests.