### PR TITLE
Override method to match attribute key

### DIFF
--- a/src/main/java/de/retest/recheck/review/GlobalIgnoreApplier.java
+++ b/src/main/java/de/retest/recheck/review/GlobalIgnoreApplier.java
@@ -48,6 +48,11 @@ public class GlobalIgnoreApplier implements Filter {
 	}
 
 	@Override
+	public boolean matches( final Element element, final String attributeKey ) {
+		return any( filter -> filter.matches( element, attributeKey ) );
+	}
+
+	@Override
 	public boolean matches( final Element element, final AttributeDifference difference ) {
 		return any( filter -> filter.matches( element, difference ) );
 	}


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [ ] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

We would like to replace `StateFilter` class from `surili-sut-model` with recheck ignore. However, as the ignore file is loaded as `GlobalIgnoreApplier` instance, it is necessary to override the respective method such that it is possible to match if an element does not contain an attribute key. Without this override, the default method from the `Filter` interface is invoked which does not take an attribute key into consideration.

This is related to State-Graph improvement in surili and there will be a separate pull request in the respective module. For additional information, see [RET-2050](https://retest.atlassian.net/browse/RET-2050).

### State of this PR

I"m not sure if this change breaks the existing filter mechanism. But it successfully does what it was intended for within surili.
