### PR TITLE
Feature/fix change set applier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Table of Contents
 ### Bug Fixes
 
 * Fixed a java.lang.ClassCastException: de.retest.recheck.ui.diff.InsertedDeletedElementDifference cannot be cast to de.retest.recheck.ui.diff.IdentifyingAttributesDifference.
+* Fix similar differences between checks not being accepted together, bringing back 1-click-maintenance.
 
 ### New Features
 

--- a/src/main/java/de/retest/recheck/SuiteAggregator.java
+++ b/src/main/java/de/retest/recheck/SuiteAggregator.java
@@ -19,6 +19,13 @@ public class SuiteAggregator {
 		return instance;
 	}
 
+	/**
+	 * Must only be called from a test
+	 */
+	public static void reset() {
+		instance = null;
+	}
+
 	static SuiteAggregator getTestInstance() {
 		return new SuiteAggregator();
 	}

--- a/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
@@ -44,8 +44,11 @@ public class GlobalChangeSetApplier {
 
 	// Replay result lookup maps.
 
+	@Getter( AccessLevel.PACKAGE )
 	private final Multimap<ImmutablePair<IdentifyingAttributes, AttributeDifference>, ActionReplayResult> attributeDiffsLookupMap;
+	@Getter( AccessLevel.PACKAGE )
 	private final Multimap<Element, ActionReplayResult> insertedDiffsLookupMap;
+	@Getter( AccessLevel.PACKAGE )
 	private final Multimap<IdentifyingAttributes, ActionReplayResult> deletedDiffsLookupMap;
 
 	private void fillReplayResultLookupMaps( final TestReport testReport ) {

--- a/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
@@ -19,6 +19,8 @@ import de.retest.recheck.ui.diff.AttributeDifference;
 import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
 import de.retest.recheck.ui.review.ActionChangeSet;
+import lombok.AccessLevel;
+import lombok.Getter;
 
 public class GlobalChangeSetApplier {
 
@@ -45,11 +47,11 @@ public class GlobalChangeSetApplier {
 	// Replay result lookup maps.
 
 	@Getter( AccessLevel.PACKAGE )
-	private final Multimap<ImmutablePair<IdentifyingAttributes, AttributeDifference>, ActionReplayResult> attributeDiffsLookupMap;
+	private final Multimap<ImmutablePair<String, String>, ActionReplayResult> attributeDiffsLookupMap;
 	@Getter( AccessLevel.PACKAGE )
-	private final Multimap<Element, ActionReplayResult> insertedDiffsLookupMap;
+	private final Multimap<String, ActionReplayResult> insertedDiffsLookupMap;
 	@Getter( AccessLevel.PACKAGE )
-	private final Multimap<IdentifyingAttributes, ActionReplayResult> deletedDiffsLookupMap;
+	private final Multimap<String, ActionReplayResult> deletedDiffsLookupMap;
 
 	private void fillReplayResultLookupMaps( final TestReport testReport ) {
 		testReport.getSuiteReplayResults().stream() //
@@ -73,9 +75,9 @@ public class GlobalChangeSetApplier {
 		final InsertedDeletedElementDifference insertedDeletedElementDiff =
 				(InsertedDeletedElementDifference) elementDiff.getIdentifyingAttributesDifference();
 		if ( insertedDeletedElementDiff.isInserted() ) {
-			insertedDiffsLookupMap.put( insertedDeletedElementDiff.getActual(), actionReplayResult );
+			insertedDiffsLookupMap.put( identifier( insertedDeletedElementDiff.getActual() ), actionReplayResult );
 		} else {
-			deletedDiffsLookupMap.put( elementDiff.getIdentifyingAttributes(), actionReplayResult );
+			deletedDiffsLookupMap.put( identifier( elementDiff.getIdentifyingAttributes() ), actionReplayResult );
 		}
 	}
 
@@ -83,14 +85,16 @@ public class GlobalChangeSetApplier {
 			final ElementDifference elementDiff ) {
 		final IdentifyingAttributes identifyingAttributes = elementDiff.getIdentifyingAttributes();
 		for ( final AttributeDifference attributeDifference : elementDiff.getAttributeDifferences() ) {
-			attributeDiffsLookupMap.put( ImmutablePair.of( identifyingAttributes, attributeDifference ),
+			attributeDiffsLookupMap.put(
+					ImmutablePair.of( identifier( identifyingAttributes ), identifier( attributeDifference ) ),
 					actionReplayResult );
 		}
 	}
 
 	private Collection<ActionReplayResult> findAllActionResultsWithEqualDifferences(
 			final IdentifyingAttributes identifyingAttributes, final AttributeDifference attributeDifference ) {
-		return attributeDiffsLookupMap.get( ImmutablePair.of( identifyingAttributes, attributeDifference ) );
+		return attributeDiffsLookupMap
+				.get( ImmutablePair.of( identifier( identifyingAttributes ), identifier( attributeDifference ) ) );
 	}
 
 	private ActionChangeSet findCorrespondingActionChangeSet( final ActionReplayResult actionReplayResult ) {
@@ -155,31 +159,42 @@ public class GlobalChangeSetApplier {
 	// Add/remove inserted/deleted differences.
 
 	public void addChangeSetForAllEqualInsertedChanges( final Element inserted ) {
-		for ( final ActionReplayResult replayResult : insertedDiffsLookupMap.get( inserted ) ) {
+		for ( final ActionReplayResult replayResult : insertedDiffsLookupMap.get( identifier( inserted ) ) ) {
 			findCorrespondingActionChangeSet( replayResult ).addInsertChange( inserted );
 		}
 		counter.add();
 	}
 
 	public void addChangeSetForAllEqualDeletedChanges( final IdentifyingAttributes deleted ) {
-		for ( final ActionReplayResult replayResult : deletedDiffsLookupMap.get( deleted ) ) {
+		for ( final ActionReplayResult replayResult : deletedDiffsLookupMap.get( identifier( deleted ) ) ) {
 			findCorrespondingActionChangeSet( replayResult ).addDeletedChange( deleted );
 		}
 		counter.add();
 	}
 
 	public void removeChangeSetForAllEqualInsertedChanges( final Element inserted ) {
-		for ( final ActionReplayResult replayResult : insertedDiffsLookupMap.get( inserted ) ) {
+		for ( final ActionReplayResult replayResult : insertedDiffsLookupMap.get( identifier( inserted ) ) ) {
 			findCorrespondingActionChangeSet( replayResult ).removeInsertChange( inserted );
 		}
 		counter.remove();
 	}
 
 	public void removeChangeSetForAllEqualDeletedChanges( final IdentifyingAttributes deleted ) {
-		for ( final ActionReplayResult replayResult : deletedDiffsLookupMap.get( deleted ) ) {
+		for ( final ActionReplayResult replayResult : deletedDiffsLookupMap.get( identifier( deleted ) ) ) {
 			findCorrespondingActionChangeSet( replayResult ).removeDeletedChange( deleted );
 		}
 		counter.remove();
 	}
 
+	private String identifier( final Element element ) {
+		return identifier( element.getIdentifyingAttributes() );
+	}
+
+	private String identifier( final IdentifyingAttributes attributes ) {
+		return attributes.identifier();
+	}
+
+	private String identifier( final AttributeDifference difference ) {
+		return difference.identifier();
+	}
 }

--- a/src/test/java/de/retest/recheck/review/GlobalChangeSetApplierIT.java
+++ b/src/test/java/de/retest/recheck/review/GlobalChangeSetApplierIT.java
@@ -1,0 +1,193 @@
+package de.retest.recheck.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Rectangle;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.retest.recheck.Recheck;
+import de.retest.recheck.RecheckAdapter;
+import de.retest.recheck.RecheckImpl;
+import de.retest.recheck.RecheckOptions;
+import de.retest.recheck.SuiteAggregator;
+import de.retest.recheck.persistence.SeparatePathsProjectLayout;
+import de.retest.recheck.report.TestReport;
+import de.retest.recheck.ui.DefaultValueFinder;
+import de.retest.recheck.ui.PathElement;
+import de.retest.recheck.ui.descriptors.Attribute;
+import de.retest.recheck.ui.descriptors.Attributes;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.MutableAttributes;
+import de.retest.recheck.ui.descriptors.OutlineAttribute;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.StringAttribute;
+
+class GlobalChangeSetApplierIT {
+
+	GlobalChangeSetApplier cut;
+
+	@BeforeEach
+	void setUp( @TempDir final Path root ) throws Exception {
+		SuiteAggregator.reset();
+
+		Files.createDirectory( root.resolve( ".retest" ) );
+
+		final RecheckAdapter adapter = new RootElementRecheckAdapter();
+
+		final Recheck re = new RecheckImpl( RecheckOptions.builder() //
+				.suiteName( "TemplateTest" ) //
+				.projectLayout( new SeparatePathsProjectLayout( root.resolve( "states" ), root.resolve( "reports" ) ) ) //
+				.build() );
+
+		// Create first step to create the Golden Masters 
+
+		re.startTest( "large" );
+		re.check( expected( 1200, 800 ), adapter, "page" );
+		capTest( re );
+
+		re.startTest( "small" );
+		re.check( expected( 800, 400 ), adapter, "page" );
+		capTest( re );
+
+		// Create second step with slight pixel differences to force the identifying attributes to contain differences
+
+		re.startTest( "large" );
+		re.check( actual( 1190, 795 ), adapter, "page" );
+		capTest( re );
+
+		re.startTest( "small" );
+		re.check( actual( 750, 390 ), adapter, "page" );
+		capTest( re );
+
+		re.cap();
+
+		final TestReport report = SuiteAggregator.getInstance().getAggregatedTestReport();
+		cut = GlobalChangeSetApplier.create( report );
+	}
+
+	@Test
+	void lookups_should_ignore_outline_changes() {
+		// Differences:
+		// html[1]/body[1]/div[1]
+		// - outline: expected="[0,0,300,200]", actual="[0,0,297,198]" (large)
+		// - outline: expected="[0,0,200,100]", actual="[0,0,187,97]" (small)
+		// - align-self: expected="", actual="flex-start" (large, small)
+		assertThat( cut.getAttributeDiffsLookupMap().asMap() ).hasSize( 3 );
+
+		// Inserted:
+		// html[1] (large, small)
+		assertThat( cut.getInsertedDiffsLookupMap().asMap() ).hasSize( 1 );
+
+		// Deleted:
+		// html[1]/body[1]/span[1] (large, small)
+		assertThat( cut.getDeletedDiffsLookupMap().asMap() ).hasSize( 1 );
+	}
+
+	private void capTest( final Recheck re ) {
+		try {
+			re.capTest();
+		} catch ( final AssertionError error ) {
+			// Ignore
+		}
+	}
+
+	private RootElement expected( final int width, final int height ) {
+		final RootElement html = html();
+		final Element body = body( html );
+		final Element div = div( body, 1, width, height, attributes( "align-self", "" ) );
+		final Element span = span( body, 1, width, height, new Attributes() );
+
+		html.addChildren( body );
+		body.addChildren( div, span );
+
+		return html;
+	}
+
+	private RootElement actual( final int width, final int height ) {
+		final RootElement html = html();
+		final Element body = body( html );
+		final Element div = div( body, 1, width, height, attributes( "align-self", "flex-start" ) );
+
+		html.addChildren( body );
+		body.addChildren( div );
+
+		return html;
+	}
+
+	private RootElement html() {
+		return new RootElement( "html", id( path( "html", 1 ) ), new Attributes(), null, "screen", 0, "title" );
+	}
+
+	private Element body( final Element parent ) {
+		return Element.create( "div", parent, id( path( parent, "body", 1 ) ), new Attributes() );
+	}
+
+	private Element div( final Element parent, final int suffix, final int width, final int height,
+			final Attributes attributes ) {
+		return Element.create( "div", parent, id( path( parent, "div", suffix ), //
+				OutlineAttribute.createAbsolute( new Rectangle( width / 2, height / 2, width / 4, height / 4 ) ), //
+				OutlineAttribute.create( new Rectangle( 0, 0, width / 4, height / 4 ) ), //
+				new StringAttribute( "class", "md-sidebar md-sidebar--primary" ) // 
+		), attributes );
+	}
+
+	private Element span( final Element parent, final int suffix, final int width, final int height,
+			final Attributes attributes ) {
+		return Element.create( "span", parent, id( path( parent, "span", suffix ), //
+				OutlineAttribute.createAbsolute( new Rectangle( 0, height / 2, width / 2, height / 4 ) ), //
+				OutlineAttribute.create( new Rectangle( 0, 0, width / 4, height / 4 ) ) //
+		), attributes );
+	}
+
+	private IdentifyingAttributes id( final de.retest.recheck.ui.Path path, final Attribute... attributes ) {
+		return new IdentifyingAttributes( Stream.concat( // 
+				IdentifyingAttributes.createList( path, path.getElement().getElementName() ).stream(), //
+				Stream.of( attributes ) //
+		).collect( Collectors.toList() ) );
+	}
+
+	private de.retest.recheck.ui.Path path( final String type, final int suffix ) {
+		return de.retest.recheck.ui.Path.path( new PathElement( type, suffix ) );
+	}
+
+	private de.retest.recheck.ui.Path path( final Element parent, final String type, final int suffix ) {
+		return de.retest.recheck.ui.Path.path( parent.getIdentifyingAttributes().getPathTyped(),
+				new PathElement( type, suffix ) );
+	}
+
+	private Attributes attributes( final String... entries ) {
+		final MutableAttributes attributes = new MutableAttributes();
+		for ( int i = 0; i < entries.length; i += 2 ) {
+			attributes.put( entries[i], entries[i + 1] );
+		}
+		return attributes.immutable();
+	}
+
+	private static class RootElementRecheckAdapter implements RecheckAdapter {
+
+		@Override
+		public boolean canCheck( final Object toCheck ) {
+			return toCheck instanceof RootElement;
+		}
+
+		@Override
+		public Set<RootElement> convert( final Object toCheck ) {
+			return Collections.singleton( (RootElement) toCheck );
+		}
+
+		@Override
+		public DefaultValueFinder getDefaultValueFinder() {
+			return ( identifyingAttributes, attributeKey, attributeValue ) -> false;
+		}
+	}
+}


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

# Description

> TLDR; Fix that "equal" changes are not accepted together. This brings back the 1-click maintenance.

## Bug

This especially noticeable, when testing the same website multiple times (different browsers, screen resolutions, etc.). Because the same site is tested multiple times, the same differences will occur within the different tests. The example below shows a test performed with two different screen resolutions, executed twice to account for the Golden Master creation.

```
Suite 'TemplateTest' has 6 difference(s) in 4 test(s):
	Test 'large' has 1 difference(s) in 1 state(s):
	page resulted in:
		No Golden Master found. First time test was run? Created new Golden Master, so don't forget to commit...
	Test 'small' has 1 difference(s) in 1 state(s):
	page resulted in:
		No Golden Master found. First time test was run? Created new Golden Master, so don't forget to commit...
	Test 'large' has 3 difference(s) in 1 state(s):
	page resulted in:
		div (div) at 'html[1]/body[1]/div[1]':
			outline:
			  expected="java.awt.Rectangle[x=0,y=0,width=300,height=200]",
			    actual="java.awt.Rectangle[x=0,y=0,width=297,height=198]"
			align-self:
			  expected="",
			    actual="flex-start"
		span (span) at 'html[1]/body[1]/span[1]':
			was deleted
	Test 'small' has 3 difference(s) in 1 state(s):
	page resulted in:
		div (div) at 'html[1]/body[1]/div[1]':
			outline:
			  expected="java.awt.Rectangle[x=0,y=0,width=200,height=100]",
			    actual="java.awt.Rectangle[x=0,y=0,width=187,height=97]"
			align-self:
			  expected="",
			    actual="flex-start"
		span (span) at 'html[1]/body[1]/span[1]':
			was deleted
```

These changes are present twice and thus are expected to be accepted with a single method call:
```
div (div) at 'html[1]/body[1]/div[1]':
    align-self:
        expected="",
        actual="flex-start"
span (span) at 'html[1]/body[1]/span[1]':
    was deleted
```

However, when accepting this within review, each change has to be accepted individually to be counted for the model and accepted into the Golden Master.

*Note that review (develop) already uses a similar technique to identify similar changes, which are not propagated properly to the `GlobalChangeSetApplier` because of this bug.*

## Workaround

Instead of using the `hashCode`, use the reduced `identifier` methods of both `IdentifyingAttributes` and `AttributeDifferences` to only take into account important attributes. The former therefore will only take the `path`, `type` and `suffix` attribute, while the latter will only take `actual` and `expected` attributes. We might want to change this in the future, but it seems to work for now.

I would consider this more of a workaround, since per definition all `IdentifyingAttributes` should only hold stable attributes. Therefore I would consider implementing retest/recheck-web#200, but that might be a major breaking change.

## Test

To have a test as close to the actual behavior, I introduced an integration test. Since manually putting together a report is cumbersome and we do not have a migration strategy for file based reports to load from, the integration test performs a full recheck lifecycle using the example above to create a report.

Since we are collecting the report within a separate class `SuiteAggregator` it has to be reset before the test begins to prevent other tests to contribute differences to the report. I am aware that this is not a clean solution as it relies on side effects due to the usage of static singletons. However, alternative solutions would be either introducing a new constructor that takes such a `SuiteAggregator` or exposing the current test report from `RecheckImpl` which both then would be public API. If the current solution does not suit you, I would be in favor of exposing the current report as that would be the lowest impact.

Due to the broken down identifier methods, the contents of the various lookup methods cannot be compared anymore. Therefore I decided to only use simple `hasSize`-checks to test for the validity of the generated lookup tables, as all other possible checks (e.g. accepting changes) seemed to be very cumbersome to properly check.

*This has been verified manually that it works with review*