### PR TITLE
Fix version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.retest</groupId>
 	<artifactId>recheck</artifactId>
-	<version>1.10.0-SNAPSHOT</version>
+	<version>1.9.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>recheck</name>


### PR DESCRIPTION
Looks like 22ecfac8 messed this up. It's a release branch for 1.9.0, so this shouldn't be a snapshot of 1.10.0.