### PR TITLE
Feature/metadata filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Table of Contents
 
 ### New Features
 
-* Metadata differences are now filterable via the recheck.ignore.
+* Metadata differences are now filterable via the recheck.ignore. A new `metadata.filter` has been added which can be imported with `import: metadata.filter` in `recheck.ignore`.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Table of Contents
 
 ### Bug Fixes
 
+* Fix a rare `java.nio.file.FileSystemAlreadyExistsException` when accessing filters concurrently.
+
 ### New Features
 
 * Metadata differences are now filterable via the recheck.ignore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Table of Contents
 
 ### New Features
 
+* Metadata differences are now filterable via the recheck.ignore.
+
 ### Improvements
 
 

--- a/src/main/java/de/retest/recheck/ignore/FilterLoader.java
+++ b/src/main/java/de/retest/recheck/ignore/FilterLoader.java
@@ -3,11 +3,27 @@ package de.retest.recheck.ignore;
 import static de.retest.recheck.ignore.SearchFilterFiles.FILTER_JS_EXTENSION;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+
+import org.apache.commons.io.IOUtils;
 
 public interface FilterLoader {
 
 	Filter load() throws IOException;
+
+	static FilterLoader loadResource( final String path ) {
+		return () -> {
+			try ( final InputStream stream = FilterLoader.class.getResourceAsStream( path ) ) {
+				if ( stream == null ) {
+					throw new NoSuchFileException( path );
+				}
+				return Filters.parse( IOUtils.readLines( stream, StandardCharsets.UTF_8 ) );
+			}
+		};
+	}
 
 	static FilterLoader load( final Path path ) {
 		if ( path.toString().toLowerCase().endsWith( FILTER_JS_EXTENSION ) ) {

--- a/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
+++ b/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
@@ -3,11 +3,6 @@ package de.retest.recheck.ignore;
 import static de.retest.recheck.RecheckProperties.RETEST_FOLDER_NAME;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URL;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -16,7 +11,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -43,36 +37,13 @@ public class SearchFilterFiles {
 	 */
 	public static List<Pair<String, FilterLoader>> getDefaultFilterFiles() {
 		return defaultWebFilter.stream() //
-				.map( SearchFilterFiles::getWebFilterResource ) //
-				.filter( Objects::nonNull ) //
-				.map( SearchFilterFiles::loadFilterFromUrl ) //
-				.filter( Objects::nonNull ) //
+				.map( SearchFilterFiles::loadFilterFromResource ) //
 				.collect( Collectors.toList() );
 	}
 
-	private static URL getWebFilterResource( final String webFilterName ) {
-		final String webFilterResource = "/" + WEB_FILTER_DIR_PATH + "/" + webFilterName;
-		return SearchFilterFiles.class.getResource( webFilterResource );
-	}
-
-	private static Pair<String, FilterLoader> loadFilterFromUrl( final URL url ) {
-		final URI uri = URI.create( url.toExternalForm() );
-		try {
-			final Path path = Paths.get( uri );
-			return Pair.of( getFileName( path ), FilterLoader.load( path ) );
-		} catch ( final FileSystemNotFoundException e ) {
-			return createFileSystemAndLoadFilter( uri );
-		}
-	}
-
-	private static Pair<String, FilterLoader> createFileSystemAndLoadFilter( final URI uri ) {
-		try ( final FileSystem fs = FileSystems.newFileSystem( uri, Collections.emptyMap() ) ) {
-			final Path path = fs.provider().getPath( uri );
-			return Pair.of( getFileName( path ), FilterLoader.provide( path ) );
-		} catch ( final IOException e ) {
-			log.error( "Could not load filter at '{}'", uri, e );
-			return null;
-		}
+	private static Pair<String, FilterLoader> loadFilterFromResource( final String resource ) {
+		final String resolvedResource = "/" + WEB_FILTER_DIR_PATH + "/" + resource;
+		return Pair.of( resource, FilterLoader.loadResource( resolvedResource ) );
 	}
 
 	/**

--- a/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
+++ b/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
@@ -37,7 +37,9 @@ public class SearchFilterFiles {
 			FilterResource.prefix( WEB_CATEGORY, "content.filter" ), //
 			FilterResource.prefix( WEB_CATEGORY, "invisible-attributes.filter" ), //
 			FilterResource.prefix( WEB_CATEGORY, "positioning.filter" ), //
-			FilterResource.prefix( WEB_CATEGORY, "style-attributes.filter" ) //
+			FilterResource.prefix( WEB_CATEGORY, "style-attributes.filter" ), //
+
+			FilterResource.absolute( "metadata.filter" ) //
 	) //
 			.map( FilterResource::loader ) //
 			.collect( Collectors.toList() );

--- a/src/main/java/de/retest/recheck/report/MetadataDifferenceFilter.java
+++ b/src/main/java/de/retest/recheck/report/MetadataDifferenceFilter.java
@@ -3,34 +3,36 @@ package de.retest.recheck.report;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toSet;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import de.retest.recheck.meta.global.GitMetadataProvider;
-import de.retest.recheck.meta.global.MachineMetadataProvider;
-import de.retest.recheck.meta.global.OSMetadataProvider;
-import de.retest.recheck.meta.global.TimeMetadataProvider;
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.descriptors.Attributes;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.diff.AttributeDifference;
 import de.retest.recheck.ui.diff.meta.MetadataDifference;
+import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class MetadataDifferenceFilter {
 
-	private static final Set<String> differencesToIgnore = new HashSet<>( Arrays.asList( //
-			GitMetadataProvider.VCS_NAME, //
-			GitMetadataProvider.BRANCH_NAME, //
-			GitMetadataProvider.COMMIT_NAME, //
-			MachineMetadataProvider.MACHINE_NAME, //
-			OSMetadataProvider.OS_ARCH, //
-			TimeMetadataProvider.DATE, //
-			TimeMetadataProvider.TIME, //
-			TimeMetadataProvider.ZONE, //
-			TimeMetadataProvider.OFFSET //
-	) );
+	private static final Element DUMMY_ELEMENT = new RootElement( "recheck-metadata",
+			IdentifyingAttributes.create( Path.fromString( "recheck/metadata" ), "metadata" ), new Attributes(), null,
+			"0", 0, "0" );
 
-	public MetadataDifference filter( final MetadataDifference metadataDifference ) {
+	public MetadataDifference filter( final MetadataDifference metadataDifference, final Filter filter ) {
 		return metadataDifference.getDifferences().stream() //
-				.filter( diff -> !differencesToIgnore.contains( diff.getKey() ) ) //
+				.filter( diff -> !filter( filter, diff ) ) //
 				.collect( collectingAndThen( toSet(), MetadataDifference::of ) );
 	}
 
+	private boolean filter( final Filter filter, final MetadataElementDifference diff ) {
+		return filter.matches( DUMMY_ELEMENT, diff.getKey() ) // 
+				|| filter.matches( DUMMY_ELEMENT, toAttributeDifference( diff ) );
+	}
+
+	private AttributeDifference toAttributeDifference( final MetadataElementDifference diff ) {
+		return new AttributeDifference( diff.getKey(), diff.getExpected(), diff.getActual() );
+	}
 }

--- a/src/main/java/de/retest/recheck/report/TestReportFilter.java
+++ b/src/main/java/de/retest/recheck/report/TestReportFilter.java
@@ -70,7 +70,7 @@ public class TestReportFilter {
 				actionReplayResult.getTargetComponent(), actionReplayResult.getGoldenMasterPath() );
 		final StateDifference newStateDiff = filter( actionReplayResult.getStateDifference() );
 		final MetadataDifference newMetadataDiff =
-				metadataDiffFilter.filter( actionReplayResult.getMetadataDifference() );
+				metadataDiffFilter.filter( actionReplayResult.getMetadataDifference(), filter );
 		final long actualDuration = actionReplayResult.getDuration();
 
 		return ActionReplayResult.withDifference( data, actionReplayResult::getWindows,
@@ -148,15 +148,15 @@ public class TestReportFilter {
 
 	Optional<InsertedDeletedElementDifference> filter( final InsertedDeletedElementDifference insertedDeletedDiff ) {
 		if ( insertedDeletedDiff.isInserted() ) {
-			return filter.matches( insertedDeletedDiff.getInsertedOrDeletedElement()) //
+			return filter.matches( insertedDeletedDiff.getInsertedOrDeletedElement() ) //
 					|| filter.matches( insertedDeletedDiff.getInsertedOrDeletedElement(), ChangeType.INSERTED ) //
-					? Optional.empty() //
-					: Optional.of( insertedDeletedDiff );
+							? Optional.empty() //
+							: Optional.of( insertedDeletedDiff );
 		}
-		return filter.matches( insertedDeletedDiff.getInsertedOrDeletedElement()) //
+		return filter.matches( insertedDeletedDiff.getInsertedOrDeletedElement() ) //
 				|| filter.matches( insertedDeletedDiff.getInsertedOrDeletedElement(), ChangeType.DELETED ) //
-				? Optional.empty() //
-				: Optional.of( insertedDeletedDiff );
+						? Optional.empty() //
+						: Optional.of( insertedDeletedDiff );
 	}
 
 	Collection<ElementDifference> filter( final Collection<ElementDifference> elementDiffs ) {

--- a/src/main/resources/default-recheck.ignore
+++ b/src/main/resources/default-recheck.ignore
@@ -21,6 +21,9 @@
 # More details and examples can be found here:
 # https://docs.retest.de/recheck/usage/filter/
 
+# Ignore metadata differences
+import: metadata.filter
+
 # These are sensible defaults, delete if they don't apply:
 attribute=style
 matcher: type=input, attribute-regex=border-.*-color

--- a/src/main/resources/filter/metadata.filter
+++ b/src/main/resources/filter/metadata.filter
@@ -1,0 +1,9 @@
+attribute=machine.name
+attribute=os.arch
+attribute=vcs.branch
+attribute=vcs.commit
+attribute=vcs.name
+attribute=time.date
+attribute=time.time
+attribute=time.offset
+attribute=time.zone

--- a/src/test/java/de/retest/recheck/RecheckImplIT.java
+++ b/src/test/java/de/retest/recheck/RecheckImplIT.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.Filters;
 import de.retest.recheck.ui.DefaultValueFinder;
@@ -28,6 +29,8 @@ class RecheckImplIT {
 
 	static final String MESSAGE_START_PATTERN = "A detailed report will be created at '.*'";
 	static final String MESSAGE_START_REPLACE = "A detailed report will be created at '*'";
+
+	static final Filter METADATA_FILTER = Filters.parse( "import: metadata.filter" );
 
 	@Test
 	void diff_should_be_created_accordingly() {
@@ -63,7 +66,7 @@ class RecheckImplIT {
 
 	private RecheckOptions withIgnore( final Filter ignore ) {
 		return RecheckOptions.builder() //
-				.setIgnore( ignore ) //
+				.setIgnore( new CompoundFilter( ignore, METADATA_FILTER ) ) // Ignore all (even metadata)
 				.build();
 	}
 

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import de.retest.recheck.RecheckOptions.RecheckOptionsBuilder;
 import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
-import de.retest.recheck.ignore.PersistentFilter;
 import de.retest.recheck.persistence.ClassAndMethodBasedShortNamingStrategy;
 import de.retest.recheck.persistence.FileNamer;
 import de.retest.recheck.persistence.NamingStrategy;
@@ -66,8 +65,7 @@ class RecheckOptionsTest {
 		final List<Filter> filters =
 				((CompoundFilter) ((CompoundFilter) ((CompoundFilter) cut.getFilter()).getFilters().get( 0 ))
 						.getFilters().get( 0 )).getFilters();
-		assertThat( ((PersistentFilter) filters.get( 0 )).getFilter().toString() )
-				.isEqualTo( "# Style attributes filter file for recheck." );
+		assertThat( filters.get( 0 ).toString() ).isEqualTo( "# Style attributes filter file for recheck." );
 	}
 
 	@Test
@@ -76,9 +74,8 @@ class RecheckOptionsTest {
 				.setIgnore( "style-attributes.filter" ) //
 				.build();
 		assertThat( cut.getFilter() ).isInstanceOf( CompoundFilter.class );
-		assertThat(
-				((PersistentFilter) ((CompoundFilter) cut.getFilter()).getFilters().get( 0 )).getFilter().toString() )
-						.isEqualTo( "# Style attributes filter file for recheck." );
+		assertThat( ((CompoundFilter) cut.getFilter()).getFilters().get( 0 ).toString() )
+				.isEqualTo( "# Style attributes filter file for recheck." );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/ignore/FilterLoaderTest.java
+++ b/src/test/java/de/retest/recheck/ignore/FilterLoaderTest.java
@@ -1,7 +1,9 @@
 package de.retest.recheck.ignore;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
@@ -19,5 +21,12 @@ class FilterLoaderTest {
 		final Element element = null;
 		final String attributeKey = null;
 		assertThat( filter.matches( element, attributeKey ) ).isTrue();
+	}
+
+	@Test
+	void loadResource_should_properly_throw_descriptive_exception_if_resource_not_present() {
+		final FilterLoader cut = FilterLoader.loadResource( "/not-present-file.file" );
+
+		assertThatThrownBy( cut::load ).isInstanceOf( NoSuchFileException.class );
 	}
 }

--- a/src/test/java/de/retest/recheck/ignore/SearchFilterFilesIT.java
+++ b/src/test/java/de/retest/recheck/ignore/SearchFilterFilesIT.java
@@ -1,0 +1,26 @@
+package de.retest.recheck.ignore;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ignore.SearchFilterFiles.FilterResource;
+
+class SearchFilterFilesIT {
+
+	@Nested
+	class FilterResourceIT {
+
+		@Test
+		void loader_should_properly_load_resource() {
+			final FilterResource cut = FilterResource.prefix( "web", "content.filter" );
+
+			final Pair<String, FilterLoader> pair = cut.loader();
+			final FilterLoader loader = pair.getRight();
+
+			assertThatCode( loader::load ).doesNotThrowAnyException();
+		}
+	}
+}

--- a/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
+++ b/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
@@ -42,9 +42,8 @@ class SearchFilterFilesTest {
 		final List<String> actualFilterFileNames = defaultFilterFiles.stream() //
 				.map( Pair::getLeft ) //
 				.collect( Collectors.toList() );
-		final List<String> expectedFilterFileNames = Arrays.asList( "positioning.filter", "style-attributes.filter",
-				"invisible-attributes.filter", "content.filter" );
-		assertThat( actualFilterFileNames ).isEqualTo( expectedFilterFileNames );
+		assertThat( actualFilterFileNames ).containsExactlyInAnyOrder( "content.filter", "invisible-attributes.filter",
+				"positioning.filter", "style-attributes.filter", "metadata.filter" );
 	}
 
 	@Test

--- a/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
+++ b/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
@@ -16,11 +16,13 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.ClearSystemProperty;
 
 import de.retest.recheck.RecheckProperties;
+import de.retest.recheck.ignore.SearchFilterFiles.FilterResource;
 
 class SearchFilterFilesTest {
 
@@ -161,5 +163,35 @@ class SearchFilterFilesTest {
 		final List<Filter> list = unwrap( ((CompoundFilter) result).getFilters() );
 		assertThat( result ).isNotNull();
 		assertThat( list.toString() ).startsWith( "[# Filter file for recheck that will filter content" );
+	}
+
+	@Nested
+	class FilterResourceTest {
+
+		@Test
+		void absolute_should_start_with_separator() {
+			final FilterResource cut = FilterResource.absolute( "content.filter" );
+
+			assertThat( cut.getName() ).isEqualTo( "content.filter" );
+			assertThat( cut.getPath() ).startsWith( "/filter" );
+		}
+
+		@Test
+		void prefix_should_start_with_separator() {
+			final FilterResource cut = FilterResource.prefix( "web", "content.filter" );
+
+			assertThat( cut.getName() ).isEqualTo( "content.filter" );
+			assertThat( cut.getPath() ).startsWith( "/filter/web" );
+		}
+
+		@Test
+		void loader_should_return_the_same_name_as_specified() {
+			final FilterResource cut = FilterResource.absolute( "content.filter" );
+
+			final Pair<String, FilterLoader> pair = cut.loader();
+			final String name = pair.getKey();
+
+			assertThat( name ).isEqualTo( cut.getName() );
+		}
 	}
 }

--- a/src/test/java/de/retest/recheck/report/MetadataDifferenceFilterTest.java
+++ b/src/test/java/de/retest/recheck/report/MetadataDifferenceFilterTest.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.ignore.Filters;
 import de.retest.recheck.meta.global.TimeMetadataProvider;
 import de.retest.recheck.ui.diff.meta.MetadataDifference;
 import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
@@ -16,10 +18,12 @@ import de.retest.recheck.ui.diff.meta.MetadataElementDifference;
 class MetadataDifferenceFilterTest {
 
 	MetadataDifferenceFilter cut;
+	Filter filter;
 
 	@BeforeEach
 	void setUp() throws Exception {
 		cut = new MetadataDifferenceFilter();
+		filter = Filters.parse( "attribute=" + TimeMetadataProvider.TIME );
 	}
 
 	@Test
@@ -28,7 +32,7 @@ class MetadataDifferenceFilterTest {
 				new MetadataElementDifference( TimeMetadataProvider.TIME, "expected", "actual" );
 		final Set<MetadataElementDifference> diffs = new HashSet<>( Arrays.asList( elementDiff ) );
 		final MetadataDifference diff = MetadataDifference.of( diffs );
-		assertThat( cut.filter( diff ) ).isEmpty();
+		assertThat( cut.filter( diff, filter ) ).isEmpty();
 	}
 
 	@Test
@@ -36,7 +40,7 @@ class MetadataDifferenceFilterTest {
 		final MetadataElementDifference elementDiff = new MetadataElementDifference( "key", "expected", "actual" );
 		final Set<MetadataElementDifference> diffs = new HashSet<>( Arrays.asList( elementDiff ) );
 		final MetadataDifference diff = MetadataDifference.of( diffs );
-		assertThat( cut.filter( diff ) ).containsExactly( elementDiff );
+		assertThat( cut.filter( diff, filter ) ).containsExactly( elementDiff );
 	}
 
 }

--- a/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
+++ b/src/test/java/de/retest/recheck/report/TestReportFilterTest.java
@@ -103,8 +103,7 @@ class TestReportFilterTest {
 		stateDiff = new StateDifference( rootElementDiffs );
 
 		actionReplayResult = mock( ActionReplayResult.class );
-		when( actionReplayResult.getMetadataDifference() ).thenReturn(
-				MetadataDifference.of( Collections.singleton( new MetadataElementDifference( "a", "b", "c" ) ) ) );
+		when( actionReplayResult.getMetadataDifference() ).thenReturn( MetadataDifference.empty() );
 		when( actionReplayResult.getStateDifference() ).thenReturn( stateDiff );
 
 		testReplayResult = new TestReplayResult( "test", 1 );
@@ -398,10 +397,27 @@ class TestReportFilterTest {
 	}
 
 	@Test
-	void filter_should_not_destroy_metadata() throws Exception {
+	void filter_should_not_touch_metadata_if_no_filter_matches() {
+		// the attribute 'meta-a' is NOT filtered
+		final MetadataElementDifference difference = new MetadataElementDifference( "meta-a", "b", "c" );
+		when( actionReplayResult.getMetadataDifference() )
+				.thenReturn( MetadataDifference.of( Collections.singleton( difference ) ) );
+
 		final ActionReplayResult filtered = cut.filter( actionReplayResult );
 
 		assertThat( filtered.getMetadataDifference() ).isEqualTo( actionReplayResult.getMetadataDifference() );
+	}
+
+	@Test
+	void filter_should_recreate_metadata_if_filter_matches() {
+		// the attribute 'a' is filtered
+		final MetadataElementDifference difference = new MetadataElementDifference( "a", "b", "c" );
+		when( actionReplayResult.getMetadataDifference() )
+				.thenReturn( MetadataDifference.of( Collections.singleton( difference ) ) );
+
+		final ActionReplayResult filtered = cut.filter( actionReplayResult );
+
+		assertThat( filtered.getMetadataDifference() ).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). (retest/docs#114)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Pass the recheck.ignore through to filter metadata

Instead of having a custom filter for the metadata differences, it now feeds of the global filter passed into `TestReportFilter`. 

However, this change now breaks the current behavior of filtering some volatile attributes. Thus I have added a new provided `metadata.filter` which can simply be overwritten and imported. Furthermore I added this to the `defaults-recheck.ignore` which gets applied to new projects.

To get this filter known to recheck (since there is a difference for the development [folder] and production environment [jar] and we must therefore statically define these filters), I have reworked the semi-fancy path loading to use the classical class resource loading. This fixes some rare cases of `java.nio.file.FileSystemAlreadyExistsException`.

### State of this PR

Although I have added the new metadata.filter to the `default-recheck.ignore` which gets placed within the project directory on initial test execution, it will not do so on subsequent executions (meaning the file already exists). However, I would not consider this a worthwhile entry as a breaking change, since the metadata differences do not have any effect on the reporting. Nonetheless, I will make sure, to properly communicate that in the upcoming release changelog and the documentation.

Secondly, I am currently passing a dummy/artificial element to emulate the `matches(Element, AttributeDifference)` filter and prevent NPEs for filters that attempt to access the data of said element. This is just filled with arbitrary data and might not conform to all edge cases. However, the actual metadata filters should never try to access the element (although in the future we might take that as an identifier, e.g: `matcher: type=metadata`). This will be properly documented.