### PR TITLE
Sanitize persistenceId when using it as part of file name

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/xml/util/ScreenshotFolderPersistence.java
+++ b/src/main/java/de/retest/recheck/persistence/xml/util/ScreenshotFolderPersistence.java
@@ -41,7 +41,7 @@ public class ScreenshotFolderPersistence {
 	}
 
 	protected static String createFileName( final Screenshot screenshot ) {
-		return screenshot.getPersistenceId() + "." + screenshot.getType().getFileExtension();
+		return new File(screenshot.getPersistenceId()).getName() + "." + screenshot.getType().getFileExtension();
 	}
 
 	public Marshaller.Listener getMarshallListener() {

--- a/src/test/java/de/retest/recheck/persistence/xml/util/ScreenshotFolderPersistenceTest.java
+++ b/src/test/java/de/retest/recheck/persistence/xml/util/ScreenshotFolderPersistenceTest.java
@@ -80,6 +80,12 @@ class ScreenshotFolderPersistenceTest {
 		assertThat( ScreenshotFolderPersistence.createFileName( filledScreenshot ) ).isEqualTo( "testimage.png" );
 	}
 
+	@Test
+	void screenshot_filename_should_not_contain_path() {
+		Screenshot screenshot = new Screenshot( "../../testimage", filledImageBytes, ImageType.PNG );
+		assertThat( ScreenshotFolderPersistence.createFileName( screenshot ) ).isEqualTo( "testimage.png" );
+	}
+
 	// TODO what if screenshot folder is a file?
 	// TODO what if screenshot folder is not write able?
 


### PR DESCRIPTION
*Before submission, please check that ...*

- [ ] ~the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.~
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] ~you updated the changelog.~
- [ ] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

## Description

`persistenceId` is used as a part of a file name for some operations, which may be a tad unsafe. A string `.png` is still appended, but a modified `retest.xml` file may end up adding `.png` files outside of the current (or project) directory to a report.

### State of this PR

Needs input if this is a concern. Paths relative to the project's directory may even be a feature.