### PR TITLE
Feature/adapt element diff printer

### DIFF
--- a/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
+++ b/src/main/java/de/retest/recheck/printer/ElementDifferencePrinter.java
@@ -21,7 +21,7 @@ public class ElementDifferencePrinter implements Printer<ElementDifference> {
 
 	private String createDescription( final ElementDifference difference ) {
 		final IdentifyingAttributes attributes = difference.getIdentifyingAttributes();
-		return attributes + " at '" + attributes.getPath() + "':";
+		return attributes.getType() + " (" + difference.getElement() + ") at '" + attributes.getPath() + "':";
 	}
 
 	private String createDifferences( final ElementDifference difference, final String indent ) {

--- a/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
+++ b/src/test/java/de/retest/recheck/printer/ActionReplayResultPrinterTest.java
@@ -20,7 +20,7 @@ import de.retest.recheck.report.action.WindowRetriever;
 import de.retest.recheck.ui.Path;
 import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
-import de.retest.recheck.ui.descriptors.PathAttribute;
+import de.retest.recheck.ui.descriptors.MutableAttributes;
 import de.retest.recheck.ui.descriptors.RootElement;
 import de.retest.recheck.ui.descriptors.SutState;
 import de.retest.recheck.ui.diff.AttributeDifference;
@@ -45,8 +45,8 @@ class ActionReplayResultPrinterTest {
 	@Test
 	void toString_should_print_state_differences_if_no_meta_differences() {
 		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
-		when( identifyingAttributes.toString() ).thenReturn( "Identifying" );
 		when( identifyingAttributes.getPath() ).thenReturn( "path/to/element" );
+		when( identifyingAttributes.getType() ).thenReturn( "element" );
 
 		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
 		when( attributeDifference.getKey() ).thenReturn( "key" );
@@ -57,6 +57,9 @@ class ActionReplayResultPrinterTest {
 		when( rootDifference.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
 		when( rootDifference.hasAnyDifference() ).thenReturn( true );
 		when( rootDifference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
+		Element element = mock( Element.class );
+		when( element.toString() ).thenReturn( "retestId" );
+		when( rootDifference.getElement() ).thenReturn( element );
 
 		final RootElementDifference root = mock( RootElementDifference.class );
 		when( root.getElementDifference() ).thenReturn( rootDifference );
@@ -73,7 +76,7 @@ class ActionReplayResultPrinterTest {
 		final String string = cut.toString( result );
 
 		assertThat( string ).isEqualTo( "foo resulted in:\n" //
-				+ "\tIdentifying at 'path/to/element':\n" //
+				+ "\telement (retestId) at 'path/to/element':\n" //
 				+ "\t\tkey:" //
 				+ "\n\t\t  expected=\"expected\"," //
 				+ "\n\t\t    actual=\"actual\"" );
@@ -108,8 +111,8 @@ class ActionReplayResultPrinterTest {
 	@Test
 	void toString_should_print_meta_before_state_differences() throws Exception {
 		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
-		when( identifyingAttributes.toString() ).thenReturn( "Identifying" );
 		when( identifyingAttributes.getPath() ).thenReturn( "path/to/element" );
+		when( identifyingAttributes.getType() ).thenReturn( "element" );
 
 		final AttributeDifference attributeDifference = mock( AttributeDifference.class );
 		when( attributeDifference.getKey() ).thenReturn( "key" );
@@ -120,6 +123,10 @@ class ActionReplayResultPrinterTest {
 		when( rootDifference.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
 		when( rootDifference.hasAnyDifference() ).thenReturn( true );
 		when( rootDifference.getAttributeDifferences() ).thenReturn( Collections.singletonList( attributeDifference ) );
+		Element element = mock( Element.class );
+		when( element.toString() ).thenReturn( "retestId" );
+		when( rootDifference.getElement() ).thenReturn( element );
+
 
 		final RootElementDifference root = mock( RootElementDifference.class );
 		when( root.getElementDifference() ).thenReturn( rootDifference );
@@ -147,7 +154,7 @@ class ActionReplayResultPrinterTest {
 				+ "\t\tb:" //
 				+ "\n\t\t  expected=\"c\"," //
 				+ "\n\t\t    actual=\"d\"\n" //
-				+ "\tIdentifying at 'path/to/element':\n" //
+				+ "\telement (retestId) at 'path/to/element':\n" //
 				+ "\t\tkey:" //
 				+ "\n\t\t  expected=\"expected\"," //
 				+ "\n\t\t    actual=\"actual\"" );
@@ -235,14 +242,8 @@ class ActionReplayResultPrinterTest {
 
 	private Element element( final String pathAsString ) {
 		final Path path = Path.fromString( pathAsString );
-		final PathAttribute pathAttribute = new PathAttribute( path );
-
-		final IdentifyingAttributes identifyingAttributes = mock( IdentifyingAttributes.class );
-		when( identifyingAttributes.getPath() ).thenReturn( path.toString() );
-		when( identifyingAttributes.toString() ).thenReturn( path.getElement().toString() );
-
-		final Element element = mock( Element.class );
-		when( element.getIdentifyingAttributes() ).thenReturn( identifyingAttributes );
-		return element;
+		final IdentifyingAttributes identifyingAttributes = IdentifyingAttributes.create( path, "type" );
+		return Element.create( "retestId", mock( Element.class ), identifyingAttributes,
+				new MutableAttributes().immutable() );
 	}
 }

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
@@ -11,14 +11,14 @@ check resulted in:
 		os.version:
 		  expected="null",
 		    actual="4.4.0-101-generic"
-	test [test] at 'foo[1]/bar[1]':
+	test (title) at 'foo[1]/bar[1]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar-3"
 		foo-3:
 		  expected="bar-3",
 		    actual="bar-1"
-	same [same] at 'foo[1]/bar[1]/same[1]':
+	same (same-id) at 'foo[1]/bar[1]/same[1]':
 		bar-1:
 		  expected="bar-1",
 		    actual="bar-1-change"
@@ -34,7 +34,7 @@ check resulted in:
 		bar-3-change:
 		  expected="(default or absent)",
 		    actual="bar-3"
-	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
+	delete (delete-id) at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
-	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+	insert (insert-id) at 'foo[1]/bar[1]/add[1]/insert[1]':
 		was inserted

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
@@ -11,14 +11,14 @@ check resulted in:
 		os.version:
 		  expected="null",
 		    actual="4.4.0-101-generic"
-	test [test] at 'foo[1]/bar[1]':
+	test (title) at 'foo[1]/bar[1]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar-3"
 		foo-3:
 		  expected="bar-3",
 		    actual="bar-1"
-	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
+	delete (delete-id) at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
-	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+	insert (insert-id) at 'foo[1]/bar[1]/add[1]/insert[1]':
 		was inserted

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_with_deleted_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_with_deleted_filtered.approved.txt
@@ -11,14 +11,14 @@ check resulted in:
 		os.version:
 		  expected="null",
 		    actual="4.4.0-101-generic"
-	test [test] at 'foo[1]/bar[1]':
+	test (title) at 'foo[1]/bar[1]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar-3"
 		foo-3:
 		  expected="bar-3",
 		    actual="bar-1"
-	same [same] at 'foo[1]/bar[1]/same[1]':
+	same (same-id) at 'foo[1]/bar[1]/same[1]':
 		bar-1:
 		  expected="bar-1",
 		    actual="bar-1-change"
@@ -34,5 +34,5 @@ check resulted in:
 		bar-3-change:
 		  expected="(default or absent)",
 		    actual="bar-3"
-	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+	insert (insert-id) at 'foo[1]/bar[1]/add[1]/insert[1]':
 		was inserted

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
@@ -11,14 +11,14 @@ check resulted in:
 		os.version:
 		  expected="null",
 		    actual="4.4.0-101-generic"
-	test [test] at 'foo[1]/bar[1]':
+	test (title) at 'foo[1]/bar[1]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar-3"
 		foo-3:
 		  expected="bar-3",
 		    actual="bar-1"
-	same [same] at 'foo[1]/bar[1]/same[1]':
+	same (same-id) at 'foo[1]/bar[1]/same[1]':
 		bar-1:
 		  expected="bar-1",
 		    actual="bar-1-change"
@@ -34,7 +34,7 @@ check resulted in:
 		bar-3-change:
 		  expected="(default or absent)",
 		    actual="bar-3"
-	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
+	delete (delete-id) at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
-	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+	insert (insert-id) at 'foo[1]/bar[1]/add[1]/insert[1]':
 		was inserted

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
@@ -11,14 +11,14 @@ check resulted in:
 		os.version:
 		  expected="null",
 		    actual="4.4.0-101-generic"
-	test [test] at 'foo[1]/bar[1]':
+	test (title) at 'foo[1]/bar[1]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar-3"
 		foo-3:
 		  expected="bar-3",
 		    actual="bar-1"
-	same [same] at 'foo[1]/bar[1]/same[1]':
+	same (same-id) at 'foo[1]/bar[1]/same[1]':
 		bar-1:
 		  expected="bar-1",
 		    actual="bar-1-change"
@@ -34,7 +34,7 @@ check resulted in:
 		bar-3-change:
 		  expected="(default or absent)",
 		    actual="bar-3"
-	delete [delete] at 'foo[1]/bar[1]/remove[1]/delete[1]':
+	delete (delete-id) at 'foo[1]/bar[1]/remove[1]/delete[1]':
 		was deleted
-	insert [insert] at 'foo[1]/bar[1]/add[1]/insert[1]':
+	insert (insert-id) at 'foo[1]/bar[1]/add[1]/insert[1]':
 		was inserted

--- a/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
+++ b/src/test/resources/de/retest/recheck/printer/ActionReplayResultPrinterTest.toString_should_not_print_child_differences_if_insertion_or_deletion.approved.txt
@@ -1,5 +1,5 @@
 Start Sut resulted in:
-	body[1] at 'html[1]/body[1]':
+	type (retestId) at 'html[1]/body[1]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar1"
@@ -9,9 +9,9 @@ Start Sut resulted in:
 		foo-3:
 		  expected="bar-3",
 		    actual="bar3"
-	div[1] at 'html[1]/body[1]/div[1]':
+	type (retestId) at 'html[1]/body[1]/div[1]':
 		was deleted
-	div[2] at 'html[1]/body[1]/div[2]':
+	type (retestId) at 'html[1]/body[1]/div[2]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar1"
@@ -21,9 +21,9 @@ Start Sut resulted in:
 		foo-3:
 		  expected="bar-3",
 		    actual="bar3"
-	div[1] at 'html[1]/body[1]/div[2]/div[1]':
+	type (retestId) at 'html[1]/body[1]/div[2]/div[1]':
 		was deleted
-	div[2] at 'html[1]/body[1]/div[2]/div[2]':
+	type (retestId) at 'html[1]/body[1]/div[2]/div[2]':
 		foo-1:
 		  expected="bar-1",
 		    actual="bar1"


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

This is essentially a fix for another PR, changing the `toString` methods.