### PR TITLE
Remove unused dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,12 +112,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.eclipse.persistence</groupId>
-			<artifactId>org.eclipse.persistence.core</artifactId>
-			<version>2.5.2</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
 			<version>4.0.2</version>


### PR DESCRIPTION
@roesslerj seems to be unused, also not required by Moxy. Do you know why added this in the past? 