### PR TITLE
Feature/improve readability of difference print outs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Table of Contents
 ### Improvements
 
 * File names in log output should now always be in single quotes, making it easier to distinguish and select them.
+* Printer layout is improved (in `MetadataDifferencePrinter` and `AttributeDifferencePrinter`). Differences will now be printed per line and aligned for easier comparison.
 
 
 --------------------------------------------------------------------------------

--- a/src/main/java/de/retest/recheck/printer/AttributeDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/AttributeDifferencePrinter.java
@@ -15,8 +15,6 @@ public class AttributeDifferencePrinter implements Printer<AttributeDifference> 
 
 	private static final String IS_DEFAULT = "(default or absent)";
 
-	private static final String KEY_EXPECTED_ACTUAL_FORMAT = "%s: expected=\"%s\", actual=\"%s\"";
-
 	private static final String WARNING_FILENAME_LINE_FORMAT = ", breaks=\"%s\"";
 
 	private final IdentifyingAttributes attributes;
@@ -25,46 +23,52 @@ public class AttributeDifferencePrinter implements Printer<AttributeDifference> 
 	@Override
 	public String toString( final AttributeDifference difference, final String indent ) {
 		if ( difference.hasElementIdentificationWarning() ) {
-			return indent + format( difference ) + printWarning( difference );
+			return indent + format( difference, indent ) + printWarning( difference );
 		}
-		return indent + format( difference );
+		return indent + format( difference, indent );
 	}
 
