### PR TITLE
Feature/attribute identifier respect key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Table of Contents
 ### Bug Fixes
 
 * Fix a rare `java.nio.file.FileSystemAlreadyExistsException` when accessing filters concurrently.
+* Fix 1-click-maintenance not respecting the key of the `AttributeDifference`. 
 
 ### New Features
 

--- a/src/main/java/de/retest/recheck/ui/diff/AttributeDifference.java
+++ b/src/main/java/de/retest/recheck/ui/diff/AttributeDifference.java
@@ -5,11 +5,11 @@ import static de.retest.recheck.util.ObjectUtil.isNullOrEmptyString;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -103,7 +103,7 @@ public class AttributeDifference implements LeafDifference, Comparable<Attribute
 	}
 
 	public String identifier() {
-		final String contents = Arrays.asList( actual, expected ).stream() //
+		final String contents = Stream.of( key, actual, expected ) //
 				.filter( Objects::nonNull ) //
 				.map( Object::toString ) //
 				.collect( Collectors.joining( " # " ) );

--- a/src/test/java/de/retest/recheck/ui/diff/AttributeDifferenceTest.java
+++ b/src/test/java/de/retest/recheck/ui/diff/AttributeDifferenceTest.java
@@ -27,6 +27,16 @@ class AttributeDifferenceTest {
 	}
 
 	@Test
+	void identifier_should_respect_key() {
+		final AttributeDifference bottom =
+				new AttributeDifference( "border-bottom-color", "rgba(0, 0, 0, 0.26)", "rgba(0, 0, 0, 0.32)" );
+		final AttributeDifference top =
+				new AttributeDifference( "border-top-color", "rgba(0, 0, 0, 0.26)", "rgba(0, 0, 0, 0.32)" );
+
+		assertThat( bottom.identifier() ).isNotEqualTo( top.identifier() );
+	}
+
+	@Test
 	void compare_to_same_object_is_zero() throws Exception {
 		final AttributeDifference cut = new AttributeDifference();
 		assertThat( cut.compareTo( cut ) ).isEqualTo( 0 );

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_different_key_and_different_values.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_different_key_and_different_values.approved.xml
@@ -1,8 +1,8 @@
-<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="5c4843e957445234524e049433378d20ec7bb872d4625cfd5ab90f84756daba2">
-	<differences key="key1" attributeDifferenceId="3c9683017f9e4bf33d0fbedd26bf143fd72de9b9dd145441b75f0604047ea28e">
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="2cf4686d202cbd7b9587a255b29930e42ebe9ea481cfc8052ae15245123c0ca7">
+	<differences key="key1" attributeDifferenceId="78c3f4461dedfe4756a4cb1ac18341161e1426a2581c48d7c957d6b42c82c5ab">
 		<expected xsi:type="xsd:string">value1</expected>
 	</differences>
-	<differences key="key2" attributeDifferenceId="0537d481f73a757334328052da3af9626ced97028e20b849f6115c22cd765197">
+	<differences key="key2" attributeDifferenceId="51b4bf0abfe2ea889f1284d957cc63f1e8386bb6ce9b09e03738dbf049da15f3">
 		<actual xsi:type="xsd:string">value2</actual>
 	</differences>
 </attributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_less_expected_than_actual.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_less_expected_than_actual.approved.xml
@@ -1,9 +1,9 @@
-<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="aeb46b023fb28df81a30394ce4e9822bfe2eac07f74832e80d844a8efa388178">
-	<differences key="key2" attributeDifferenceId="46cb03830259ae4ec134e64705cceffe25e67bc5b10af4ec29bf5853222aa0a0">
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="7a9c32a03590cf3ed0186ea6c53b3228b83f942858922caf1e601bd4f5da9623">
+	<differences key="key2" attributeDifferenceId="bee8f11069f4cc3365a27cc4435da70097363fa97036e98755fa0e05fd922d5b">
 		<expected xsi:type="xsd:string">value2</expected>
 		<actual xsi:type="xsd:string">different-value</actual>
 	</differences>
-	<differences key="key3" attributeDifferenceId="89dc6ae7f06a9f46b565af03eab0ece0bf6024d3659b7e3a1d03573cfeb0b59d">
+	<differences key="key3" attributeDifferenceId="44ef012051bdbca25813da2b78cdf2f54ab0266a32b63fd79851d39f9e0c160b">
 		<actual xsi:type="xsd:string">value3</actual>
 	</differences>
 </attributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_more_expected_than_actual.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_more_expected_than_actual.approved.xml
@@ -1,9 +1,9 @@
-<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="aeb46b023fb28df81a30394ce4e9822bfe2eac07f74832e80d844a8efa388178">
-	<differences key="key2" attributeDifferenceId="46cb03830259ae4ec134e64705cceffe25e67bc5b10af4ec29bf5853222aa0a0">
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="7a9c32a03590cf3ed0186ea6c53b3228b83f942858922caf1e601bd4f5da9623">
+	<differences key="key2" attributeDifferenceId="bee8f11069f4cc3365a27cc4435da70097363fa97036e98755fa0e05fd922d5b">
 		<expected xsi:type="xsd:string">value2</expected>
 		<actual xsi:type="xsd:string">different-value</actual>
 	</differences>
-	<differences key="key3" attributeDifferenceId="89dc6ae7f06a9f46b565af03eab0ece0bf6024d3659b7e3a1d03573cfeb0b59d">
+	<differences key="key3" attributeDifferenceId="44ef012051bdbca25813da2b78cdf2f54ab0266a32b63fd79851d39f9e0c160b">
 		<expected xsi:type="xsd:string">value3</expected>
 	</differences>
 </attributesDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_the_same_key_but_different_values.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/AttributesDifferenceFinderTest.attributesDifference_with_the_same_key_but_different_values.approved.xml
@@ -1,5 +1,5 @@
-<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="7eec93af28496e7aa8f2ff4d3557542698725b8b8bf26da1d8298d4d3ecc9e7d">
-	<differences key="key" attributeDifferenceId="bbf83e3a0a45262ce65be4dc05194f7abe74c78225544b7e0f036ea11f388d59">
+<attributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="988581eba110215ce99340510d18e214c4474beb44cb739cd14324093eeb6e4f">
+	<differences key="key" attributeDifferenceId="065e2ae33427f26a29d2e93f4675ce7c0fe116b19249c886c358ff8b1c8c89a0">
 		<expected xsi:type="xsd:string">value1</expected>
 		<actual xsi:type="xsd:string">value2</actual>
 	</differences>

--- a/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.differences_should_be_recognized_accordingly.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.differences_should_be_recognized_accordingly.approved.xml
@@ -1,12 +1,12 @@
-<identifyingAttributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="4a4744180ebcb6a912e30679732aff30b2f906ea14b22edeef8e2428cba9f0d3">
+<identifyingAttributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="43ab3522694564cacc88f603a606de03f4e2b46d2e579472b99c948f27657155">
 	<attribute key="path" xsi:type="pathAttribute">parentPath[1]/type[1]</attribute>
 	<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 	<attribute key="type" xsi:type="stringAttribute">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type</attribute>
-	<attributeDifference key="path" attributeDifferenceId="99e2e6b492e99075f2ad0c022a1dfaed7bd99a98695eb612f4703a82ab1e23cf">
+	<attributeDifference key="path" attributeDifferenceId="91947ac8f3bc91b8f0874b920aadf413a986f9ab21063e7d46993ba239488b52">
 		<expected xsi:type="xsd:string">parentPath[1]/type[1]</expected>
 		<actual xsi:type="xsd:string">anotherParentPath[1]/anotherType[1]</actual>
 	</attributeDifference>
-	<attributeDifference key="type" attributeDifferenceId="886ce09093615d835af906ee8516f5623bf1a15f2cf7e9f4f7bd5a7688eccf58">
+	<attributeDifference key="type" attributeDifferenceId="0f50f4015324077de9c37ccffbb5a339559c546ec3f244a43e40ab2f5c804697">
 		<expected xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type</expected>
 		<actual xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType</actual>
 	</attributeDifference>

--- a/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.different_paths_and_components_should_be_recognized_accordingly.approved.xml
+++ b/src/test/resources/de/retest/recheck/ui/diff/IdentifyingAttributesDifferenceFinderTest.different_paths_and_components_should_be_recognized_accordingly.approved.xml
@@ -1,12 +1,12 @@
-<identifyingAttributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="1b34c45a52e339e7f7e9ccff2dd60297566b419af9fef5f8b09af49e5569afe3">
+<identifyingAttributesDifference xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" differenceId="8b75869a6c9c1c21ada61ec3bc16037362913de56a0c8ccaa889edf89bb8a6f9">
 	<attribute key="path" xsi:type="pathAttribute">AnotherType[1]</attribute>
 	<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
 	<attribute key="type" xsi:type="stringAttribute">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType</attribute>
-	<attributeDifference key="path" attributeDifferenceId="02642fe8cf782225a14d2188b087976b7205eb66ed6858d62ec97a77e43a31b5">
+	<attributeDifference key="path" attributeDifferenceId="53a9950b71274c9f2e7961af1b783afe2a496f57a400d72a018af5be1409d99d">
 		<expected xsi:type="xsd:string">AnotherType[1]</expected>
 		<actual xsi:type="xsd:string">Type[1]</actual>
 	</attributeDifference>
-	<attributeDifference key="type" attributeDifferenceId="0a919a43bfd37fabc5fd6775f56d83ed69d7c9fb785e152f71d694f6a35e2336">
+	<attributeDifference key="type" attributeDifferenceId="4ddbebab186a658fbac319e373ebf1d023a804da0b7391bfbf8986454d495b11">
 		<expected xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$AnotherType</expected>
 		<actual xsi:type="xsd:string">de.retest.recheck.ui.diff.IdentifyingAttributesDifferenceFinderTest$Type</actual>
 	</attributeDifference>


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This fixes that the GlobalChangeSetApplier accepts similar attribute differences.

For the return of one-click-maintenance (more details in #726), the GlobalChangeSetApplier 
 uses the `AttributeDifference#identifier()` to find equal differences, since `AttributeDifference#equals` per definition cannot be used since it would check the warnings too.

However, the identifier currently only takes the `expected` and `actual` values into account, ignoring the `key` attribute. That means, following differences are considered equal, although differing in keys:

```
border-bottom-color: expected=rgba(0, 0, 0, 0.26), actual=rgba(0, 0, 0, 0.32)
border-top-color: expected=rgba(0, 0, 0, 0.26), actual=rgba(0, 0, 0, 0.32)
```` 

This causes review to accept these attributes with a single click (which, currently, is not the expected behavior, as that could group completely different differences).

*Technically, the above example is the same difference, because in the report the differences could be grouped to `border-color: expected=rgba(0, 0, 0, 0.26), actual=rgba(0, 0, 0, 0.32)`, but since we cannot implement grouping (technically), this is unwanted behavior.*

### State of this PR

I do not know what the intentions were to exclude the key from the identifier (since I could not search through the history of the different repositories), but a quick usage search indicates that this should not have any breaking side-effects.