### PR TITLE
Feature/name in retest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Table of Contents
 
 * File names in log output should now always be in single quotes, making it easier to distinguish and select them.
 * Printer layout is improved (in `MetadataDifferencePrinter` and `AttributeDifferencePrinter`). Differences will now be printed per line and aligned for easier comparison.
+* Prefer the text over the ID in the default recheckId provider, because the ID is often generated, the text never is.
 
 
 --------------------------------------------------------------------------------

--- a/src/main/java/de/retest/recheck/ui/descriptors/idproviders/AbstractFirstNonNullRetestIdProvider.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/idproviders/AbstractFirstNonNullRetestIdProvider.java
@@ -19,8 +19,9 @@ abstract class AbstractFirstNonNullRetestIdProvider implements RetestIdProvider 
 		}
 		final String htmlId = normalizeAndCut( identifyingAttributes.get( "id" ) );
 		final String text = normalizeAndCut( identifyingAttributes.get( "text" ) );
+		final String name = normalizeAndCut( identifyingAttributes.get( "name" ) );
 		final String type = normalizeAndCut( cutTypeQualifier( identifyingAttributes.get( "type" ) ) );
-		final String id = returnFirstNonBlank( htmlId, text, type, randomUUID().toString() );
+		final String id = returnFirstNonBlank( htmlId, text, name, type, randomUUID().toString() );
 		return makeUnique( id );
 	}
 

--- a/src/main/java/de/retest/recheck/ui/descriptors/idproviders/AbstractFirstNonNullRetestIdProvider.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/idproviders/AbstractFirstNonNullRetestIdProvider.java
@@ -17,11 +17,11 @@ abstract class AbstractFirstNonNullRetestIdProvider implements RetestIdProvider 
 		if ( identifyingAttributes == null ) {
 			throw new NullPointerException( "Identifying attributes must not be null." );
 		}
-		final String htmlId = normalizeAndCut( identifyingAttributes.get( "id" ) );
 		final String text = normalizeAndCut( identifyingAttributes.get( "text" ) );
+		final String htmlId = normalizeAndCut( identifyingAttributes.get( "id" ) );
 		final String name = normalizeAndCut( identifyingAttributes.get( "name" ) );
 		final String type = normalizeAndCut( cutTypeQualifier( identifyingAttributes.get( "type" ) ) );
-		final String id = returnFirstNonBlank( htmlId, text, name, type, randomUUID().toString() );
+		final String id = returnFirstNonBlank( text, htmlId, name, type, randomUUID().toString() );
 		return makeUnique( id );
 	}
 

--- a/src/test/java/de/retest/recheck/ui/descriptors/idproviders/DefaultRetestIdProviderTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/idproviders/DefaultRetestIdProviderTest.java
@@ -37,6 +37,7 @@ class DefaultRetestIdProviderTest {
 
 		// and cut should still be unique!
 		assertThat( retestId ).isNotEqualTo( cut.getRetestId( ident ) );
+		assertThat( retestId ).isEqualTo( "this_is_some" );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/ui/descriptors/idproviders/DefaultRetestIdProviderTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/idproviders/DefaultRetestIdProviderTest.java
@@ -41,6 +41,28 @@ class DefaultRetestIdProviderTest {
 	}
 
 	@Test
+	void should_prefer_text_over_id_over_name_over_type() {
+		IdentifyingAttributes ident = mock( IdentifyingAttributes.class );
+		when( ident.get( "text" ) ).thenReturn( "My Text" );
+		when( ident.get( "id" ) ).thenReturn( "My ID" );
+		when( ident.get( "name" ) ).thenReturn( "My Name" );
+		when( ident.get( "type" ) ).thenReturn( "My Type" );
+		assertThat( cut.getRetestId( ident ) ).isEqualTo( "my_text" );
+
+		when( ident.get( "text" ) ).thenReturn( null );
+		assertThat( cut.getRetestId( ident ) ).isEqualTo( "my_id" );
+
+		when( ident.get( "id" ) ).thenReturn( null );
+		assertThat( cut.getRetestId( ident ) ).isEqualTo( "my_name" );
+
+		when( ident.get( "name" ) ).thenReturn( null );
+		assertThat( cut.getRetestId( ident ) ).isEqualTo( "my_type" );
+
+		when( ident.get( "name" ) ).thenReturn( null );
+		assertThat( cut.getRetestId( ident ) ).isNotNull();
+	}
+
+	@Test
 	void too_long_words_should_be_cut() {
 		// but also for single words
 		final IdentifyingAttributes ident = createIdentAttributes( "supercalifragilisticexpialidocious" );


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

I suggested the retestId is a better indicator of the element than the XPath ... time to correct the implementation to make this actually true :-|

As the CHANGELOG says: the ID is often generated, the text is not, so also prefer text over ID.