### PR TITLE
Feature/ret 1916 add test resource root to report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Table of Contents
 
 ### Breaking Changes
 
+* Reports before version 1.9.0 cannot be loaded anymore. Simply re-run your tests with the new recheck version to create them again.
+
 ### Bug Fixes
 
 * The project root is not searched for multiple times on startup of recheck.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Table of Contents
 
 ### New Features
 
+* The `ProjectLayout` may now retrieve the test source root for the current project in order to allow for test healing to be applied. This is required for custom `ProjectLayouts` to be implemented, in order for this feature to work. For more information, please refer to the documentation.
+
 ### Improvements
 
 

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -71,7 +71,8 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		Runtime.getRuntime().addShutdownHook( capWarner );
 		this.options = options;
 		suiteName = options.getNamingStrategy().getSuiteName();
-		suite = SuiteAggregator.getInstance().getSuite( suiteName );
+		suite = SuiteAggregator.getInstance().getSuite( suiteName,
+				options.getProjectLayout().getTestSourcesRoot().orElse( null ) );
 
 		if ( isRehubEnabled( options ) ) {
 			try {

--- a/src/main/java/de/retest/recheck/SuiteAggregator.java
+++ b/src/main/java/de/retest/recheck/SuiteAggregator.java
@@ -1,5 +1,6 @@
 package de.retest.recheck;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import de.retest.recheck.report.SuiteReplayResult;
@@ -33,21 +34,25 @@ public class SuiteAggregator {
 	}
 
 	public SuiteReplayResult getSuite( final String suiteName ) {
+		return getSuite( suiteName, null );
+	}
+
+	public SuiteReplayResult getSuite( final String suiteName, final Path testSourceRoot ) {
 		if ( currentSuite == null ) {
-			currentSuite = createSuiteReplayResult( suiteName );
+			currentSuite = createSuiteReplayResult( suiteName, testSourceRoot );
 		}
 		if ( !suiteName.equals( currentSuite.getName() ) ) {
-			currentSuite = createSuiteReplayResult( suiteName );
+			currentSuite = createSuiteReplayResult( suiteName, testSourceRoot );
 		}
 		return currentSuite;
 	}
 
-	private SuiteReplayResult createSuiteReplayResult( final String suiteName ) {
+	private SuiteReplayResult createSuiteReplayResult( final String suiteName, final Path testSourceRoot ) {
 		final GroundState groundState = new GroundState();
 		final ExecutableSuite execSuite = new ExecutableSuite( groundState, 0, new ArrayList<>() );
 		execSuite.setName( suiteName );
 		final SuiteReplayResult suiteReplayResult =
-				new SuiteReplayResult( suiteName, 0, groundState, execSuite.getUuid(), groundState );
+				new SuiteReplayResult( suiteName, testSourceRoot, 0, groundState, execSuite.getUuid(), groundState );
 		aggregatedTestReport.addSuite( suiteReplayResult );
 		return suiteReplayResult;
 	}

--- a/src/main/java/de/retest/recheck/persistence/GradleProjectLayout.java
+++ b/src/main/java/de/retest/recheck/persistence/GradleProjectLayout.java
@@ -6,6 +6,7 @@ import static java.lang.String.format;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Gradle-conform file namer strategy that uses the following paths:
@@ -54,5 +55,10 @@ public class GradleProjectLayout extends SeparatePathsProjectLayout {
 			throw new IllegalArgumentException( "sourceSetName cannot be empty!" );
 		}
 		return sourceSetName;
+	}
+
+	@Override
+	public Optional<Path> getTestSourcesRoot() {
+		return Optional.of( Paths.get( "src/test/java" ) );
 	}
 }

--- a/src/main/java/de/retest/recheck/persistence/MavenProjectLayout.java
+++ b/src/main/java/de/retest/recheck/persistence/MavenProjectLayout.java
@@ -2,7 +2,9 @@ package de.retest.recheck.persistence;
 
 import static de.retest.recheck.RecheckProperties.RECHECK_FOLDER_NAME;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 /**
  * Maven-conform file namer that uses the following paths:
@@ -21,4 +23,8 @@ public class MavenProjectLayout extends SeparatePathsProjectLayout {
 				Paths.get( DEFAULT_RETEST_TESTREPORTS_PATH, RECHECK_FOLDER_NAME ) );
 	}
 
+	@Override
+	public Optional<Path> getTestSourcesRoot() {
+		return Optional.of( Paths.get( "src/test/java" ) );
+	}
 }

--- a/src/main/java/de/retest/recheck/persistence/ProjectLayout.java
+++ b/src/main/java/de/retest/recheck/persistence/ProjectLayout.java
@@ -1,12 +1,35 @@
 package de.retest.recheck.persistence;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Provides file paths for both Golden Masters and test reports. There exist implementations for Maven and Gradle. If
  * these do not fit your need or your layout deviates from standard, you need to implement this class.
  */
 public interface ProjectLayout {
+
+	/**
+	 * Gets the path to the test sources root, relatively to the project root. In general this is the folder where your
+	 * test classes reside.
+	 * 
+	 * <pre>
+	 * ${PROJECT_ROOT}
+	 * +- src/test/java
+	 *    +- com.example.Test.java
+	 * </pre>
+	 * 
+	 * The above example should return <code>Optional.of(Paths.get("src/test/java")</code>.
+	 * 
+	 * @return The relative path to the test classes as {@link Optional} or empty, if test healing is not supported for
+	 *         some reason.
+	 * 
+	 * @implSpec For compatibility, the default method returns {@link Optional#empty()}, indicating that test healing is
+	 *           not possible.
+	 */
+	default Optional<Path> getTestSourcesRoot() {
+		return Optional.empty();
+	}
 
 	/**
 	 * Gets the base-folder of the suite where the tests are stored in. Useful to store additional data, like a

--- a/src/main/java/de/retest/recheck/report/SuiteReplayResult.java
+++ b/src/main/java/de/retest/recheck/report/SuiteReplayResult.java
@@ -98,7 +98,7 @@ public class SuiteReplayResult implements Serializable {
 	}
 
 	public Optional<Path> getTestSourceRoot() {
-		return Optional.of( testSourceRoot ).map( Paths::get );
+		return Optional.ofNullable( testSourceRoot ).map( Paths::get );
 	}
 
 	public long getDuration() {

--- a/src/main/java/de/retest/recheck/report/SuiteReplayResult.java
+++ b/src/main/java/de/retest/recheck/report/SuiteReplayResult.java
@@ -3,9 +3,12 @@ package de.retest.recheck.report;
 import static de.retest.recheck.persistence.xml.util.XmlUtil.clean;
 
 import java.io.Serializable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,12 +22,15 @@ import de.retest.recheck.ui.descriptors.GroundState;
 @XmlAccessorType( XmlAccessType.FIELD )
 public class SuiteReplayResult implements Serializable {
 
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 
 	private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger( SuiteReplayResult.class );
 
 	@XmlAttribute
 	private final String name;
+
+	@XmlAttribute
+	private final String testSourceRoot;
 
 	@XmlAttribute
 	private final String suiteUuid;
@@ -48,6 +54,7 @@ public class SuiteReplayResult implements Serializable {
 	private SuiteReplayResult() {
 		// for JAXB
 		suiteNr = 0;
+		testSourceRoot = null;
 		name = null;
 		execSuiteSutVersion = null;
 		replaySutVersion = null;
@@ -56,7 +63,19 @@ public class SuiteReplayResult implements Serializable {
 
 	public SuiteReplayResult( final String name, final int suiteNr, final GroundState execSuiteSutVersion,
 			final String suiteUuid, final GroundState replaySutVersion ) {
+		this( name, (String) null, suiteNr, execSuiteSutVersion, suiteUuid, replaySutVersion );
+	}
+
+	public SuiteReplayResult( final String name, final Path testSourceRoot, final int suiteNr,
+			final GroundState execSuiteSutVersion, final String suiteUuid, final GroundState replaySutVersion ) {
+		this( name, testSourceRoot != null ? testSourceRoot.toString() : null, suiteNr, execSuiteSutVersion, suiteUuid,
+				replaySutVersion );
+	}
+
+	private SuiteReplayResult( final String name, final String testSourceRoot, final int suiteNr,
+			final GroundState execSuiteSutVersion, final String suiteUuid, final GroundState replaySutVersion ) {
 		this.name = name == null ? "Suite no. " + suiteNr : clean( name );
+		this.testSourceRoot = testSourceRoot;
 		if ( name == null ) {
 			logger.info( "No suite name given, using {}.", this.name );
 		}
@@ -76,6 +95,10 @@ public class SuiteReplayResult implements Serializable {
 
 	public int getSuiteNr() {
 		return suiteNr;
+	}
+
+	public Optional<Path> getTestSourceRoot() {
+		return Optional.of( testSourceRoot ).map( Paths::get );
 	}
 
 	public long getDuration() {

--- a/src/main/java/de/retest/recheck/report/TestReport.java
+++ b/src/main/java/de/retest/recheck/report/TestReport.java
@@ -24,7 +24,7 @@ import de.retest.recheck.ui.review.GoldenMasterSource;
 public class TestReport extends Persistable {
 
 	private static final long serialVersionUID = 1L;
-	public static final int PERSISTENCE_VERSION = 22; // Last changed for 1.8.0
+	public static final int PERSISTENCE_VERSION = 23; // Last changed for 1.9.0
 
 	@XmlElement( name = "suite" )
 	private final List<SuiteReplayResult> suiteReplayResults = new ArrayList<>();

--- a/src/main/java/de/retest/recheck/report/TestReportFilter.java
+++ b/src/main/java/de/retest/recheck/report/TestReportFilter.java
@@ -39,8 +39,9 @@ public class TestReportFilter {
 
 	public SuiteReplayResult filter( final SuiteReplayResult suiteReplayResult ) {
 		final SuiteReplayResult newSuiteReplayResult = new SuiteReplayResult( suiteReplayResult.getName(),
-				suiteReplayResult.getSuiteNr(), suiteReplayResult.getExecSuiteSutVersion(),
-				suiteReplayResult.getSuiteUuid(), suiteReplayResult.getReplaySutVersion() );
+				suiteReplayResult.getTestSourceRoot().orElse( null ), suiteReplayResult.getSuiteNr(),
+				suiteReplayResult.getExecSuiteSutVersion(), suiteReplayResult.getSuiteUuid(),
+				suiteReplayResult.getReplaySutVersion() );
 		for ( final TestReplayResult testReplayResult : suiteReplayResult.getTestReplayResults() ) {
 			newSuiteReplayResult.addTest( filter( testReplayResult ) );
 		}

--- a/src/test/java/de/retest/recheck/RecheckImplTest.java
+++ b/src/test/java/de/retest/recheck/RecheckImplTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -139,6 +140,18 @@ public class RecheckImplTest {
 		mockStatic( Rehub.class );
 		doThrow( new HeadlessException() ).when( Rehub.class, method( Rehub.class, "init" ) ).withNoArguments();
 		assertThatThrownBy( () -> new RecheckImpl( opts ) ).isExactlyInstanceOf( AssertionError.class );
+	}
+
+	@org.junit.jupiter.api.Test
+	public void constructor_should_invoke_project_layout_test_source_root( @TempDir final Path path ) {
+		final ProjectLayout layout = mock( ProjectLayout.class );
+		when( layout.getSuiteFolder( any() ) ).thenReturn( path );
+
+		final RecheckImpl cut = new RecheckImpl( RecheckOptions.builder() //
+				.projectLayout( layout ) //
+				.build() );
+
+		verify( layout ).getTestSourcesRoot();
 	}
 
 	private static class DummyStringRecheckAdapter implements RecheckAdapter {

--- a/src/test/java/de/retest/recheck/SuiteAggregatorTest.java
+++ b/src/test/java/de/retest/recheck/SuiteAggregatorTest.java
@@ -2,7 +2,10 @@ package de.retest.recheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReport;
@@ -47,5 +50,23 @@ class SuiteAggregatorTest {
 		final TestReport aggregatedTestReport = cut.getAggregatedTestReport();
 
 		assertThat( aggregatedTestReport.getSuiteReplayResults() ).containsExactly( currentSuite, nextSuite );
+	}
+
+	@Test
+	void getSuite_with_test_source_root_should_properly_return_path( @TempDir final Path path ) {
+		final SuiteAggregator cut = SuiteAggregator.getTestInstance();
+
+		final SuiteReplayResult suite = cut.getSuite( "foo", path );
+
+		assertThat( suite.getTestSourceRoot() ).hasValue( path );
+	}
+
+	@Test
+	void getSuite_without_test_source_root_should_properly_return_empty() {
+		final SuiteAggregator cut = SuiteAggregator.getTestInstance();
+
+		final SuiteReplayResult suite = cut.getSuite( "foo" );
+
+		assertThat( suite.getTestSourceRoot() ).isEmpty();
 	}
 }

--- a/src/test/java/de/retest/recheck/persistence/GradleProjectLayoutTest.java
+++ b/src/test/java/de/retest/recheck/persistence/GradleProjectLayoutTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +41,19 @@ class GradleProjectLayoutTest {
 	void should_not_allow_empty_source_set_name() {
 		assertThatThrownBy( () -> new GradleProjectLayout( "" ) ).isExactlyInstanceOf( IllegalArgumentException.class )
 				.hasMessage( "sourceSetName cannot be empty!" );
+	}
+
+	@Test
+	void getTestResourceRoot_for_test_should_return_correct_path() throws Exception {
+		final GradleProjectLayout cut = new GradleProjectLayout( "test" );
+
+		assertThat( cut.getTestSourcesRoot() ).hasValue( Paths.get( "src/test/java" ) );
+	}
+
+	@Test
+	void getTestResourceRoot_for_main_should_still_return_correct_path() throws Exception {
+		final GradleProjectLayout cut = new GradleProjectLayout( "main" );
+
+		assertThat( cut.getTestSourcesRoot() ).hasValue( Paths.get( "src/test/java" ) );
 	}
 }

--- a/src/test/java/de/retest/recheck/persistence/MavenProjectLayoutTest.java
+++ b/src/test/java/de/retest/recheck/persistence/MavenProjectLayoutTest.java
@@ -1,0 +1,17 @@
+package de.retest.recheck.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+class MavenProjectLayoutTest {
+
+	@Test
+	void getTestResourceRoot_for_main_should_return_correct_path() throws Exception {
+		final ProjectLayout cut = new MavenProjectLayout();
+
+		assertThat( cut.getTestSourcesRoot() ).hasValue( Paths.get( "src/test/java" ) );
+	}
+}

--- a/src/test/java/de/retest/recheck/printer/SuiteReplayResultTest.java
+++ b/src/test/java/de/retest/recheck/printer/SuiteReplayResultTest.java
@@ -1,10 +1,14 @@
 package de.retest.recheck.printer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import de.retest.recheck.report.SuiteReplayResult;
 import de.retest.recheck.report.TestReplayResult;
@@ -31,5 +35,26 @@ class SuiteReplayResultTest {
 		cut.addTest( test );
 
 		assertThat( cut.isEmpty() ).isFalse();
+	}
+
+	@Test
+	void constructor_without_test_source_root_should_be_empty() {
+		final SuiteReplayResult cut = new SuiteReplayResult( "foo", 0, null, null, null );
+
+		assertThat( cut.getTestSourceRoot() ).isEmpty();
+	}
+
+	@Test
+	void constructor_with_test_source_root_should_be_present( @TempDir final Path path ) {
+		final SuiteReplayResult cut = new SuiteReplayResult( "foo", path, 0, null, null, null );
+
+		assertThat( cut.getTestSourceRoot() ).isPresent();
+	}
+
+	@Test
+	void constructor_with_test_source_root_being_null_should_not_throw_exception() {
+		assertThatCode( () -> {
+			new SuiteReplayResult( "foo", null, 0, null, null, null );
+		} ).doesNotThrowAnyException();
 	}
 }

--- a/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
+++ b/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import de.retest.recheck.NoGoldenMasterActionReplayResult;
 import de.retest.recheck.ignore.CompoundFilter;
@@ -393,5 +395,18 @@ class TestReportFilterTest {
 		final ActionReplayResult filtered = cut.filter( actionReplayResult );
 
 		assertThat( filtered.getMetadataDifference() ).isEqualTo( actionReplayResult.getMetadataDifference() );
+	}
+
+	@Test
+	void filter_should_not_alter_test_source_root_from_suite( @TempDir final Path path ) {
+		final SuiteReplayResult noTestSourceRoot = mock( SuiteReplayResult.class );
+		when( noTestSourceRoot.getTestSourceRoot() ).thenReturn( Optional.empty() );
+
+		assertThat( cut.filter( noTestSourceRoot ).getTestSourceRoot() ).isEmpty();
+
+		final SuiteReplayResult testSourceRoot = mock( SuiteReplayResult.class );
+		when( testSourceRoot.getTestSourceRoot() ).thenReturn( Optional.of( path ) );
+
+		assertThat( cut.filter( testSourceRoot ).getTestSourceRoot() ).hasValue( path );
 	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR <!-- Please provide some short description here -->

Save the test source root in the suite. This is done because each class may be separated in a own test source root (as in multi module project).

For compatibility purposes&mdash;as also for actual logic implementation&mdash;the `ProjectLayout#getTestSourcesRoot` returns an `Optional<Path>`. An empty optional (the default if not implemented) simply indicates that the test healing is not supported.

### State of this PR

There is some not so "clean" code in this PR (e.g. passing `null` in methods or constructors) to work around our old data model.

### Things to consider

1. The `ProjectLayout` as of yet is not able to identify sub modules as in multi module projects. For each such a sub module, a separate project layout must be specified, retrieving the correct path for the sub module in question.