### PR TITLE
Fix/element warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Table of Contents
 
 ### Bug Fixes
 
+* Fix accepting of attributes without warning deletes warnings of similar attribute differences.
+
 ### New Features
 
 ### Improvements

--- a/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
@@ -19,6 +19,7 @@ import de.retest.recheck.ui.diff.AttributeDifference;
 import de.retest.recheck.ui.diff.ElementDifference;
 import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
 import de.retest.recheck.ui.review.ActionChangeSet;
+import de.retest.recheck.ui.review.AttributeChanges;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -121,7 +122,8 @@ public class GlobalChangeSetApplier {
 		for ( final ActionReplayResult actionReplayResult : actionResultsWithDiffs ) {
 			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
 			assert correspondingActionChangeSet != null : "Should have been added during load and thus not be empty!";
-			correspondingActionChangeSet.getIdentAttributeChanges().add( identifyingAttributes, attributeDifference );
+			final AttributeChanges changes = correspondingActionChangeSet.getIdentAttributeChanges();
+			changes.add( identifyingAttributes, attributeDifference );
 		}
 		counter.add();
 	}
@@ -130,8 +132,9 @@ public class GlobalChangeSetApplier {
 			final AttributeDifference attributeDifference ) {
 		for ( final ActionReplayResult actionReplayResult : findAllActionResultsWithEqualDifferences(
 				identifyingAttributes, attributeDifference ) ) {
-			findCorrespondingActionChangeSet( actionReplayResult ).getAttributesChanges().add( identifyingAttributes,
-					attributeDifference );
+			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
+			final AttributeChanges changes = correspondingActionChangeSet.getAttributesChanges();
+			changes.add( identifyingAttributes, attributeDifference );
 		}
 		counter.add();
 	}
@@ -140,8 +143,9 @@ public class GlobalChangeSetApplier {
 			final AttributeDifference attributeDifference ) {
 		for ( final ActionReplayResult actionReplayResult : findAllActionResultsWithEqualDifferences(
 				identifyingAttributes, attributeDifference ) ) {
-			findCorrespondingActionChangeSet( actionReplayResult ).getIdentAttributeChanges()
-					.remove( identifyingAttributes, attributeDifference );
+			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
+			final AttributeChanges changes = correspondingActionChangeSet.getIdentAttributeChanges();
+			changes.remove( identifyingAttributes, attributeDifference );
 		}
 		counter.remove();
 	}
@@ -150,8 +154,9 @@ public class GlobalChangeSetApplier {
 			final AttributeDifference attributeDifference ) {
 		for ( final ActionReplayResult actionReplayResult : findAllActionResultsWithEqualDifferences(
 				identifyingAttributes, attributeDifference ) ) {
-			findCorrespondingActionChangeSet( actionReplayResult ).getAttributesChanges().remove( identifyingAttributes,
-					attributeDifference );
+			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
+			final AttributeChanges changes = correspondingActionChangeSet.getAttributesChanges();
+			changes.remove( identifyingAttributes, attributeDifference );
 		}
 		counter.remove();
 	}

--- a/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalChangeSetApplier.java
@@ -1,8 +1,12 @@
 package de.retest.recheck.review;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -17,6 +21,7 @@ import de.retest.recheck.ui.descriptors.Element;
 import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
 import de.retest.recheck.ui.diff.AttributeDifference;
 import de.retest.recheck.ui.diff.ElementDifference;
+import de.retest.recheck.ui.diff.ElementIdentificationWarning;
 import de.retest.recheck.ui.diff.InsertedDeletedElementDifference;
 import de.retest.recheck.ui.review.ActionChangeSet;
 import de.retest.recheck.ui.review.AttributeChanges;
