### PR TITLE
Quote file names in log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Table of Contents
 
 ### Improvements
 
+* File names in log output should now always be in single quotes, making it easier to distinguish and select them.
+
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
+++ b/src/main/java/de/retest/recheck/ignore/JSFilterImpl.java
@@ -47,7 +47,7 @@ public class JSFilterImpl implements Filter {
 
 	Reader readScriptFile( final Path filterFilePath ) {
 		try {
-			logger.info( "Reading JS filter rules file from {}.", filterFilePath );
+			logger.info( "Reading JS filter rules file from '{}'.", filterFilePath );
 			return Files.newBufferedReader( filterFilePath, StandardCharsets.UTF_8 );
 		} catch ( final NoSuchFileException e ) {
 			logger.warn( "No JS filter file found at '{}': {}", filterFilePath, e.getMessage() );
@@ -77,22 +77,22 @@ public class JSFilterImpl implements Filter {
 		try {
 			final Object callResult = inv.invokeFunction( functionName, args );
 			if ( callResult == null ) {
-				logger.warn( "{} returned 'null' instead of a boolean value in file {}. Interpreting that as 'false'.",
+				logger.warn( "{} returned 'null' instead of a boolean value in file '{}'. Interpreting that as 'false'.",
 						filePath, functionName );
 				return false;
 			}
 			if ( !(callResult instanceof Boolean) ) {
-				logger.error( "'{}' of {} cannot be cast to java.lang.Boolean in file {}.", callResult,
+				logger.error( "'{}' of {} cannot be cast to java.lang.Boolean in file '{}'.", callResult,
 						callResult.getClass(), filePath );
 				return false;
 			}
 			return (boolean) callResult;
 		} catch ( final ScriptException e ) {
-			logger.error( "JS '{}' method caused an exception: {} in file {}.", functionName, e.getMessage(),
+			logger.error( "JS '{}' method caused an exception: {} in file '{}'.", functionName, e.getMessage(),
 					filePath );
 		} catch ( final NoSuchMethodException e ) {
 			if ( !functionName.startsWith( "shouldIgnore" ) && !noMethodWarningPrinted ) {
-				logger.warn( "Specified JS filter file {} has no '{}' function.", filePath, functionName );
+				logger.warn( "Specified JS filter file '{}' has no '{}' function.", filePath, functionName );
 				noMethodWarningPrinted = true;
 			}
 		}

--- a/src/main/java/de/retest/recheck/persistence/bin/KryoPersistence.java
+++ b/src/main/java/de/retest/recheck/persistence/bin/KryoPersistence.java
@@ -96,7 +96,7 @@ public class KryoPersistence<T extends Persistable> implements Persistence<T> {
 			save( newOutputStream( path ), element );
 			log.debug( "Done writing {} to {}", element, identifier );
 		} catch ( final Throwable t ) {
-			log.error( "Error writing to file {}. Deleting what has been written to not leave corrupt file behind...",
+			log.error( "Error writing to file '{}'. Deleting what has been written to not leave corrupt file behind...",
 					identifier, t );
 			FileUtils.deleteQuietly( file );
 			throw t;

--- a/src/main/java/de/retest/recheck/persistence/migration/XmlTransformer.java
+++ b/src/main/java/de/retest/recheck/persistence/migration/XmlTransformer.java
@@ -41,7 +41,7 @@ public abstract class XmlTransformer {
 			// Since these files can become pretty big, storing them in memory might lead to OutOfMemoryErrors.
 			final File tmpFile = File.createTempFile( "retest-migration-", ".xml.lz4" );
 			tmpFile.deleteOnExit();
-			logger.debug( "Creating temporary file {} for XML migration. File will be deleted upon exit.",
+			logger.debug( "Creating temporary file '{}' for XML migration. File will be deleted upon exit.",
 					canonicalPathQuietly( tmpFile ) );
 
 			convertAndWriteToFile( inputStream, tmpFile );

--- a/src/main/java/de/retest/recheck/review/workers/SaveFilterWorker.java
+++ b/src/main/java/de/retest/recheck/review/workers/SaveFilterWorker.java
@@ -43,7 +43,7 @@ public class SaveFilterWorker {
 					.map( f -> Loaders.filter().save( f.getFilter() ) ) //
 					.collect( Collectors.toList() );
 			final Path target = line.getKey();
-			log.info( "Writing filters to file {}.", target );
+			log.info( "Writing filters to file '{}'.", target );
 			createDirectories( target.getParent() );
 			write( target, save );
 		}

--- a/src/main/java/de/retest/recheck/util/FileUtil.java
+++ b/src/main/java/de/retest/recheck/util/FileUtil.java
@@ -45,7 +45,7 @@ public class FileUtil {
 			}
 		} catch ( final IOException exc ) {
 			final String result = file.getAbsolutePath();
-			logger.error( "Exception getting canonical path for file {}.", result, exc );
+			logger.error( "Exception getting canonical path for file '{}'.", result, exc );
 			return result;
 		}
 	}
@@ -56,7 +56,7 @@ public class FileUtil {
 				return file.getCanonicalFile();
 			}
 		} catch ( final IOException exc ) {
-			logger.error( "Exception getting canonical file for file {}.", file.getPath(), exc );
+			logger.error( "Exception getting canonical file for file '{}'.", file.getPath(), exc );
 		}
 		return file;
 	}
@@ -146,7 +146,7 @@ public class FileUtil {
 		try {
 			result.getCanonicalFile().getParentFile().mkdirs();
 		} catch ( final IOException exc ) {
-			logger.error( "Exception creating parent folder of file {}.", result, exc );
+			logger.error( "Exception creating parent folder of file '{}'.", result, exc );
 			throw new ReTestSaveException( result.getAbsoluteFile().toURI(), "Exception creating parent folder.", exc );
 		}
 	}
@@ -282,7 +282,7 @@ public class FileUtil {
 				try {
 					in.close();
 				} catch ( final IOException e ) {
-					logger.error( "Exception closing input stream for zip file {}.", file, e );
+					logger.error( "Exception closing input stream for zip file '{}'.", file, e );
 				}
 			}
 		}
@@ -298,7 +298,7 @@ public class FileUtil {
 			in = new ZipFile( file );
 			return reader.read( in );
 		} catch ( final IllegalArgumentException exc ) {
-			logger.warn( "Error reading from file with wrong XML-version: {}", canonicalPathQuietly( file ), exc );
+			logger.warn( "Error reading from file with wrong XML-version: '{}'", canonicalPathQuietly( file ), exc );
 			throw exc;
 		} catch ( final Exception e ) {
 			logger.warn( "Error reading from file '{}', ignoring: ", canonicalPathQuietly( file ), e );
@@ -308,7 +308,7 @@ public class FileUtil {
 				try {
 					in.close();
 				} catch ( final IOException e ) {
-					logger.error( "Exception closing input stream for file {}.", file, e );
+					logger.error( "Exception closing input stream for file '{}'.", file, e );
 				}
 			}
 		}


### PR DESCRIPTION
*Before submission, please check that ...*

- [ ] ~the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.~
- [ ] ~the necessary tests are either created or updated.~
- [ ] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

I noticed that during usage of recheck-cli, I wasn't able to simply double-click some file names (as printed on the terminal) for selection. In some cases a trailing dot was copied. It seems that most of the time we put file names in single quotes, which makes them selectable by double-clicking.

### State of this PR

All done.