### PR TITLE
Use TempDir extension to clean up temporary zip files

### DIFF
--- a/src/test/java/de/retest/recheck/persistence/xml/util/LazyScreenshotZipPersistenceTest.java
+++ b/src/test/java/de/retest/recheck/persistence/xml/util/LazyScreenshotZipPersistenceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.zip.ZipEntry;
@@ -19,6 +20,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import de.retest.recheck.persistence.Persistable;
 import de.retest.recheck.ui.image.Screenshot;
@@ -27,6 +29,9 @@ import de.retest.recheck.util.FileUtil.Writer;
 import de.retest.recheck.util.FileUtil.ZipReader;
 
 class LazyScreenshotZipPersistenceTest {
+
+	@TempDir
+	Path tempDir;
 
 	LazyScreenshotZipPersistence screenshotPersistence;
 
@@ -287,7 +292,7 @@ class LazyScreenshotZipPersistenceTest {
 	}
 
 	File getTmpZipfile() throws IOException {
-		return File.createTempFile( "tmptestzip", Long.toString( System.currentTimeMillis() ) );
+		return tempDir.resolve( "tmptestzip" ).toFile();
 	}
 
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [ ] ~the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.~
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] ~you updated the changelog.~
- [ ] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

Running the tests in `LazyScreenshotZipPersistenceTest` will create a number of temporary ZIP files. While they are created in a temporary directory, I suppose it still makes sense to let JUnit remove them after the tests are done.

### State of this PR

All done.