### PR TITLE
Sanitize persistenceId when using it for ZIP entries

### DIFF
--- a/src/main/java/de/retest/recheck/persistence/xml/util/LazyScreenshotZipPersistence.java
+++ b/src/main/java/de/retest/recheck/persistence/xml/util/LazyScreenshotZipPersistence.java
@@ -3,6 +3,7 @@ package de.retest.recheck.persistence.xml.util;
 import static de.retest.recheck.RecheckProperties.SCREENSHOT_FOLDER_NAME;
 import static de.retest.recheck.RecheckProperties.ZIP_FOLDER_SEPARATOR;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -97,8 +98,8 @@ public class LazyScreenshotZipPersistence {
 		}
 	}
 
-	private String createFilePath( final Screenshot screenshot ) {
-		return SCREENSHOT_FOLDER_NAME + ZIP_FOLDER_SEPARATOR + screenshot.getPersistenceId() + "."
+	protected static String createFilePath( final Screenshot screenshot ) {
+		return SCREENSHOT_FOLDER_NAME + ZIP_FOLDER_SEPARATOR + new File( screenshot.getPersistenceId() ).getName() + "."
 				+ screenshot.getType().getFileExtension();
 	}
 

--- a/src/test/java/de/retest/recheck/persistence/xml/util/LazyScreenshotZipPersistenceTest.java
+++ b/src/test/java/de/retest/recheck/persistence/xml/util/LazyScreenshotZipPersistenceTest.java
@@ -291,6 +291,12 @@ class LazyScreenshotZipPersistenceTest {
 		assertThat( parent.getLeft() ).isNull();
 	}
 
+	@Test
+	void screenshot_zippath_should_be_sanitized() {
+		Screenshot screenshot = new Screenshot( "../../testimage", new byte[] { 0 }, ImageType.PNG );
+		assertThat( LazyScreenshotZipPersistence.createFilePath( screenshot ) ).isEqualTo( "screenshot/testimage.png" );
+	}
+
 	File getTmpZipfile() throws IOException {
 		return tempDir.resolve( "tmptestzip" ).toFile();
 	}


### PR DESCRIPTION
*Before submission, please check that ...*

- [ ] ~the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.~
- [x] the necessary tests are either created or updated.
- [ ] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] ~you updated the changelog.~
- [ ] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

## Description

This is related to #604. The `persistenceId` is cleaned up upon using it as a name for a ZIP entry, in order to reduce surprises. Additionally `createFilePath` is made `static` and `protected`, which helps testing in this case.

### State of this PR

Please veto if relative paths created from `persistenceId` are needed.