### PR TITLE
Fix Mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,6 +6,8 @@ pull_request_rules:
       - status-success=Travis CI - Pull Request
       - status-success=SonarCloud Code Analysis
       - status-success=verification/cla-signed
+      - "#approved-reviews-by<=0"
+      - "#changes-requested-reviews-by<=0"
     actions:
       rebase: {}
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: 'rebase when the head branch is not a release and all status checks passed'
+  - name: 'rebase unreviewed non-release PRs'
     conditions:
       - head~=^(?!(release|hotfix)).*$
       - status-success=Travis CI - Branch
@@ -9,8 +9,24 @@ pull_request_rules:
     actions:
       rebase: {}
 
-  - name: 'merge when the head branch is up-to-date, all status checks passed, one or more reviewers approved and no changes requested'
+  - name: 'merge non-release PRs with strict rebase'
     conditions:
+      - head~=^(?!(release|hotfix)).*$
+      - status-success=Travis CI - Branch
+      - status-success=Travis CI - Pull Request
+      - status-success=SonarCloud Code Analysis
+      - status-success=verification/cla-signed
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by<=0"
+    actions:
+      merge:
+        strict: true
+        strict_method: rebase
+        method: merge
+
+  - name: 'merge release PRs with strict merge'
+    conditions:
+      - head~=^(release|hotfix).*$
       - status-success=Travis CI - Branch
       - status-success=Travis CI - Pull Request
       - status-success=SonarCloud Code Analysis
@@ -22,7 +38,7 @@ pull_request_rules:
         strict: true
         method: merge
 
-  - name: 'delete after successful merge'
+  - name: 'delete PR branches after merge'
     conditions:
       - merged
     actions:


### PR DESCRIPTION
@roesslerj pointed out that Mergify sometimes merges base into head, rather than rebasing head against base. This fix should solve this issue and also introduces less-verbose rule names.

@diba1013 we already talked about this a few weeks ago. Any other ideas? We should also keep an eye on this before adopting Mergify elsewhere. However, as soon as this is merged, I will update the other configs accordingly.