### PR TITLE
Feature/attribute subtree filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Table of Contents
 
 ### Bug Fixes
 
+* When defining an ignore rule with element and attribute, this rule is now applied to the whole _subtree_, i.e. all child elements of the specified element. We found that this is more intuitive and straightforward and more often what people would expect. Also, it is more in line with the current behavior when just ignoring an element (which also ignores all of its child elements).
+
 ### New Features
 
 ### Improvements
@@ -41,7 +43,6 @@ Table of Contents
 ### Breaking Changes
 
 * Reports before version 1.9.0 cannot be loaded anymore. Simply re-run your tests with the new recheck version to create them again.
-* When defining an ignore rule with element and attribute, this rule is now applied to the whole _subtree_, i.e. all child elements of the specified element. We found that this is more intuitive and straightforward and more often what people would expect. Also, it is more in line with the current behavior when just ignoring an element (which also ignores all of its child elements).
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Table of Contents
 ### Breaking Changes
 
 * Reports before version 1.9.0 cannot be loaded anymore. Simply re-run your tests with the new recheck version to create them again.
+* When defining an ignore rule with element and attribute, this rule is now applied to the whole _subtree_, i.e. all child elements of the specified element. We found that this is more intuitive and straightforward and more often what people would expect. Also, it is more in line with the current behavior when just ignoring an element (which also ignores all of its child elements).
 
 ### Bug Fixes
 

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeFilter.java
@@ -27,7 +27,11 @@ public class ElementAttributeFilter implements Filter {
 
 	@Override
 	public boolean matches( final Element element, final String attributeKey ) {
-		return matcher.test( element ) && key.equals( attributeKey );
+		if ( matcher.test( element ) && key.equals( attributeKey ) ) {
+			return true;
+		}
+		final Element parent = element.getParent();
+		return parent != null && matches( parent, attributeKey );
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ElementAttributeRegexFilter.java
@@ -27,7 +27,11 @@ public class ElementAttributeRegexFilter implements Filter {
 
 	@Override
 	public boolean matches( final Element element, final String attributeKey ) {
-		return matcher.test( element ) && attributePattern.matcher( attributeKey ).matches();
+		if ( matcher.test( element ) && attributePattern.matcher( attributeKey ).matches() ) {
+			return true;
+		}
+		final Element parent = element.getParent();
+		return parent != null && matches( parent, attributeKey );
 	}
 
 	@Override

--- a/src/main/resources/default-recheck.ignore
+++ b/src/main/resources/default-recheck.ignore
@@ -4,7 +4,7 @@
 # matcher: type=meta
 
 # Or via absolute XPath:
-# matcher: xpath=html[1]/body[1]/div[1]
+# matcher: xpath=html[1]/body[1]/iframe[1]
 
 # To ignore attributes globally, use:
 # attribute=class

--- a/src/main/resources/default-recheck.ignore
+++ b/src/main/resources/default-recheck.ignore
@@ -9,8 +9,8 @@
 # To ignore attributes globally, use:
 # attribute=class
 
-# To ignore attributes e.g. of specific elements, use (excludes children): 
-# matcher: type=img, attribute=alt
+# To ignore attributes for a subtree of the DOM, use:
+# matcher: id=menu, attribute=text
 
 # You can also use regex for elements or attributes:
 # attribute-regex=data-.*

--- a/src/test/java/de/retest/recheck/ignore/ContentFilterIT.java
+++ b/src/test/java/de/retest/recheck/ignore/ContentFilterIT.java
@@ -1,7 +1,6 @@
 package de.retest.recheck.ignore;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.nio.file.Paths;
 
@@ -11,6 +10,7 @@ import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.descriptors.MutableAttributes;
+import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.diff.AttributeDifference;
 
 class ContentFilterIT {
@@ -19,7 +19,9 @@ class ContentFilterIT {
 	void should_filter_img_src_and_alt_diffs() throws Exception {
 		final Filter filter = FilterLoader.load( Paths.get( "src/main/resources/filter/web/content.filter" ) ).load();
 
-		final Element element = Element.create( "retestId", mock( Element.class ),
+		final Element element = Element.create( "retestId",
+				new RootElement( "html", IdentifyingAttributes.create( Path.fromString( "/html[1]" ), "html" ),
+						new MutableAttributes().immutable(), null, "screen", -1, "title" ),
 				IdentifyingAttributes.create( Path.fromString( "/html[1]/img[1]" ), "img" ),
 				new MutableAttributes().immutable() );
 		final AttributeDifference srcDiff =
@@ -37,7 +39,9 @@ class ContentFilterIT {
 	void should_filter_text_diffs() throws Exception {
 		final Filter filter = FilterLoader.load( Paths.get( "src/main/resources/filter/web/content.filter" ) ).load();
 
-		final Element element = Element.create( "retestId", mock( Element.class ),
+		final Element element = Element.create( "retestId",
+				new RootElement( "html", IdentifyingAttributes.create( Path.fromString( "/html[1]" ), "html" ),
+						new MutableAttributes().immutable(), null, "screen", -1, "title" ),
 				IdentifyingAttributes.create( Path.fromString( "/html[1]/p[1]" ), "p" ),
 				new MutableAttributes().immutable() );
 		final AttributeDifference textDiff = new AttributeDifference( "text", "An ancient text.", "A hip new text." );

--- a/src/test/java/de/retest/recheck/ignore/FiltersIT.java
+++ b/src/test/java/de/retest/recheck/ignore/FiltersIT.java
@@ -44,18 +44,18 @@ class FiltersIT {
 	}
 
 	@Test
-	void matches_should_not_work_for_children_when_searching_attribute() {
+	void matches_should_work_for_children_when_searching_attribute() {
 		final Filter filter = Filters.parse( "matcher: type=input, attribute: outline" );
 		assertThat( filter.matches( element, attributeDifference ) ).isTrue();
-		assertThat( filter.matches( childElement, attributeDifference ) ).isFalse();
+		assertThat( filter.matches( childElement, attributeDifference ) ).isTrue();
 		assertThat( filter.matches( childElement ) ).isFalse();
 	}
 
 	@Test
-	void matches_should_not_work_for_children_when_searching_regex() {
+	void matches_should_work_for_children_when_searching_regex() {
 		final Filter filter = Filters.parse( "matcher: type=input, attribute-regex: .*" );
 		assertThat( filter.matches( element, attributeDifference ) ).isTrue();
-		assertThat( filter.matches( childElement, attributeDifference ) ).isFalse();
+		assertThat( filter.matches( childElement, attributeDifference ) ).isTrue();
 		assertThat( filter.matches( childElement ) ).isFalse();
 	}
 }


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). -> https://github.com/retest/docs/pull/81

We should be consistent and apply attribute filters also to the complete sub-DOM of the references element.