### PR TITLE
Add a changelog entry for the addition of a retest id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Table of Contents
 * You can now specify that a specific value-regex should be filtered, either globally, for specific elements or specific attributes. This allows to e.g. ignore a date, but still ensure that it is actually a valid date.
 * You can now specify to ignore a percentage color-diff, much like a pixel-diff. This allows to ignore, e.g. minor color changes or changes where opacity value is added or missing. Can be added globally, per element or attribute or combination thereof.
 * Add the option to filter elements based on whether they are inserted, deleted or changed.
+* The report output now displays the `retestId`: `input (input-retest-id) at 'html[1]/body[1]/input[1]'`. This may be used, for example, by a filter: `matcher: retestId=input-retest-id`.
 
 ### Improvements
 


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] ~the necessary tests are either created or updated.~
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). (*pending...*)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Apparently, we have missed to add a entry for displaying the `retestId`.

recheck-1.10.0 introduced the `retestId` within a report output. As #740 brought to my attention that we have not updated our documentation accordingly (and the changelog for that matter) to include the introduction of the retestId in the report output. Before (pre 1.10), it was a semi-random output of some basic attributes as #665 clarifies. Furthermore #667 ensured that the `retestId` was consistently displayed when a report is printed.

I have added the missing changelog entry and will update the documentation later.

### Additional Context

This change was introduced by a mix of #665 and #667 and thus we might have missed to add a respective changelog entry.