### PR TITLE
Fix/attribute null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Table of Contents
 ### Bug Fixes
 
 * Fix accepting of attributes without warning deletes warnings of similar attribute differences.
+* Fix NPE when applying an identifying attribute that has been inserted.
 
 ### New Features
 

--- a/src/main/java/de/retest/recheck/ui/descriptors/IdentifyingAttributes.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/IdentifyingAttributes.java
@@ -232,9 +232,17 @@ public class IdentifyingAttributes implements Serializable, Comparable<Identifyi
 		for ( final AttributeDifference attributeDifference : attributeChanges ) {
 			final String key = attributeDifference.getKey();
 			final Attribute attribute = attributes.get( key );
-			newAttributes.put( key, attributeDifference.applyChangeTo( attribute ) );
+			if ( attribute == null ) { // Insertion, assuming expected to be null
+				final Serializable actual = attributeDifference.getActual();
+				if ( actual instanceof Attribute ) {
+					newAttributes.put( key, (Attribute) actual );
+				} else {
+					newAttributes.put( key, new DefaultAttribute( key, actual ) );
+				}
+			} else { // Attribute must be present, either deleted or change
+				newAttributes.put( key, attributeDifference.applyChangeTo( attribute ) );
+			}
 		}
-
 		return newInstance( newAttributes.values() );
 	}
 

--- a/src/test/java/de/retest/recheck/ui/descriptors/IdentifyingAttributesTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/IdentifyingAttributesTest.java
@@ -1,7 +1,7 @@
 package de.retest.recheck.ui.descriptors;
 
-import static de.retest.recheck.ui.descriptors.IdentifyingAttributes.TYPE_ATTRIBUTE_KEY;
 import static de.retest.recheck.ui.Path.fromString;