@@ -30,6 +35,7 @@ public class GlobalChangeSetApplier {
 	private GlobalChangeSetApplier( final TestReport testReport, final Counter counter ) {
 		this.counter = counter;
 		attributeDiffsLookupMap = ArrayListMultimap.create();
+		warningsLookup = new HashMap<>();
 		insertedDiffsLookupMap = ArrayListMultimap.create();
 		deletedDiffsLookupMap = ArrayListMultimap.create();
 		actionChangeSetLookupMap = new HashMap<>();
@@ -49,6 +55,8 @@ public class GlobalChangeSetApplier {
 
 	@Getter( AccessLevel.PACKAGE )
 	private final Multimap<ImmutablePair<String, String>, ActionReplayResult> attributeDiffsLookupMap;
+	@Getter( AccessLevel.PACKAGE )
+	private final HashMap<ImmutablePair<String, String>, Set<ElementIdentificationWarning>> warningsLookup;
 	@Getter( AccessLevel.PACKAGE )
 	private final Multimap<String, ActionReplayResult> insertedDiffsLookupMap;
 	@Getter( AccessLevel.PACKAGE )
@@ -86,9 +94,13 @@ public class GlobalChangeSetApplier {
 			final ElementDifference elementDiff ) {
 		final IdentifyingAttributes identifyingAttributes = elementDiff.getIdentifyingAttributes();
 		for ( final AttributeDifference attributeDifference : elementDiff.getAttributeDifferences() ) {
-			attributeDiffsLookupMap.put(
-					ImmutablePair.of( identifier( identifyingAttributes ), identifier( attributeDifference ) ),
-					actionReplayResult );
+			final ImmutablePair<String, String> key =
+					ImmutablePair.of( identifier( identifyingAttributes ), identifier( attributeDifference ) );
+			attributeDiffsLookupMap.put( key, actionReplayResult );
+			final List<ElementIdentificationWarning> warnings = attributeDifference.getElementIdentificationWarnings();
+			if ( !warnings.isEmpty() ) {
+				warningsLookup.computeIfAbsent( key, k -> new HashSet<>() ).addAll( warnings );
+			}
 		}
 	}
 
@@ -96,6 +108,12 @@ public class GlobalChangeSetApplier {
 			final IdentifyingAttributes identifyingAttributes, final AttributeDifference attributeDifference ) {
 		return attributeDiffsLookupMap
 				.get( ImmutablePair.of( identifier( identifyingAttributes ), identifier( attributeDifference ) ) );
+	}
+
+	private Set<ElementIdentificationWarning> findAllWarningsForDifference( final IdentifyingAttributes attributes,
+			final AttributeDifference difference ) {
+		return warningsLookup.getOrDefault( ImmutablePair.of( identifier( attributes ), identifier( difference ) ),
+				Collections.emptySet() );
 	}
 
 	private ActionChangeSet findCorrespondingActionChangeSet( final ActionReplayResult actionReplayResult ) {
@@ -123,7 +141,7 @@ public class GlobalChangeSetApplier {
 			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
 			assert correspondingActionChangeSet != null : "Should have been added during load and thus not be empty!";
 			final AttributeChanges changes = correspondingActionChangeSet.getIdentAttributeChanges();
-			changes.add( identifyingAttributes, attributeDifference );
+			changes.add( identifyingAttributes, injectWarningsFor( identifyingAttributes, attributeDifference ) );
 		}
 		counter.add();
 	}
@@ -134,7 +152,7 @@ public class GlobalChangeSetApplier {
 				identifyingAttributes, attributeDifference ) ) {
 			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
 			final AttributeChanges changes = correspondingActionChangeSet.getAttributesChanges();
-			changes.add( identifyingAttributes, attributeDifference );
+			changes.add( identifyingAttributes, injectWarningsFor( identifyingAttributes, attributeDifference ) );
 		}
 		counter.add();
 	}
@@ -145,7 +163,7 @@ public class GlobalChangeSetApplier {
 				identifyingAttributes, attributeDifference ) ) {
 			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
 			final AttributeChanges changes = correspondingActionChangeSet.getIdentAttributeChanges();
-			changes.remove( identifyingAttributes, attributeDifference );
+			changes.remove( identifyingAttributes, injectWarningsFor( identifyingAttributes, attributeDifference ) );
 		}
 		counter.remove();
 	}
