### PR TITLE
Feature/add colordiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Table of Contents
 
 * You can now specify that e.g. the pixel-diff filter should only apply to a specific subtree of the given elements, or to only a specific attribute. For more details, see the [docs](https://docs.retest.de).
 * You can now specify that a specific value-regex should be filtered, either globally, for specific elements or specific attributes. This allows to e.g. ignore a date, but still ensure that it is actually a valid date.
+* You can now specify to ignore a percentage color-diff, much like a pixel-diff. This allows to ignore, e.g. minor color changes or changes where opacity value is added or missing. Can be added globally, per element or attribute or combination thereof.
 
 ### Improvements
 

--- a/src/main/java/de/retest/recheck/review/ignore/ChainableFilterLoaderUtil.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ChainableFilterLoaderUtil.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import de.retest.recheck.ignore.AllMatchFilter;
 import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.review.ignore.ColorDiffFilter.ColorDiffFilterLoader;
 import de.retest.recheck.review.ignore.PixelDiffFilter.PixelDiffFilterLoader;
 import de.retest.recheck.review.ignore.ValueRegexFilter.ValueRegexFilterLoader;
 import de.retest.recheck.review.ignore.io.InheritanceLoader;
@@ -18,7 +19,8 @@ class ChainableFilterLoaderUtil {
 
 	private static final Loader<Filter> chainableFilter = new InheritanceLoader<>( Arrays.asList( //
 			Pair.of( PixelDiffFilter.class, new PixelDiffFilterLoader() ), //
-			Pair.of( ValueRegexFilter.class, new ValueRegexFilterLoader() ) //
+			Pair.of( ValueRegexFilter.class, new ValueRegexFilterLoader() ), //
+			Pair.of( ColorDiffFilter.class, new ColorDiffFilterLoader() ) //
 	) );
 
 	public static Optional<Filter> load( final MatchResult regex, final Function<String, Filter> simpleFilterLoader ) {

--- a/src/main/java/de/retest/recheck/review/ignore/ColorDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ColorDiffFilter.java
@@ -59,16 +59,13 @@ public class ColorDiffFilter implements Filter {
 	 * 100% change in the perceived color.
 	 */
 	static double calculateColorDistance( final Color expected, final Color actual ) {
-		final double r1 = expected.getRed();
-		final double r2 = actual.getRed();
-		final double g1 = expected.getGreen();
-		final double g2 = actual.getGreen();
-		final double b1 = expected.getBlue();
-		final double b2 = actual.getBlue();
-		final double a1 = expected.getAlpha();
-		final double a2 = actual.getAlpha();
+		final double redDiff = abs( expected.getRed() - actual.getRed() );
+		final double greenDiff = abs( expected.getGreen() - actual.getGreen() );
+		final double blueDiff = abs( expected.getBlue() - actual.getBlue() );
+		final double alphaDiff = abs( expected.getAlpha() - actual.getAlpha() );
 
-		final double distance = min( abs( r1 - r2 ) + abs( g1 - g2 ) + abs( b1 - b2 ) + abs( a1 - a2 ), 255 );
+		// min so we don't exceed max_distance
+		final double distance = min( redDiff + greenDiff + blueDiff + alphaDiff, 255 );
 		return distance / MAX_DISTANCE;
 	}
 
@@ -85,15 +82,15 @@ public class ColorDiffFilter implements Filter {
 			return null;
 		}
 		try {
-			final String r = matcher.group( 1 );
-			final String g = matcher.group( 2 );
-			final String b = matcher.group( 3 );
-			final String a = matcher.group( 5 );
-			if ( a != null ) {
-				return new Color( round( parseFloat( r ) ), round( parseFloat( g ) ), round( parseFloat( b ) ),
-						round( parseFloat( a ) ) );
+			final String red = matcher.group( 1 );
+			final String green = matcher.group( 2 );
+			final String blue = matcher.group( 3 );
+			final String alpha = matcher.group( 5 );
+			if ( alpha != null ) {
+				return new Color( round( parseFloat( red ) ), round( parseFloat( green ) ), round( parseFloat( blue ) ),
+						round( parseFloat( alpha ) ) );
 			}
-			return new Color( round( parseFloat( r ) ), round( parseFloat( g ) ), round( parseFloat( b ) ) );
+			return new Color( round( parseFloat( red ) ), round( parseFloat( green ) ), round( parseFloat( blue ) ) );
 		} catch ( final Exception e ) {
 			log.debug( "Error parsing input {} to color: ", input, e );
 			return null;

--- a/src/main/java/de/retest/recheck/review/ignore/ColorDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ColorDiffFilter.java
@@ -1,0 +1,125 @@
+package de.retest.recheck.review.ignore;
+
+import static java.lang.Float.parseFloat;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
+import static java.lang.Math.round;
+
+import java.awt.Color;
+import java.io.Serializable;
+import java.util.Optional;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.review.ignore.io.RegexLoader;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class ColorDiffFilter implements Filter {
+
+	private static final Pattern RGB = Pattern.compile( "rgb\\((\\d+),\\s?(\\d+),\\s?(\\d+)(,\\s?(\\d+))?\\)" );
+	private static final double MAX_DISTANCE = 255;
+
+	private final String givenInput;
+	private final double colorDiff;
+
+	public ColorDiffFilter( final String givenInput, final double colorDiff ) {
+		this.givenInput = givenInput;
+		this.colorDiff = colorDiff;
+	}
+
+	@Override
+	public boolean matches( final Element element ) {
+		return false;
+	}
+
+	@Override
+	public boolean matches( final Element element, final AttributeDifference attributeDifference ) {
+		final Color expected = parse( attributeDifference.getExpected() );
+		final Color actual = parse( attributeDifference.getActual() );
+
+		if ( expected == null || actual == null ) {
+			return false;
+		}
+
+		final double distance = calculateColorDistance( expected, actual ) * 100;
+
+		return distance < colorDiff;
+	}
+
+	/**
+	 * Return the color distance as a value in the range of [0.0, 1.0]. Note this is about perception: any one of the
+	 * rgba values is reviewed in isolation, as a change from e.g. white to red or green to yellow already constitutes a
+	 * 100% change in the perceived color.
+	 */
+	static double calculateColorDistance( final Color expected, final Color actual ) {
+		final double r1 = expected.getRed();
+		final double r2 = actual.getRed();
+		final double g1 = expected.getGreen();
+		final double g2 = actual.getGreen();
+		final double b1 = expected.getBlue();
+		final double b2 = actual.getBlue();
+		final double a1 = expected.getAlpha();
+		final double a2 = actual.getAlpha();
+
+		final double distance = min( abs( r1 - r2 ) + abs( g1 - g2 ) + abs( b1 - b2 ) + abs( a1 - a2 ), 255 );
+		return distance / MAX_DISTANCE;
+	}
+
+	static Color parse( final Serializable input ) {
+		if ( input == null || !(input instanceof String) ) {
+			return null;
+		}
+		final String color = (String) input;
+		if ( color.startsWith( "#" ) ) {
+			return Color.decode( color );
+		}
+		final Matcher matcher = RGB.matcher( color );
+		if ( !matcher.find() ) {
+			return null;
+		}
+		try {
+			final String r = matcher.group( 1 );
+			final String g = matcher.group( 2 );
+			final String b = matcher.group( 3 );
+			final String a = matcher.group( 5 );
+			if ( a != null ) {
+				return new Color( round( parseFloat( r ) ), round( parseFloat( g ) ), round( parseFloat( b ) ),
+						round( parseFloat( a ) ) );
+			}
+			return new Color( round( parseFloat( r ) ), round( parseFloat( g ) ), round( parseFloat( b ) ) );
+		} catch ( final Exception e ) {
+			log.debug( "Error parsing input {} to color: ", input, e );
+			return null;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format( ColorDiffFilterLoader.FORMAT, givenInput );
+	}
+
+	public static class ColorDiffFilterLoader extends RegexLoader<ColorDiffFilter> {
+
+		private static final String KEY = "color-diff=";
+		private static final String FORMAT = KEY + "%s";
+		private static final Pattern REGEX = Pattern.compile( KEY + "(\\d+(\\.\\d+)?)(\\%)?" );
+
+		public ColorDiffFilterLoader() {
+			super( REGEX );
+		}
+
+		@Override
+		protected Optional<ColorDiffFilter> load( final MatchResult regex ) {
+			final String value = regex.group( 1 );
+			final double colorDiff = Double.parseDouble( value );
+			return Optional.of( new ColorDiffFilter( value, colorDiff ) );
+		}
+	}
+}

--- a/src/main/java/de/retest/recheck/review/ignore/ColorDiffFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ColorDiffFilter.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ColorDiffFilter implements Filter {
 
 	private static final Pattern RGB = Pattern.compile( "rgb\\((\\d+),\\s?(\\d+),\\s?(\\d+)(,\\s?(\\d+))?\\)" );
-	private static final double MAX_DISTANCE = 255;
+	private static final double MAX_DISTANCE = 255.0;
 
 	private final String givenInput;
 	private final double colorDiff;

--- a/src/main/java/de/retest/recheck/review/ignore/io/Loaders.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/Loaders.java
@@ -43,7 +43,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor( access = AccessLevel.PRIVATE )
 public class Loaders {
 
-	private static final Loader<Filter> filter = new InheritanceLoader<>( Arrays.asList( //
+	private static final Loader<Filter> filter = new InheritanceLoader<Filter>( Arrays.asList( //
 			Pair.of( MatcherFilter.class, new MatcherFilterLoader() ), //
 			Pair.of( AttributeFilter.class, new AttributeFilterLoader() ), //
 			Pair.of( AttributeRegexFilter.class, new AttributeRegexFilterLoader() ), //

--- a/src/main/java/de/retest/recheck/review/ignore/io/Loaders.java
+++ b/src/main/java/de/retest/recheck/review/ignore/io/Loaders.java
@@ -13,6 +13,8 @@ import de.retest.recheck.review.ignore.AttributeFilter;
 import de.retest.recheck.review.ignore.AttributeFilter.AttributeFilterLoader;
 import de.retest.recheck.review.ignore.AttributeRegexFilter;
 import de.retest.recheck.review.ignore.AttributeRegexFilter.AttributeRegexFilterLoader;
+import de.retest.recheck.review.ignore.ColorDiffFilter;
+import de.retest.recheck.review.ignore.ColorDiffFilter.ColorDiffFilterLoader;
 import de.retest.recheck.review.ignore.FilterPreserveLineLoader;
 import de.retest.recheck.review.ignore.FilterPreserveLineLoader.FilterPreserveLine;
 import de.retest.recheck.review.ignore.ImportedExternalFilter;
@@ -47,6 +49,7 @@ public class Loaders {
 			Pair.of( AttributeRegexFilter.class, new AttributeRegexFilterLoader() ), //
 			Pair.of( PixelDiffFilter.class, new PixelDiffFilterLoader() ), //
 			Pair.of( ValueRegexFilter.class, new ValueRegexFilterLoader() ), //
+			Pair.of( ColorDiffFilter.class, new ColorDiffFilterLoader() ), //
 			Pair.of( FilterPreserveLine.class, new FilterPreserveLineLoader() ), //
 			Pair.of( ImportedExternalFilter.class, new ImportExternalFilterLoader() ), //
 			Pair.of( AllMatchFilter.class, new AllMatchFilterLoader() ), //

--- a/src/test/java/de/retest/recheck/review/ignore/ColorDiffFilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ColorDiffFilterLoaderTest.java
@@ -1,0 +1,37 @@
+package de.retest.recheck.review.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.review.ignore.ColorDiffFilter.ColorDiffFilterLoader;
+
+public class ColorDiffFilterLoaderTest {
+
+	@Test
+	void should_not_load_non_integer_and_non_double() throws Exception {
+		final ColorDiffFilterLoader cut = new ColorDiffFilterLoader();
+
+		assertThat( cut.load( "foo=bar" ) ).isNotPresent();
+		assertThat( cut.load( "color-diff=baz" ) ).isNotPresent();
+		assertThat( cut.load( "color-diff=-5" ) ).isNotPresent();
+		assertThat( cut.load( "color-diff=5." ) ).isNotPresent();
+		assertThat( cut.load( "color-diff=5.0." ) ).isNotPresent();
+		assertThat( cut.load( "color-diff=5,0" ) ).isNotPresent();
+	}
+
+	@Test
+	void should_load_integer_and_double() throws Exception {
+		final ColorDiffFilterLoader cut = new ColorDiffFilterLoader();
+
+		final String intDiff = "color-diff=5";
+		assertThat( cut.load( intDiff ) ).isPresent();
+		final ColorDiffFilter loadedIntDiff = cut.load( intDiff ).get();
+		assertThat( loadedIntDiff.getColorDiff() ).isEqualTo( 5.0 );
+
+		final String doubleDiff = "color-diff=5.0";
+		assertThat( cut.load( doubleDiff ) ).isPresent();
+		final ColorDiffFilter loadedDoubleDiff = cut.load( doubleDiff ).get();
+		assertThat( loadedDoubleDiff.getColorDiff() ).isEqualTo( 5.0 );
+	}
+}

--- a/src/test/java/de/retest/recheck/review/ignore/ColorDiffFilterTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ColorDiffFilterTest.java
@@ -1,0 +1,124 @@
+package de.retest.recheck.review.ignore;
+
+import static de.retest.recheck.review.ignore.ColorDiffFilter.calculateColorDistance;
+import static de.retest.recheck.review.ignore.ColorDiffFilter.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.awt.Color;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class ColorDiffFilterTest {
+
+	double colorDiff = 5.0;
+	Filter cut;
+	Element element;
+
+	@BeforeEach
+	void setUp() {
+		cut = new ColorDiffFilter( "5%", colorDiff );
+		element = mock( Element.class );
+	}
+
+	static AttributeDifference toDiff( final String expected, final String actual ) {
+		return new AttributeDifference( "color", expected, actual );
+	}
+
+	@Test
+	void should_filter_diff_when_color_diff_is_not_exceeded() throws Exception {
+		assertThat( cut.matches( element, toDiff( "rgb(255, 0, 0)", "rgb(250, 0, 0)" ) ) ).isTrue();
+		assertThat( cut.matches( element, toDiff( "rgb(255, 255, 0)", "rgb(250, 250, 0)" ) ) ).isTrue();
+	}
+
+	@Test
+	void should_not_filter_diff_when_color_diff_is_exceeded() throws Exception {
+		assertThat( cut.matches( element, toDiff( "rgb(0, 0, 0)", "rgb(255, 255, 255)" ) ) ).isFalse();
+		assertThat( cut.matches( element, toDiff( "rgb(255, 255, 255)", "rgb(250, 250, 250)" ) ) ).isFalse();
+	}
+
+	@Test
+	void should_filter_when_diff_is_just_opacity_given() throws Exception {
+		assertThat( cut.matches( element, toDiff( "rgb(255, 255, 255)", "rgb(255, 255, 255, 255)" ) ) ).isTrue();
+	}
+
+	@Test
+	void should_skip_nulls() throws Exception {
+		assertThat( cut.matches( element, new AttributeDifference( "color", "rgb(0,0,0)", null ) ) ).isFalse();
+		assertThat( cut.matches( element, new AttributeDifference( "color", null, "rgb(0,0,0)" ) ) ).isFalse();
+	}
+
+	@Test
+	void should_skip_non_color_strings() throws Exception {
+		final String expected = "bar";
+		final String actual = "baz";
+		final AttributeDifference diff = new AttributeDifference( "foo", expected, actual );
+
+		assertThat( cut.matches( element, diff ) ).isFalse();
+	}
+
+	@Test
+	void complete_opacity_change_should_be_100_percent_change() throws Exception {
+		assertThat( calculateColorDistance( Color.BLACK, new Color( 0, 0, 0, 0 ) ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( new Color( 0, 0, 0, 0 ), Color.BLACK ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( Color.RED, new Color( 0, 0, 0, 0 ) ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( new Color( 0, 0, 0, 0 ), Color.RED ) ).isEqualTo( 1.0 );
+	}
+
+	@Test
+	void black_to_white_should_be_100_percent_change() throws Exception {
+		assertThat( calculateColorDistance( Color.BLACK, Color.WHITE ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( Color.WHITE, Color.BLACK ) ).isEqualTo( 1.0 );
+	}
+
+	@Test
+	void red_to_yellow_should_be_100_percent_change() throws Exception {
+		assertThat( calculateColorDistance( Color.RED, Color.YELLOW ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( Color.YELLOW, Color.RED ) ).isEqualTo( 1.0 );
+	}
+
+	@Test
+	void green_to_yellow_should_be_100_percent_change() throws Exception {
+		assertThat( calculateColorDistance( Color.GREEN, Color.YELLOW ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( Color.YELLOW, Color.GREEN ) ).isEqualTo( 1.0 );
+	}
+
+	@Test
+	void white_to_red_should_be_100_percent_change() throws Exception {
+		assertThat( calculateColorDistance( Color.WHITE, Color.RED ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( Color.RED, Color.WHITE ) ).isEqualTo( 1.0 );
+	}
+
+	@Test
+	void black_to_red_should_be_100_percent_change() throws Exception {
+		assertThat( calculateColorDistance( Color.BLACK, Color.RED ) ).isEqualTo( 1.0 );
+		assertThat( calculateColorDistance( Color.RED, Color.BLACK ) ).isEqualTo( 1.0 );
+	}
+
+	@Test
+	void should_parse_both_rgb_and_rgba_correctly() {
+		assertThat( parse( "rgb(0,0,0)" ) ).isEqualTo( Color.BLACK );
+		assertThat( parse( "rgb(0,0,0,255)" ) ).isEqualTo( Color.BLACK );
+		assertThat( parse( "rgb(0,0,0,255)" ) ).isEqualTo( new Color( 0, 0, 0, 255 ) );
+		assertThat( parse( "rgb(255,255,255,255)" ) ).isEqualTo( new Color( 255, 255, 255, 255 ) );
+	}
+
+	@Test
+	void should_handle_whitespace() {
+		assertThat( parse( "rgb(0, 0, 0)" ) ).isEqualTo( Color.BLACK );
+		assertThat( parse( "rgb(0, 0, 0, 255)" ) ).isEqualTo( Color.BLACK );
+	}
+
+	@Test
+	void invalid_values_should_return_null() {
+		assertThat( parse( "rgb(0,2fw,0)" ) ).isNull();
+		assertThat( parse( "rgb(-1,0,0)" ) ).isNull();
+		assertThat( parse( "rgb(0,0,322)" ) ).isNull();
+		assertThat( parse( "rgb(0,0,0,255.021)" ) ).isNull();
+	}
+}


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

Adds a percentual color-diff filter, much like the pixel filter. This allows to ignore, e.g. minor color changes or changes where opacity value is added or missing. Documentation is in the making...