-	private String format( final AttributeDifference difference ) {
+	private String format( final AttributeDifference difference, final String indent ) {
 		if ( isExpectedDefault( difference ) ) { // The attribute changed from default to a non-default
-			return printExpectedDefaultDifference( difference );
+			return printExpectedDefaultDifference( difference, indent );
 		}
 		if ( isActualDefault( difference ) ) { // The attribute changed back to default
-			return printActualDefaultDifference( difference );
+			return printActualDefaultDifference( difference, indent );
 		}
-		return printBothDifferences( difference );
+		return printBothDifferences( difference, indent );
 	}
 
 	private boolean isActualDefault( final AttributeDifference difference ) {
 		return defaultProvider.isDefaultValue( attributes, difference.getKey(), difference.getActual() );
 	}
 
-	private String printActualDefaultDifference( final AttributeDifference difference ) {
+	private String printActualDefaultDifference( final AttributeDifference difference, final String indent ) {
 		final String key = difference.getKey();
 		final Serializable expected = difference.getExpected();
-		return String.format( KEY_EXPECTED_ACTUAL_FORMAT, key, expected, IS_DEFAULT );
+		final String keyExpectedActualFormat = getKeyExpectedActualFormat( indent );
+
+		return String.format( keyExpectedActualFormat, key, expected, IS_DEFAULT );
 	}
 
 	private boolean isExpectedDefault( final AttributeDifference difference ) {
 		return difference.getExpected() == null; // We do not save defaults, thus this is null
 	}
 
-	private String printExpectedDefaultDifference( final AttributeDifference difference ) {
+	private String printExpectedDefaultDifference( final AttributeDifference difference, final String indent ) {
 		final String key = difference.getKey();
 		final Serializable actual = difference.getActual();
-		return String.format( KEY_EXPECTED_ACTUAL_FORMAT, key, IS_DEFAULT, actual );
+		final String keyExpectedActualFormat = getKeyExpectedActualFormat( indent );
+
+		return String.format( keyExpectedActualFormat, key, IS_DEFAULT, actual );
 	}
 
-	private String printBothDifferences( final AttributeDifference difference ) {
+	private String printBothDifferences( final AttributeDifference difference, final String indent ) {
 		final String key = difference.getKey();
 		final Serializable expected = difference.getExpected();
 		final Serializable actual = difference.getActual();
-		return String.format( KEY_EXPECTED_ACTUAL_FORMAT, key, expected, actual );
+		final String keyExpectedActualFormat = getKeyExpectedActualFormat( indent );
+
+		return String.format( keyExpectedActualFormat, key, expected, actual );
 	}
 
 	private String printWarning( final AttributeDifference difference ) {
@@ -76,5 +80,11 @@ public class AttributeDifferencePrinter implements Printer<AttributeDifference> 
 
 	private String formatWarning( final ElementIdentificationWarning warning ) {
 		return warning.getTestFileName() + ":" + warning.getTestLineNumber();
+	}
+
+	private String getKeyExpectedActualFormat( final String indent ) {
+		final String expectedItemIndent = indent + "  ";
+		final String actualItemIndent = indent + "    "; // tab leads to wrong indent on console
+		return "%s:\n" + expectedItemIndent + "expected=\"%s\",\n" + actualItemIndent + "actual=\"%s\"";
 	}
 }

--- a/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/MetadataDifferencePrinter.java
@@ -7,24 +7,31 @@ import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
 
 public class MetadataDifferencePrinter implements Printer<MetadataDifference> {
 
-	private static final String KEY_EXPECTED_ACTUAL_FORMAT = "%s: expected=\"%s\", actual=\"%s\"";
-
 	@Override
 	public String toString( final MetadataDifference difference, final String indent ) {
-		final String prefix = "Metadata Differences:";
+		final String prefix = "Metadata Differences:\n";
 		final String note =
-				"\n\t  Please note that these differences do not affect the result and are not included in the difference count.";
-		return indent + prefix + note + printDifferences( difference, indent + "\t" );
+				"Please note that these differences do not affect the result and are not included in the difference count.";
+		final String noteIndent = indent + "  ";
+		final String differenceIndent = indent + "\t";
+		return indent + prefix + noteIndent + note + printDifferences( difference, differenceIndent );
 	}
 
 	private String printDifferences( final MetadataDifference difference, final String indent ) {
 		return difference.getDifferences().stream() //
-				.map( this::print ) //
+				.map( d -> print( d, indent ) ) //
 				.collect( Collectors.joining( "\n" + indent, "\n" + indent, "" ) );
 	}
 
-	private String print( final MetadataElementDifference difference ) {
-		return String.format( KEY_EXPECTED_ACTUAL_FORMAT, difference.getKey(), difference.getExpected(),
+	private String print( final MetadataElementDifference difference, final String indent ) {
+		final String expectedItemIndent = indent + "  ";
+		final String actualItemIndent = indent + "    "; // tab leads to wrong indent on console
+
+		final String keyExpectedActualFormat =
+				"%s:\n" + expectedItemIndent + "expected=\"%s\",\n" + actualItemIndent + "actual=\"%s\"";
+
+		return String.format( keyExpectedActualFormat, difference.getKey(), difference.getExpected(),
 				difference.getActual() );
 	}
+
 }

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -74,7 +74,9 @@ class ActionReplayResultPrinterTest {
 
 		assertThat( string ).isEqualTo( "foo resulted in:\n" //
 				+ "\tIdentifying at 'path/to/element':\n" //
-				+ "\t\tkey: expected=\"expected\", actual=\"actual\"" );
+				+ "\t\tkey:" //
+				+ "\n\t\t  expected=\"expected\"," //
+				+ "\n\t\t    actual=\"actual\"" );
 	}
 
 	@Test
@@ -95,8 +97,12 @@ class ActionReplayResultPrinterTest {
 		assertThat( cut.toString( actionResult ) ).isEqualTo( "foo resulted in:\n" //
 				+ "\tMetadata Differences:\n" //
 				+ "\t  Please note that these differences do not affect the result and are not included in the difference count.\n" //
-				+ "\t\ta: expected=\"b\", actual=\"c\"\n" //
-				+ "\t\tb: expected=\"c\", actual=\"d\"" );
+				+ "\t\ta:" //
+				+ "\n\t\t  expected=\"b\"," // 
+				+ "\n\t\t    actual=\"c\"\n" //
+				+ "\t\tb:" //
+				+ "\n\t\t  expected=\"c\"," //
+				+ "\n\t\t    actual=\"d\"" );
 	}
 
 	@Test
@@ -135,10 +141,16 @@ class ActionReplayResultPrinterTest {
 		assertThat( cut.toString( actionResult ) ).isEqualTo( "foo resulted in:\n" //
 				+ "\tMetadata Differences:\n" //
 				+ "\t  Please note that these differences do not affect the result and are not included in the difference count.\n" //
-				+ "\t\ta: expected=\"b\", actual=\"c\"\n" //
-				+ "\t\tb: expected=\"c\", actual=\"d\"\n" //
+				+ "\t\ta:" //
+				+ "\n\t\t  expected=\"b\"," //
+				+ "\n\t\t    actual=\"c\"\n" //
+				+ "\t\tb:" //
+				+ "\n\t\t  expected=\"c\"," //
+				+ "\n\t\t    actual=\"d\"\n" //
 				+ "\tIdentifying at 'path/to/element':\n" //
-				+ "\t\tkey: expected=\"expected\", actual=\"actual\"" );
+				+ "\t\tkey:" //
+				+ "\n\t\t  expected=\"expected\"," //
+				+ "\n\t\t    actual=\"actual\"" );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/MetadataDifferencePrinterTest.java
@@ -22,9 +22,13 @@ class MetadataDifferencePrinterTest {
 		final MetadataDifferencePrinter cut = new MetadataDifferencePrinter();
 
 		assertThat( cut.toString( differences, "____" ) ).isEqualTo( "____Metadata Differences:\n" //
-				+ "\t  Please note that these differences do not affect the result and are not included " //
+				+ "____  Please note that these differences do not affect the result and are not included " //
 				+ "in the difference count.\n" //
-				+ "____\ta: expected=\"b\", actual=\"c\"\n" //
-				+ "____\tb: expected=\"c\", actual=\"d\"" );
+				+ "____\ta:\n" //
+				+ "____\t  expected=\"b\",\n" //
+				+ "____\t    actual=\"c\"\n" //
+				+ "____\tb:\n" //
+				+ "____\t  expected=\"c\",\n" //
+				+ "____\t    actual=\"d\"" );
 	}
 }

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
@@ -5,17 +5,35 @@ Test 'no-filter' has 9 difference(s) in 1 state(s):
 check resulted in:
 	Metadata Differences:
 	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
+		os.name:
+		  expected="null",
+		    actual="Linux"
+		os.version:
+		  expected="null",
+		    actual="4.4.0-101-generic"
 	test [test] at 'foo[1]/bar[1]':
-		foo-1: expected="bar-1", actual="bar-3"
-		foo-3: expected="bar-3", actual="bar-1"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar-3"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar-1"
 	same [same] at 'foo[1]/bar[1]/same[1]':
-		bar-1: expected="bar-1", actual="bar-1-change"
-		bar-2: expected="bar-2", actual="null"
-		bar-3: expected="bar-3", actual="(default or absent)"
-		bar-2-change: expected="(default or absent)", actual="bar-2"
-		bar-3-change: expected="(default or absent)", actual="bar-3"
+		bar-1:
+		  expected="bar-1",
+		    actual="bar-1-change"
+		bar-2:
+		  expected="bar-2",
+		    actual="null"
+		bar-3:
+		  expected="bar-3",
+		    actual="(default or absent)"
+		bar-2-change:
+		  expected="(default or absent)",
+		    actual="bar-2"
+		bar-3-change:
+		  expected="(default or absent)",
+		    actual="bar-3"
 	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
 	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
@@ -5,11 +5,19 @@ Test 'filter' has 4 difference(s) in 1 state(s):
 check resulted in:
 	Metadata Differences:
 	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
+		os.name:
+		  expected="null",
+		    actual="Linux"
+		os.version:
+		  expected="null",
+		    actual="4.4.0-101-generic"
 	test [test] at 'foo[1]/bar[1]':
-		foo-1: expected="bar-1", actual="bar-3"
-		foo-3: expected="bar-3", actual="bar-1"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar-3"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar-1"
 	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
 	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
@@ -5,17 +5,35 @@ Test 'with legacy spaces' has 9 difference(s) in 1 state(s):
 check resulted in:
 	Metadata Differences:
 	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
+		os.name:
+		  expected="null",
+		    actual="Linux"
+		os.version:
+		  expected="null",
+		    actual="4.4.0-101-generic"
 	test [test] at 'foo[1]/bar[1]':
-		foo-1: expected="bar-1", actual="bar-3"
-		foo-3: expected="bar-3", actual="bar-1"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar-3"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar-1"
 	same [same] at 'foo[1]/bar[1]/same[1]':
-		bar-1: expected="bar-1", actual="bar-1-change"
-		bar-2: expected="bar-2", actual="null"
-		bar-3: expected="bar-3", actual="(default or absent)"
-		bar-2-change: expected="(default or absent)", actual="bar-2"
-		bar-3-change: expected="(default or absent)", actual="bar-3"
+		bar-1:
+		  expected="bar-1",
+		    actual="bar-1-change"
+		bar-2:
+		  expected="bar-2",
+		    actual="null"
+		bar-3:
+		  expected="bar-3",
+		    actual="(default or absent)"
+		bar-2-change:
+		  expected="(default or absent)",
+		    actual="bar-2"
+		bar-3-change:
+		  expected="(default or absent)",
+		    actual="bar-3"
 	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
 	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
@@ -5,17 +5,35 @@ Test 'with spaces' has 9 difference(s) in 1 state(s):
 check resulted in:
 	Metadata Differences:
 	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
+		os.name:
+		  expected="null",
+		    actual="Linux"
+		os.version:
+		  expected="null",
+		    actual="4.4.0-101-generic"
 	test [test] at 'foo[1]/bar[1]':
-		foo-1: expected="bar-1", actual="bar-3"
-		foo-3: expected="bar-3", actual="bar-1"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar-3"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar-1"
 	same [same] at 'foo[1]/bar[1]/same[1]':
-		bar-1: expected="bar-1", actual="bar-1-change"
-		bar-2: expected="bar-2", actual="null"
-		bar-3: expected="bar-3", actual="(default or absent)"
-		bar-2-change: expected="(default or absent)", actual="bar-2"
-		bar-3-change: expected="(default or absent)", actual="bar-3"
+		bar-1:
+		  expected="bar-1",
+		    actual="bar-1-change"
+		bar-2:
+		  expected="bar-2",
+		    actual="null"
+		bar-3:
+		  expected="bar-3",
+		    actual="(default or absent)"
+		bar-2-change:
+		  expected="(default or absent)",
+		    actual="bar-2"
+		bar-3-change:
+		  expected="(default or absent)",
+		    actual="bar-3"
 	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
 	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':

--- a/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
+++ b/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
@@ -1,17 +1,35 @@
 Start Sut resulted in:
 	body[1] at 'html[1]/body[1]':
-		foo-1: expected="bar-1", actual="bar1"
-		foo-2: expected="bar-2", actual="bar2"
-		foo-3: expected="bar-3", actual="bar3"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar1"
+		foo-2:
+		  expected="bar-2",
+		    actual="bar2"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar3"
 	div[1] at 'html[1]/body[1]/div[1]':
 		was deleted
 	div[2] at 'html[1]/body[1]/div[2]':
-		foo-1: expected="bar-1", actual="bar1"
-		foo-2: expected="bar-2", actual="bar2"
-		foo-3: expected="bar-3", actual="bar3"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar1"
+		foo-2:
+		  expected="bar-2",
+		    actual="bar2"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar3"
 	div[1] at 'html[1]/body[1]/div[2]/div[1]':
 		was deleted
 	div[2] at 'html[1]/body[1]/div[2]/div[2]':
-		foo-1: expected="bar-1", actual="bar1"
-		foo-2: expected="bar-2", actual="bar2"
-		foo-3: expected="bar-3", actual="bar3"
+		foo-1:
+		  expected="bar-1",
+		    actual="bar1"
+		foo-2:
+		  expected="bar-2",
+		    actual="bar2"
+		foo-3:
+		  expected="bar-3",
+		    actual="bar3"


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). --> https://github.com/retest/docs/pull/90

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> Improve readability of printed differences <!-- Please provide some short description here -->

This PR improves the readability of the printer outputs used by e.g. the CLI tool.

Output such as

```
foo-1: expected="bar-1", actual="bar-3"
```

will now be presented per line and aligned:

```
foo-1:
  expected="bar-1",
    actual="bar-3"
```
### State of this PR

done

<!-- If there is any work left (see above) or things to consider -->

### Additional Context

<!-- Add any other context, screenshots or minimal code example about the feature request here. Please check that you do not expose any secrets. -->