@@ -156,9 +174,17 @@ public class GlobalChangeSetApplier {
 				identifyingAttributes, attributeDifference ) ) {
 			final ActionChangeSet correspondingActionChangeSet = findCorrespondingActionChangeSet( actionReplayResult );
 			final AttributeChanges changes = correspondingActionChangeSet.getAttributesChanges();
-			changes.remove( identifyingAttributes, attributeDifference );
+			changes.remove( identifyingAttributes, injectWarningsFor( identifyingAttributes, attributeDifference ) );
 		}
 		counter.remove();
+	}
+
+	private AttributeDifference injectWarningsFor( final IdentifyingAttributes attributes,
+			final AttributeDifference difference ) {
+		final AttributeDifference copy =
+				new AttributeDifference( difference.getKey(), difference.getExpected(), difference.getActual() );
+		copy.addElementIdentificationWarnings( findAllWarningsForDifference( attributes, difference ) );
+		return copy;
 	}
 
 	// Add/remove inserted/deleted differences.

--- a/src/main/java/de/retest/recheck/ui/diff/AttributeDifference.java
+++ b/src/main/java/de/retest/recheck/ui/diff/AttributeDifference.java
@@ -5,6 +5,7 @@ import static de.retest.recheck.util.ObjectUtil.isNullOrEmptyString;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -78,6 +79,10 @@ public class AttributeDifference implements LeafDifference, Comparable<Attribute
 
 	public void addElementIdentificationWarning( final ElementIdentificationWarning elementIdentificationWarning ) {
 		elementIdentificationWarnings.add( elementIdentificationWarning );
+	}
+
+	public void addElementIdentificationWarnings( final Collection<? extends ElementIdentificationWarning> warnings ) {
+		elementIdentificationWarnings.addAll( warnings );
 	}
 
 	public boolean hasElementIdentificationWarning() {


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This fixes a problem with automatic code healing, where the breaking changes were lost when accepting attribute differences without these warnings.

### Background

The `GlobalChangeSetApplier` collects and aggregates related differences and accepts them in one go, based on a key created from both the element and difference. Once done, it will accept all differences with the difference passed, not the original difference (as this cannot be reconstructed).

There are multiple ways to settle this:

1. Do nothing, i.e. enforce the difference to contain a warning (aka the UI must pass the correct difference). This is difficult, as the UI itself uses caching to get notified for the related attributes.
1. Allow the original differences for each `ActionReplayResult` be reconstructable (i.e. restructurize the report).
1. Aggregate the collection of all warnings per element and difference and reconstruct the correct difference with warning.
1. ... *(more solutions I forgot or dismissed until now)*

I went for approach 3 because it is one of the easiest solutions, I came up with. Whenever an attribute is accepted/ignored (or the reverse actions), this will now attempt to reconstruct the difference with all encountered warnings. Since the `AttributeChanges` saves them simply within a list, all add/remove operations must be with the same object (a.k.a. the warnings).

### State of this PR

However, the `GlobalChangeSetApplier` now grows slowly and it becomes more apparent that the decision to add the warning to the `AttributeDifference` is not that great from an algorithmic point of view (both in `equals` and `apply`).

As mentioned in the commit message, this does not technically create the expected `ReviewResult`, because as soon as one accepted difference has an warning, all of the related differences will now contain warnings. These differences, however, are not present in the original report. But we never check for such a condition and thus I favored this approach over the others.

Furthermore, this essentially renders the passing of a `AttributeDifference` useless, as it will now only ever be used as a identifier. Thus we should rethink the collection of warnings in the future.

Lastly, this is fairly difficult to test, as a full integration test is a pain to setup. Thus I only added basic unit tests to (hopefully) ensure correct behavior in the future.

### Additional Context

This can be reproduced with the [auto-healing tutorial](https://docs.retest.de/recheck-web/usage/healing/). Notice that `btn-login` will not be healed with the broken version, since the initial encounter does not contain a warning added, and since this is cached, it will perform all operations with this difference.