### PR TITLE
Add metadata for web, that should also be ignored on default...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Table of Contents
 
 ### New Features
 
-* Metadata differences are now filterable via the recheck.ignore. A new `metadata.filter` has been added which can be imported with `import: metadata.filter` in `recheck.ignore`.
+* Metadata differences are now filterable via the recheck.ignore. New `volatile-metadata.filter` and `metadata.filter` filters have been added, where the first one filters metadata which is added for diagnosing purposes and too verbose to be displayed upon every change and the latter filters _all_ metadata. They can be imported with `import: volatile-metadata.filter` and `import: metadata.filter` in `recheck.ignore`.
 * Add a `disableReportUpload` method.
 
 ### Improvements

--- a/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
+++ b/src/main/java/de/retest/recheck/ignore/SearchFilterFiles.java
@@ -39,6 +39,7 @@ public class SearchFilterFiles {
 			FilterResource.prefix( WEB_CATEGORY, "positioning.filter" ), //
 			FilterResource.prefix( WEB_CATEGORY, "style-attributes.filter" ), //
 
+			FilterResource.absolute( "volatile-metadata.filter" ), //
 			FilterResource.absolute( "metadata.filter" ) //
 	) //
 			.map( FilterResource::loader ) //

--- a/src/main/resources/default-recheck.ignore
+++ b/src/main/resources/default-recheck.ignore
@@ -21,8 +21,8 @@
 # More details and examples can be found here:
 # https://docs.retest.de/recheck/usage/filter/
 
-# Ignore metadata differences
-import: metadata.filter
+# Ignore volatile metadata differences
+import: volatile-metadata.filter
 
 # These are sensible defaults, delete if they don't apply:
 attribute=style

--- a/src/main/resources/filter/metadata.filter
+++ b/src/main/resources/filter/metadata.filter
@@ -7,3 +7,11 @@ attribute=time.date
 attribute=time.time
 attribute=time.offset
 attribute=time.zone
+# for recheck-web
+attribute=browser.name
+attribute=browser.version
+attribute=check.type
+attribute=driver.type
+attribute=os.name
+attribute=os.version
+attribute=url

--- a/src/main/resources/filter/metadata.filter
+++ b/src/main/resources/filter/metadata.filter
@@ -1,12 +1,5 @@
-attribute=machine.name
-attribute=os.arch
-attribute=vcs.branch
-attribute=vcs.commit
-attribute=vcs.name
-attribute=time.date
-attribute=time.time
-attribute=time.offset
-attribute=time.zone
+import: volatile-metadata.filter
+
 # for recheck-web
 attribute=browser.name
 attribute=browser.version

--- a/src/main/resources/filter/volatile-metadata.filter
+++ b/src/main/resources/filter/volatile-metadata.filter
@@ -1,0 +1,13 @@
+# These differences should be recorded in the GM for diagnosing,
+# but are too verbose and too volatile 
+# to be spilled out for every change
+
+attribute=machine.name
+attribute=os.arch
+attribute=vcs.branch
+attribute=vcs.commit
+attribute=vcs.name
+attribute=time.date
+attribute=time.time
+attribute=time.offset
+attribute=time.zone

--- a/src/test/java/de/retest/recheck/RecheckImplIT.java
+++ b/src/test/java/de/retest/recheck/RecheckImplIT.java
@@ -53,6 +53,7 @@ class RecheckImplIT {
 		doReturn( RecheckImplIT.class.getName() + " legacy spaces" ).when( fileNamerStrategy ).getTestClassName();
 
 		execute( "with legacy spaces", RecheckOptions.builder() //
+				.setIgnore( METADATA_FILTER ) // Ignore metadata
 				.fileNamerStrategy( fileNamerStrategy ) //
 				.build() );
 	}
@@ -60,6 +61,7 @@ class RecheckImplIT {
 	@Test
 	void diff_should_handle_spaces_accordingly() {
 		execute( "with spaces", RecheckOptions.builder() //
+				.setIgnore( METADATA_FILTER ) //
 				.suiteName( RecheckImplIT.class.getName() + " spaces" ) //
 				.build() );
 	}

--- a/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
+++ b/src/test/java/de/retest/recheck/ignore/SearchFilterFilesTest.java
@@ -43,7 +43,7 @@ class SearchFilterFilesTest {
 				.map( Pair::getLeft ) //
 				.collect( Collectors.toList() );
 		assertThat( actualFilterFileNames ).containsExactlyInAnyOrder( "content.filter", "invisible-attributes.filter",
-				"positioning.filter", "style-attributes.filter", "metadata.filter" );
+				"positioning.filter", "style-attributes.filter", "volatile-metadata.filter", "metadata.filter" );
 	}
 
 	@Test

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_accordingly.approved.txt
@@ -3,10 +3,6 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
 Test 'no-filter' has 9 difference(s) in 1 state(s):
 check resulted in:
-	Metadata Differences:
-	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
 	test (title) at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_if_filtered.approved.txt
@@ -3,10 +3,6 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
 Test 'filter' has 4 difference(s) in 1 state(s):
 check resulted in:
-	Metadata Differences:
-	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
 	test (title) at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_with_deleted_filtered.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_be_created_with_deleted_filtered.approved.txt
@@ -3,10 +3,6 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
 Test 'filter-deleted' has 8 difference(s) in 1 state(s):
 check resulted in:
-	Metadata Differences:
-	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
 	test (title) at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_legacy_spaces_accordingly.approved.txt
@@ -3,10 +3,6 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT legacy spaces' found the following difference(s):
 Test 'with legacy spaces' has 9 difference(s) in 1 state(s):
 check resulted in:
-	Metadata Differences:
-	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
 	test (title) at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_handle_spaces_accordingly.approved.txt
@@ -3,10 +3,6 @@ A detailed report will be created at '*'. You can review the details by using ou
 1 check(s) in 'de.retest.recheck.RecheckImplIT spaces' found the following difference(s):
 Test 'with spaces' has 9 difference(s) in 1 state(s):
 check resulted in:
-	Metadata Differences:
-	  Please note that these differences do not affect the result and are not included in the difference count.
-		os.name: expected="null", actual="Linux"
-		os.version: expected="null", actual="4.4.0-101-generic"
 	test (title) at 'foo[1]/bar[1]':
 		foo-1: expected="bar-1", actual="bar-3"
 		foo-3: expected="bar-3", actual="bar-1"


### PR DESCRIPTION
The name of the filter (metadata.filter) suggests that it filters all meta-data. So it should also filter recheck-web metadata. As far as I know, this hasn't made it to the docs yet, so...