### PR TITLE
In case the access token cannot be verified

### DIFF
--- a/src/main/java/de/retest/recheck/auth/RetestAuthentication.java
+++ b/src/main/java/de/retest/recheck/auth/RetestAuthentication.java
@@ -214,11 +214,15 @@ public class RetestAuthentication {
 
 		if ( response.isSuccess() ) {
 			final JSONObject object = response.getBody().getObject();
-			return Optional.of( verifier.verify( object.getString( OAUTH_ACCESS_TOKEN ) ) );
-		} else {
-			log.error( "Error retrieving access token: {}", response.getStatusText() );
-			return Optional.empty();
+			try {
+				return Optional.of( verifier.verify( object.getString( OAUTH_ACCESS_TOKEN ) ) );
+			} catch ( final Exception e ) {
+				log.error( "Error verifying access token: {}", e.getMessage() );
+				log.debug( "Details: ", e );
+			}
 		}
+		log.error( "Error retrieving access token: {}", response.getStatusText() );
+		return Optional.empty();
 	}
 
 	private boolean isAccessTokenValid() {


### PR DESCRIPTION
10:10:17.928 ERROR [main] [de.retest.gui.helper.ReTestErrorHandler] - Uncaugt exception in thread Thread[main,5,main]
 com.auth0.jwt.exceptions.InvalidClaimException: The Token can't be used before Thu Jan 23 10:10:09 CET 2020.
	at com.auth0.jwt.JWTVerifier.assertDateIsPast(JWTVerifier.java:479)
	at com.auth0.jwt.JWTVerifier.assertValidDateClaim(JWTVerifier.java:465)
	at com.auth0.jwt.JWTVerifier.verifyClaims(JWTVerifier.java:407)
	at com.auth0.jwt.JWTVerifier.verify(JWTVerifier.java:387)
	at com.auth0.jwt.JWTVerifier.verify(JWTVerifier.java:370)
	at de.retest.recheck.auth.RetestAuthentication.refreshAccessToken(RetestAuthentication.java:217)
	at de.retest.recheck.auth.RetestAuthentication.refreshTokens(RetestAuthentication.java:193)
	at de.retest.recheck.auth.RetestAuthentication.authenticate(RetestAuthentication.java:90)
	at de.retest.license.LicenseManager.authenticate(LicenseManager.java:73)
	at de.retest.license.LicenseManager.readLicense(LicenseManager.java:67)
	at de.retest.license.LicenseManager.<init>(LicenseManager.java:57)
	at de.retest.license.LicenseManager.createInstance(LicenseManager.java:29)
	at de.retest.util.MainUtil.initializeRetest(MainUtil.java:42)
	at de.retest.gui.ReTestGui.main(ReTestGui.java:46)