### PR TITLE
Fix/import filter

### DIFF
--- a/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
+++ b/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
@@ -158,8 +158,8 @@ public class SearchFilterFiles {
 	}
 
 	public static Filter getFilterByName( final String name ) {
-		final Filter filter = toFileNameFilterMapping().get( name );
-		if ( filter == null ) {
+		final FilterLoader loader = toFileLoaderMapping().get( name );
+		if ( loader == null ) {
 			throw ProjectConfiguration.getInstance().getProjectConfigFolder() //
 					.map( path -> path.resolve( FILTER_DIR_NAME ) ) //
 					.map( Path::toAbsolutePath ) //
@@ -167,6 +167,6 @@ public class SearchFilterFiles {
 					.map( s -> new FilterNotFoundException( name, s ) )
 					.orElseGet( () -> new FilterNotFoundException( name ) );
 		}
-		return filter;
+		return loadSilently( loader, name );
 	}
 }

--- a/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
+++ b/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -150,12 +149,12 @@ public class SearchFilterFiles {
 	public static Filter getFilterByName( final String name ) {
 		final Filter filter = toFileNameFilterMapping().get( name );
 		if ( filter == null ) {
-			final Optional<String> projectFilterDir = ProjectConfiguration.getInstance().getProjectConfigFolder() //
+			throw ProjectConfiguration.getInstance().getProjectConfigFolder() //
 					.map( path -> path.resolve( FILTER_DIR_NAME ) ) //
 					.map( Path::toAbsolutePath ) //
-					.map( Path::toString );
-			throw projectFilterDir.isPresent() ? new FilterNotFoundException( name, projectFilterDir.get() )
-					: new FilterNotFoundException( name );
+					.map( Path::toString ) //
+					.map( s -> new FilterNotFoundException( name, s ) )
+					.orElseGet( () -> new FilterNotFoundException( name ) );
 		}
 		return filter;
 	}


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

## Description

> TL;DR Fix importing filters not being able to load

### Problem

This should fix importing filters via:

```properties
# custom.filter
import: positioning.filter
```

The `ImportExternalFilterLoader` (which is associated with this line) will load `custom.filter` and try to call `SearchFilterFiles.getFilterByName( "positioning.filter" );`. This loads all filters again, which include `custom.filter` and then would load the `InternalFilterLoader`, ... -> infinite loop.

### Fix

The method `SearchFilterFiles#getFilterByName` will now only load the filters that match the name, resulting either in an empty or a single entry map. This is done by not directly loading the filters, i.e. keeping the `FilterLoader` and picking only the filters that match the name specified.

### State of this PR

I do not like this this approach and fix 100%, but it works for now. 