### PR TITLE
In case someone is offline, this should not cause a generic exception

### DIFF
--- a/src/main/java/de/retest/recheck/auth/UnableToAuthenticateOfflineException.java
+++ b/src/main/java/de/retest/recheck/auth/UnableToAuthenticateOfflineException.java
@@ -1,0 +1,11 @@
+package de.retest.recheck.auth;
+
+public class UnableToAuthenticateOfflineException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public UnableToAuthenticateOfflineException( final Throwable cause ) {
+		super( "It appears you are offline. You need either to be online or have a special offline-license.", cause );
+	}
+
+}


### PR DESCRIPTION
08:25:48.857 ERROR [main] [de.retest.license.LicenseManager] - Error authenticating.
 java.lang.RuntimeException: You need to be online to validate the recheck license.
	at de.retest.recheck.auth.RetestAuthentication.getJwtVerifier(RetestAuthentication.java:85)
	at de.retest.recheck.auth.RetestAuthentication.<init>(Unknown Source)
	at de.retest.license.LicenseManager.authenticate(LicenseManager.java:72)
	at de.retest.license.LicenseManager.readLicense(LicenseManager.java:67)
	at de.retest.license.LicenseManager.<init>(LicenseManager.java:57)
	at de.retest.license.LicenseManager.createInstance(LicenseManager.java:29)
	at de.retest.util.MainUtil.initializeRetest(MainUtil.java:41)
	at de.retest.gui.ReTestGui.main(ReTestGui.java:46)
Caused by: com.auth0.jwk.SigningKeyNotFoundException: Cannot obtain jwks from url https://sso.prod.cloud.retest.org/auth/realms/customer/protocol/openid-connect/certs
	at com.auth0.jwk.UrlJwkProvider.getJwks(UrlJwkProvider.java:112)
	at com.auth0.jwk.UrlJwkProvider.getAll(UrlJwkProvider.java:118)
	at com.auth0.jwk.UrlJwkProvider.get(UrlJwkProvider.java:136)
	at de.retest.recheck.auth.RetestAuthentication.getJwtVerifier(RetestAuthentication.java:82)
	... 7 common frames omitted
Caused by: java.net.UnknownHostException: sso.prod.cloud.retest.org
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:668)
	at sun.security.ssl.BaseSSLSocketImpl.connect(BaseSSLSocketImpl.java:173)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:180)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:432)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:527)
	at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
	at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:367)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:191)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1138)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1032)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:177)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1546)
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1474)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:254)
	at com.auth0.jwk.UrlJwkProvider.getJwks(UrlJwkProvider.java:108)
	... 10 common frames omitted