+import static de.retest.recheck.ui.descriptors.IdentifyingAttributes.TYPE_ATTRIBUTE_KEY;
 import static de.retest.recheck.ui.descriptors.IdentifyingAttributes.create;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -184,17 +184,17 @@ public class IdentifyingAttributesTest {
 	public void different_absolute_outline_should_result_in_change() {
 		final Collection<Attribute> expected = IdentifyingAttributes
 				.createList( Path.fromString( "html[1]/body[1]/ytd-app[1]" ), component.class.getName() );
-		expected.add( OutlineAttribute.createAbsolute(  new Rectangle( 0, 0, 1179, 2046 ) ) );
+		expected.add( OutlineAttribute.createAbsolute( new Rectangle( 0, 0, 1179, 2046 ) ) );
 		final IdentifyingAttributes expectedIdent = new IdentifyingAttributes( expected );
 
 		final Collection<Attribute> actual = IdentifyingAttributes
 				.createList( Path.fromString( "html[1]/body[1]/ytd-app[1]" ), component.class.getName() );
-		actual.add( OutlineAttribute.createAbsolute( new Rectangle( 0, 0, 1179, 2030 )) );
+		actual.add( OutlineAttribute.createAbsolute( new Rectangle( 0, 0, 1179, 2030 ) ) );
 		final IdentifyingAttributes actualIdent = new IdentifyingAttributes( actual );
 
-//		assertThat( expectedIdent.match( actualIdent ) ).isLessThan(1.0 ); should be less than 1.0
+		//		assertThat( expectedIdent.match( actualIdent ) ).isLessThan(1.0 ); should be less than 1.0
 		assertThat( expectedIdent.equals( actualIdent ) ).isFalse();
-		assertThat( expectedIdent.hashCode() ).isNotEqualTo(  actualIdent.hashCode() );
+		assertThat( expectedIdent.hashCode() ).isNotEqualTo( actualIdent.hashCode() );
 		assertThat( expectedIdent ).isNotEqualTo( actualIdent );
 	}
 
@@ -233,6 +233,16 @@ public class IdentifyingAttributesTest {
 	@Test( expected = NullPointerException.class )
 	public void null_Class_type_should_give_exception() {
 		create( fromString( "/HTML/DIV" ), (Class<?>) null );
+	}
+
+	@Test
+	public void apply_should_add_inserted_attribute() {
+		final Path path = fromString( "/html/div" );
+		final IdentifyingAttributes cut = create( path, String.class );
+
+		final IdentifyingAttributes applied = cut.applyChanges( createAttributeChanges( path, "text", null, "foo" ) );
+
+		assertThat( applied.getAttribute( "text" ) ).isNotNull();
 	}
 
 	private Set<AttributeDifference> createAttributeChanges( final Path path, final String key,

--- a/src/test/java/de/retest/recheck/ui/descriptors/IdentifyingAttributesTest.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/IdentifyingAttributesTest.java
@@ -245,6 +245,47 @@ public class IdentifyingAttributesTest {
 		assertThat( applied.getAttribute( "text" ) ).isNotNull();
 	}
 
+	@Test
+	public void apply_should_use_additional_attribute_if_inserted() {
+		final Path path = fromString( "/html/div" );
+		final IdentifyingAttributes cut = create( path, String.class );
+
+		final IdentifyingAttributes applied = cut.applyChanges( Collections
+				.singleton( new AdditionalAttributeDifference( "text", new TextAttribute( "text", "foo" ) ) ) );
+
+		final Attribute attribute = applied.getAttribute( "text" );
+		assertThat( attribute ).isInstanceOf( TextAttribute.class );
+		assertThat( attribute.getKey() ).isEqualTo( "text" );
+		assertThat( attribute.getValue() ).isEqualTo( "foo" );
+	}
+
+	@Test
+	public void apply_should_use_attribute_if_inserted() {
+		final Path path = fromString( "/html/div" );
+		final IdentifyingAttributes cut = create( path, String.class );
+
+		final IdentifyingAttributes applied = cut.applyChanges(
+				Collections.singleton( new AttributeDifference( "text", null, new TextAttribute( "text", "foo" ) ) ) );
+
+		final Attribute attribute = applied.getAttribute( "text" );
+		assertThat( attribute ).isInstanceOf( TextAttribute.class );
+		assertThat( attribute.getKey() ).isEqualTo( "text" );
+		assertThat( attribute.getValue() ).isEqualTo( "foo" );
+	}
+
+	@Test
+	public void apply_should_fallback_to_default_attribute_if_inserted() {
+		final Path path = fromString( "/html/div" );
+		final IdentifyingAttributes cut = create( path, String.class );
+
+		final IdentifyingAttributes applied = cut.applyChanges( createAttributeChanges( path, "text", null, "foo" ) );
+
+		final Attribute attribute = applied.getAttribute( "text" );
+		assertThat( attribute ).isInstanceOf( DefaultAttribute.class );
+		assertThat( attribute.getKey() ).isEqualTo( "text" );
+		assertThat( attribute.getValue() ).isEqualTo( "foo" );
+	}
+
 	private Set<AttributeDifference> createAttributeChanges( final Path path, final String key,
 			final Serializable expected, final Serializable actual ) {
 		return Collections.singleton( new AttributeDifference( key, expected, actual ) );


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Fix NPE when attribute is inserted and applied

This is somewhat caused by #748 which destroys the attribute differences.

When performing the [autohealing tutorial](https://docs.retest.de/recheck-web/usage/healing/) applying the text attribute difference (which is an identifying attribute) results in an exception reported, because the attribute is missing and cannot be applied.

```text
java.lang.NullPointerException: Cannot apply change to an attribute that is null.
```

### Fix

The changes in #748 causes the attribute difference to be reconstructed. This destroys any special attribute differences (e.g. `AdditionalAttributeDifference`), which are used to convey additional meaning to the `IdentifyingAttributes` apply mechanism.

This was used to pass the original inserted attribute along and ignore the missing `null` attribute to simply create a new attribute (see `AdditionalAttributeDifference`). However, decided to custom handle the insertion of a (identifying) attribute the following:

1. If an attribute is present: Use the difference to apply.
2. If an attribute is missing: Check the actual value for attribute or try to create a new default attribute.

### State of this PR

I decided not to revert or adjust the changes made by the causing PR, since most custom `AttributeDifferences` are related to legacy code (to my understanding)  and should not be created. The remaining differences (mostly `AdditionalAttributeDifference`) should not require special handling (besides the one to be introduced).

### Additional Context

This bug has happened a few times in the past and couldn't be reproduced, since it seemed to happen only on edge cases. I hope, that this fix also fixes those cases.