### PR TITLE
Feature/add exclude filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Table of Contents
 ### New Features
 
 * Metadata differences are now filterable via the recheck.ignore. New `volatile-metadata.filter` and `metadata.filter` filters have been added, where the first one filters metadata which is added for diagnosing purposes and too verbose to be displayed upon every change and the latter filters _all_ metadata. They can be imported with `import: volatile-metadata.filter` and `import: metadata.filter` in `recheck.ignore`.
+* Add `exclude()` filter expression to allow child elements to be excluded. Ignoring an element `matcher: type=body, exclude(matcher: type=button)` will ignore everything below the `body` element but still capture changes for `button` elements.
 * Add a `disableReportUpload` method.
 
 ### Improvements

--- a/src/main/java/de/retest/recheck/review/ignore/ExcludeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ExcludeFilter.java
@@ -1,0 +1,74 @@
+package de.retest.recheck.review.ignore;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.review.ignore.io.Loader;
+import de.retest.recheck.review.ignore.io.RegexLoader;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ExcludeFilter implements Filter {
+
+	@Getter( AccessLevel.PACKAGE )
+	private final Filter filter;
+
+	@Override
+	public boolean matches( final Element element ) {
+		return !filter.matches( element );
+	}
+
+	@Override
+	public boolean matches( final Element element, final ChangeType change ) {
+		return !filter.matches( element, change );
+	}
+
+	@Override
+	public boolean matches( final Element element, final String attributeKey ) {
+		return !filter.matches( element, attributeKey );
+	}
+
+	@Override
+	public boolean matches( final Element element, final AttributeDifference attributeDifference ) {
+		return !filter.matches( element, attributeDifference );
+	}
+
+	@Override
+	public String toString() {
+		return String.format( FilterLoader.FORMAT, filter );
+	}
+
+	public static class FilterLoader extends RegexLoader<ExcludeFilter> {
+
+		private static final String FORMAT = "exclude(%s)";
+
+		private final Loader<Filter> delegate;
+
+		public FilterLoader( final Loader<Filter> delegate ) {
+			super( Pattern.compile( "exclude\\((.+)\\)" ) );
+			this.delegate = delegate;
+		}
+
+		@Override
+		protected Optional<ExcludeFilter> load( final MatchResult matcher ) {
+			return delegate.load( matcher.group( 1 ) ) //
+					.map( ExcludeFilter::new );
+		}
+
+		@Override
+		public String save( final ExcludeFilter filter ) {
+			return format( filter, delegate::save );
+		}
+
+		private static String format( final ExcludeFilter filter, final Function<Filter, String> wrapped ) {
+			return String.format( FORMAT, wrapped.apply( filter.filter ) );
+		}
+	}
+}

--- a/src/main/java/de/retest/recheck/review/ignore/ExcludeFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/ExcludeFilter.java
@@ -15,7 +15,9 @@ import de.retest.recheck.ui.diff.AttributeDifference;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class ExcludeFilter implements Filter {
 
@@ -81,6 +83,7 @@ public class ExcludeFilter implements Filter {
 				if ( load.isPresent() ) {
 					filters.add( load.get() );
 				} else { // There was a loading error, abort
+					log.warn( "Could not find loader for inner part '{}'.", inner );
 					return Optional.empty();
 				}
 			}

--- a/src/main/java/de/retest/recheck/review/ignore/MatcherFilter.java
+++ b/src/main/java/de/retest/recheck/review/ignore/MatcherFilter.java
@@ -18,6 +18,7 @@ import de.retest.recheck.review.ignore.DeletedFilter.DeletedFilterLoader;
 import de.retest.recheck.review.ignore.InsertedFilter.InsertedFilterLoader;
 import de.retest.recheck.review.ignore.PixelDiffFilter.PixelDiffFilterLoader;
 import de.retest.recheck.review.ignore.ValueRegexFilter.ValueRegexFilterLoader;
+import de.retest.recheck.review.ignore.io.ImportExternalFilterLoader;
 import de.retest.recheck.review.ignore.io.InheritanceLoader;
 import de.retest.recheck.review.ignore.io.Loader;
 import de.retest.recheck.review.ignore.io.Loaders;
@@ -49,7 +50,27 @@ public class MatcherFilter implements Filter {
 
 	public static class MatcherFilterLoader extends RegexLoader<Filter> {
 
+		static final String MATCHER = "matcher: ";
+
+		private static final Pattern REGEX = Pattern.compile( MATCHER + "(.+)" );
+
+		public static final Loader<Filter> excludeFilters = new InheritanceLoader<>( Arrays.asList( //
+				Pair.of( MatcherFilter.class, new MatcherFilterLoader() ), //
+
+				Pair.of( AttributeFilter.class, new AttributeFilterLoader() ), //
+				Pair.of( AttributeRegexFilter.class, new AttributeRegexFilterLoader() ), //
+
+				Pair.of( PixelDiffFilter.class, new PixelDiffFilterLoader() ), //
+				Pair.of( ValueRegexFilter.class, new ValueRegexFilterLoader() ), //
+				Pair.of( InsertedFilter.class, new InsertedFilterLoader() ), //
+				Pair.of( DeletedFilter.class, new DeletedFilterLoader() ), //
+
+				Pair.of( ImportedExternalFilter.class, new ImportExternalFilterLoader() ) //
+		) );
+
 		private static final Loader<Filter> chainableFilter = new InheritanceLoader<>( Arrays.asList( //
+				Pair.of( ExcludeFilter.class, new ExcludeFilter.FilterLoader( excludeFilters ) ), //
+
 				Pair.of( AttributeFilter.class, new AttributeFilterLoader() ), //
 				Pair.of( AttributeFilter.class, new LegacyAttributeFilterLoader() ), //
 				Pair.of( AttributeRegexFilter.class, new AttributeRegexFilterLoader() ), //
@@ -59,10 +80,6 @@ public class MatcherFilter implements Filter {
 				Pair.of( InsertedFilter.class, new InsertedFilterLoader() ), //
 				Pair.of( DeletedFilter.class, new DeletedFilterLoader() ) //
 		) );
-
-		static final String MATCHER = "matcher: ";
-
-		private static final Pattern REGEX = Pattern.compile( MATCHER + "(.+)" );
 
 		public MatcherFilterLoader() {
 			super( REGEX );

--- a/src/main/resources/default-recheck.ignore
+++ b/src/main/resources/default-recheck.ignore
@@ -6,6 +6,9 @@
 # Or via absolute XPath:
 # matcher: xpath=html[1]/body[1]/iframe[1]
 
+# Or if you want to ignore everything, except specific dom-subtrees:
+# matcher: type=html, exclude(matcher: xpath=html/body/section[4])
+
 # To ignore attributes globally, use:
 # attribute=class
 

--- a/src/test/java/de/retest/recheck/RecheckImplIT.java
+++ b/src/test/java/de/retest/recheck/RecheckImplIT.java
@@ -55,6 +55,7 @@ class RecheckImplIT {
 		execute( "with legacy spaces", RecheckOptions.builder() //
 				.setIgnore( METADATA_FILTER ) // Ignore metadata
 				.fileNamerStrategy( fileNamerStrategy ) //
+				.setIgnore( METADATA_FILTER ) //
 				.build() );
 	}
 
@@ -63,7 +64,14 @@ class RecheckImplIT {
 		execute( "with spaces", RecheckOptions.builder() //
 				.setIgnore( METADATA_FILTER ) //
 				.suiteName( RecheckImplIT.class.getName() + " spaces" ) //
+				.setIgnore( METADATA_FILTER ) //
 				.build() );
+	}
+
+	@Test
+	void diff_should_ignore_everything_but_include_deleted_and_same_attributes_with_change_suffix() {
+		execute( "with_exclude", withIgnore( Filters.parse(
+				"matcher: type=test, exclude(matcher: type=same, exclude(attribute-regex=bar-\\d)), exclude(matcher: type=delete)" ) ) );
 	}
 
 	private RecheckOptions withIgnore( final Filter ignore ) {

--- a/src/test/java/de/retest/recheck/review/ignore/ExcludeFilterIT.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ExcludeFilterIT.java
@@ -1,0 +1,35 @@
+package de.retest.recheck.review.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class ExcludeFilterIT {
+
+	@Test
+	void load_should_handle_multiple_entries() {
+		final Element element = mock( Element.class );
+
+		final AttributeFilter.AttributeFilterLoader delegate = new AttributeFilter.AttributeFilterLoader();
+		final ExcludeFilter.FilterLoader cut = new ExcludeFilter.FilterLoader( delegate );
+
+		assertThat( cut.load( "exclude(attribute=text), exclude(attribute=font)" ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( element, "class" ) ).isTrue();
+			assertThat( filter.matches( element, difference( "class" ) ) ).isTrue();
+
+			assertThat( filter.matches( element, "font" ) ).isFalse();
+			assertThat( filter.matches( element, difference( "font" ) ) ).isFalse();
+
+			assertThat( filter.matches( element, "text" ) ).isFalse();
+			assertThat( filter.matches( element, difference( "text" ) ) ).isFalse();
+		} );
+	}
+
+	private AttributeDifference difference( final String key ) {
+		return new AttributeDifference( key, "expected", "actual" );
+	}
+}

--- a/src/test/java/de/retest/recheck/review/ignore/ExcludeFilterTest.java
+++ b/src/test/java/de/retest/recheck/review/ignore/ExcludeFilterTest.java
@@ -1,0 +1,127 @@
+package de.retest.recheck.review.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.review.ignore.io.Loader;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class ExcludeFilterTest {
+
+	Filter cut;
+
+	Element trueElement;
+	Element falseElement;
+
+	@BeforeEach
+	void setUp() {
+		trueElement = mock( Element.class );
+		falseElement = mock( Element.class );
+
+		final Filter delegate = mock( Filter.class );
+		when( delegate.matches( trueElement ) ).thenReturn( true );
+		when( delegate.matches( eq( trueElement ), anyString() ) ).thenReturn( true );
+		when( delegate.matches( eq( trueElement ), any( AttributeDifference.class ) ) ).thenReturn( true );
+		when( delegate.matches( eq( trueElement ), any( Filter.ChangeType.class ) ) ).thenReturn( true );
+
+		cut = new ExcludeFilter( delegate );
+	}
+
+	@Test
+	void matches_should_always_be_inverted() {
+		assertThat( cut.matches( trueElement ) ).isFalse();
+		assertThat( cut.matches( falseElement ) ).isTrue();
+
+		assertThat( cut.matches( trueElement, "a" ) ).isFalse();
+		assertThat( cut.matches( falseElement, "a" ) ).isTrue();
+
+		assertThat( cut.matches( trueElement, mock( AttributeDifference.class ) ) ).isFalse();
+		assertThat( cut.matches( falseElement, mock( AttributeDifference.class ) ) ).isTrue();
+
+		assertThat( cut.matches( trueElement, Filter.ChangeType.CHANGED ) ).isFalse();
+		assertThat( cut.matches( falseElement, Filter.ChangeType.CHANGED ) ).isTrue();
+	}
+
+	@Nested
+	class FilterLoaderTest {
+
+		Loader<Filter> delegate;
+		Loader<ExcludeFilter> cut;
+
+		@BeforeEach
+		void setUp() {
+			delegate = mock( Loader.class );
+
+			cut = new ExcludeFilter.FilterLoader( delegate );
+		}
+
+		@Test
+		void load_should_fail_if_incomplete() {
+			assertThat( cut.load( "exclude" ) ).isEmpty();
+			assertThat( cut.load( "exclude(" ) ).isEmpty();
+		}
+
+		@Test
+		void load_should_fail_if_empty() {
+			assertThat( cut.load( "exclude()" ) ).isEmpty();
+		}
+
+		@Test
+		void load_should_delegate_if_parsed() {
+			final Filter wrapped = mock( Filter.class );
+			when( delegate.load( "foo" ) ).thenReturn( Optional.of( wrapped ) );
+
+			assertThat( cut.load( "exclude(foo)" ) ).hasValueSatisfying( filter -> {
+				assertThat( filter.getFilter() ).isEqualTo( wrapped );
+			} );
+		}
+
+		@Test
+		void load_should_forward_spaces_to_delegate() {
+			final Filter wrapped = mock( Filter.class );
+
+			when( delegate.load( " foo" ) ).thenReturn( Optional.of( wrapped ) );
+			assertThat( cut.load( "exclude( foo)" ) ).isPresent();
+			assertThat( cut.load( "exclude( foo )" ) ).isEmpty();
+
+			when( delegate.load( "foo " ) ).thenReturn( Optional.of( wrapped ) );
+			assertThat( cut.load( "exclude(foo )" ) ).isPresent();
+			assertThat( cut.load( "exclude( foo )" ) ).isEmpty();
+
+			when( delegate.load( " foo " ) ).thenReturn( Optional.of( wrapped ) );
+			assertThat( cut.load( "exclude( foo )" ) ).isPresent();
+		}
+
+		@Test
+		void load_should_fail_if_delegate_fails_to_load() {
+			when( delegate.load( anyString() ) ).thenReturn( Optional.empty() );
+
+			assertThat( cut.load( "exclude(foo)" ) ).isEmpty();
+			verify( delegate ).load( "foo" );
+		}
+
+		@Test
+		void save_should_delegate() {
+			when( delegate.save( any( Filter.class ) ) ).thenReturn( "foo" );
+
+			final Filter filter = mock( Filter.class );
+			final ExcludeFilter negated = new ExcludeFilter( filter );
+
+			assertThat( cut.save( negated ) ).isEqualTo( "exclude(foo)" );
+			verify( delegate ).save( filter );
+		}
+	}
+}

--- a/src/test/java/de/retest/recheck/review/ignore/MatcherFilterIT.java
+++ b/src/test/java/de/retest/recheck/review/ignore/MatcherFilterIT.java
@@ -1,0 +1,430 @@
+package de.retest.recheck.review.ignore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.retest.recheck.ignore.Filter;
+import de.retest.recheck.review.ignore.MatcherFilter.MatcherFilterLoader;
+import de.retest.recheck.ui.Path;
+import de.retest.recheck.ui.PathElement;
+import de.retest.recheck.ui.descriptors.Attributes;
+import de.retest.recheck.ui.descriptors.Element;
+import de.retest.recheck.ui.descriptors.IdentifyingAttributes;
+import de.retest.recheck.ui.descriptors.MutableAttributes;
+import de.retest.recheck.ui.descriptors.PathAttribute;
+import de.retest.recheck.ui.descriptors.RootElement;
+import de.retest.recheck.ui.descriptors.StringAttribute;
+import de.retest.recheck.ui.diff.AttributeDifference;
+
+class MatcherFilterIT {
+
+	Element html;
+	Element body;
+	Element subscribe;
+	Element unsubscribe;
+	Element div1;
+	Element form;
+	Element input;
+	Element div2;
+	Element nav;
+
+	MatcherFilterLoader loader;
+
+	@BeforeEach
+	void setUp() {
+		loader = new MatcherFilterLoader();
+
+		html = root( "html", attributes( "lang", "en" ) );
+		body = element( html, "body", id( html, "body", 1 ) );
+		subscribe = element( body, "button", id( body, "button", 1, "id", "btn-subscribe" ) );
+		unsubscribe = element( body, "button", id( body, "button", 2, "id", "btn-unsubscribe" ) );
+		div1 = element( body, "div", id( body, "div", 1, "id", "div" ) );
+		form = element( div1, "form", id( div1, "form", 1, "id", "form" ) );
+		input = element( form, "input", id( form, "input", 1, "id", "input" ) );
+		div2 = element( body, "div", id( body, "div", 2 ) );
+		nav = element( div2, "nav", id( div2, "nav", 1 ) );
+	}
+
+	@Test
+	void exclude_matcher_should_correctly_apply_to_chained_and_nested_children() {
+		final String line =
+				"matcher: type=body, exclude(matcher: id=btn-subscribe), exclude(matcher: xpath=html/body/div, exclude(matcher: id=form))";
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( html ) ).isFalse();
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( subscribe ) ).isFalse();
+			assertThat( filter.matches( unsubscribe ) ).isTrue();
+			assertThat( filter.matches( div1 ) ).isFalse();
+			assertThat( filter.matches( form ) ).isTrue();
+			assertThat( filter.matches( input ) ).isTrue();
+			assertThat( filter.matches( div2 ) ).isTrue();
+			assertThat( filter.matches( nav ) ).isTrue();
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "attribute", "attribute-regex" } )
+	void exclude_matcher_with_attribute_should_only_match_changed_for_that_element_and_attribute_value( String key ) {
+		String line = String.format( "matcher: type=body, exclude(matcher: id=form, %s=text)", key );
+		final AttributeDifference text = new AttributeDifference( "text", "foo", "bar" );
+		final AttributeDifference content = new AttributeDifference( "content", "foo", "bar" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( body, "content" ) ).isTrue();
+			assertThat( filter.matches( body, content ) ).isTrue();
+			assertThat( filter.matches( body, "text" ) ).isTrue();
+			assertThat( filter.matches( body, text ) ).isTrue();
+
+			assertThat( filter.matches( form ) ).isTrue();
+			assertThat( filter.matches( form, "content" ) ).isTrue();
+			assertThat( filter.matches( form, content ) ).isTrue();
+			assertThat( filter.matches( form, "text" ) ).isFalse();
+			assertThat( filter.matches( form, text ) ).isFalse();
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "attribute", "attribute-regex" } )
+	void exclude_matcher_with_attribute_and_pixel_diff_should_only_match_element_attribute_pixel_differences(
+			String key ) {
+		String line = String
+				.format( "matcher: type=body, exclude(matcher: id=div, %s=border-bottom-width, pixel-diff=5px)", key );
+
+		AttributeDifference equalBelow = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		AttributeDifference equalEqual = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		AttributeDifference equalAbove = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		AttributeDifference nonEqualBelow = new AttributeDifference( "border-top-width", "1px", "2px" );
+		AttributeDifference nonEqualEqual = new AttributeDifference( "border-top-width", "1px", "5px" );
+		AttributeDifference nonEqualAbove = new AttributeDifference( "border-top-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( body, "border-bottom-width" ) ).isTrue();
+			assertThat( filter.matches( body, "border-top-width" ) ).isTrue();
+			assertThat( filter.matches( body, equalBelow ) ).isTrue();
+			assertThat( filter.matches( body, equalEqual ) ).isTrue();
+			assertThat( filter.matches( body, equalAbove ) ).isTrue();
+			assertThat( filter.matches( body, nonEqualBelow ) ).isTrue();
+			assertThat( filter.matches( body, nonEqualEqual ) ).isTrue();
+			assertThat( filter.matches( body, nonEqualAbove ) ).isTrue();
+
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, "border-bottom-width" ) ).isTrue();
+			assertThat( filter.matches( div1, "border-top-width" ) ).isTrue();
+			assertThat( filter.matches( div1, equalBelow ) ).isFalse();
+			assertThat( filter.matches( div1, equalEqual ) ).isFalse();
+			assertThat( filter.matches( div1, equalAbove ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualBelow ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualEqual ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualAbove ) ).isTrue();
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "attribute", "attribute-regex" } )
+	void exclude_matcher_with_attribute_and_value_should_only_match_changed_for_that_element_and_attribute_value(
+			String key ) {
+		String line = String
+				.format( "matcher: type=body, exclude(matcher: id=div, %s=border-bottom-width, value-regex=5px)", key );
+
+		final AttributeDifference equalBelow = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equalEqual = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference equalAbove = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		final AttributeDifference nonEqualBelow = new AttributeDifference( "border-top-width", "1px", "2px" );
+		final AttributeDifference nonEqualEqual = new AttributeDifference( "border-top-width", "1px", "5px" );
+		final AttributeDifference nonEqualAbove = new AttributeDifference( "border-top-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( body, "border-bottom-width" ) ).isTrue();
+			assertThat( filter.matches( body, "border-top-width" ) ).isTrue();
+			assertThat( filter.matches( body, equalBelow ) ).isTrue();
+			assertThat( filter.matches( body, equalEqual ) ).isTrue();
+			assertThat( filter.matches( body, equalAbove ) ).isTrue();
+			assertThat( filter.matches( body, nonEqualBelow ) ).isTrue();
+			assertThat( filter.matches( body, nonEqualEqual ) ).isTrue();
+			assertThat( filter.matches( body, nonEqualAbove ) ).isTrue();
+
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, "border-bottom-width" ) ).isTrue();
+			assertThat( filter.matches( div1, "border-top-width" ) ).isTrue();
+			assertThat( filter.matches( div1, equalBelow ) ).isTrue();
+			assertThat( filter.matches( div1, equalEqual ) ).isFalse();
+			assertThat( filter.matches( div1, equalAbove ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualBelow ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualEqual ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualAbove ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_matcher_with_pixel_diff_should_only_match_pixel_differences() {
+		String line = "matcher: type=body, exclude(matcher: id=div, pixel-diff=5px)";
+
+		final AttributeDifference below = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equal = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference above = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( body, below ) ).isTrue();
+			assertThat( filter.matches( body, equal ) ).isTrue();
+			assertThat( filter.matches( body, above ) ).isTrue();
+
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, below ) ).isFalse();
+			assertThat( filter.matches( div1, equal ) ).isFalse();
+			assertThat( filter.matches( div1, above ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_matcher_with_value_should_only_match_exact_value() {
+		String line = "matcher: type=body, exclude(matcher: id=div, value-regex=5px)";
+
+		final AttributeDifference below = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equal = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference above = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( body, below ) ).isTrue();
+			assertThat( filter.matches( body, equal ) ).isTrue();
+			assertThat( filter.matches( body, above ) ).isTrue();
+
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, below ) ).isTrue();
+			assertThat( filter.matches( div1, equal ) ).isFalse();
+			assertThat( filter.matches( div1, above ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_matcher_with_inserted_should_only_match_inserted_differences() {
+		String line = "matcher: xpath=html/body/div[2], exclude(matcher: type=nav, change=inserted)";
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( div2 ) ).isTrue();
+			assertThat( filter.matches( div2, Filter.ChangeType.DELETED ) ).isTrue();
+			assertThat( filter.matches( div2, Filter.ChangeType.INSERTED ) ).isTrue();
+
+			assertThat( filter.matches( nav ) ).isTrue();
+			assertThat( filter.matches( nav, Filter.ChangeType.DELETED ) ).isTrue();
+			assertThat( filter.matches( nav, Filter.ChangeType.INSERTED ) ).isFalse();
+		} );
+	}
+
+	@Test
+	void exclude_matcher_with_deleted_should_only_match_deleted_differences() {
+		String line = "matcher: xpath=html/body/div[2], exclude(matcher: type=nav, change=deleted)";
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( div2 ) ).isTrue();
+			assertThat( filter.matches( div2, Filter.ChangeType.INSERTED ) ).isTrue();
+			assertThat( filter.matches( div2, Filter.ChangeType.DELETED ) ).isTrue();
+
+			assertThat( filter.matches( nav ) ).isTrue();
+			assertThat( filter.matches( nav, Filter.ChangeType.INSERTED ) ).isTrue();
+			assertThat( filter.matches( nav, Filter.ChangeType.DELETED ) ).isFalse();
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "attribute", "attribute-regex" } )
+	void exclude_attribute_should_just_match_changed( String key ) {
+		String line = String.format( "matcher: type=form, exclude(%s=text)", key );
+		final AttributeDifference text = new AttributeDifference( "text", "foo", "bar" );
+		final AttributeDifference content = new AttributeDifference( "content", "foo", "bar" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( form ) ).isTrue();
+			assertThat( filter.matches( form, "content" ) ).isTrue();
+			assertThat( filter.matches( form, content ) ).isTrue();
+			assertThat( filter.matches( form, "text" ) ).isFalse();
+			assertThat( filter.matches( form, text ) ).isFalse();
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "attribute", "attribute-regex" } )
+	void exclude_attribute_and_pixel_diff_should_match_changed( String key ) {
+		String line = String.format( "matcher: type=div, exclude(%s=border-bottom-width, pixel-diff=5px)", key );
+
+		final AttributeDifference equalBelow = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equalEqual = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference equalAbove = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		final AttributeDifference nonEqualBelow = new AttributeDifference( "border-top-width", "1px", "2px" );
+		final AttributeDifference nonEqualEqual = new AttributeDifference( "border-top-width", "1px", "5px" );
+		final AttributeDifference nonEqualAbove = new AttributeDifference( "border-top-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( form ) ).isTrue();
+
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, "border-bottom-width" ) ).isTrue();
+			assertThat( filter.matches( div1, "border-top-width" ) ).isTrue();
+			assertThat( filter.matches( div1, equalBelow ) ).isFalse();
+			assertThat( filter.matches( div1, equalEqual ) ).isFalse();
+			assertThat( filter.matches( div1, equalAbove ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualBelow ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualEqual ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualAbove ) ).isTrue();
+		} );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "attribute", "attribute-regex" } )
+	void exclude_attribute_and_value_should_match_changed( String key ) {
+		String line = String.format( "matcher: type=div, exclude(%s=border-bottom-width, value-regex=5px)", key );
+
+		final AttributeDifference equalBelow = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equalEqual = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference equalAbove = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		final AttributeDifference nonEqualBelow = new AttributeDifference( "border-top-width", "1px", "2px" );
+		final AttributeDifference nonEqualEqual = new AttributeDifference( "border-top-width", "1px", "5px" );
+		final AttributeDifference nonEqualAbove = new AttributeDifference( "border-top-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( form ) ).isTrue();
+
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, "border-bottom-width" ) ).isTrue();
+			assertThat( filter.matches( div1, "border-top-width" ) ).isTrue();
+			assertThat( filter.matches( div1, equalBelow ) ).isTrue();
+			assertThat( filter.matches( div1, equalEqual ) ).isFalse();
+			assertThat( filter.matches( div1, equalAbove ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualBelow ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualEqual ) ).isTrue();
+			assertThat( filter.matches( div1, nonEqualAbove ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_pixel_diff_should_only_match_changed() {
+		String line = "matcher: id=div, exclude(pixel-diff=5px)";
+
+		final AttributeDifference below = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equal = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference above = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, below ) ).isFalse();
+			assertThat( filter.matches( div1, equal ) ).isFalse();
+			assertThat( filter.matches( div1, above ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_value_should_only_match_exact_value() {
+		String line = "matcher: id=div, exclude(value-regex=5px)";
+
+		final AttributeDifference below = new AttributeDifference( "border-bottom-width", "1px", "2px" );
+		final AttributeDifference equal = new AttributeDifference( "border-bottom-width", "1px", "5px" );
+		final AttributeDifference above = new AttributeDifference( "border-bottom-width", "1px", "7px" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( div1 ) ).isTrue();
+			assertThat( filter.matches( div1, below ) ).isTrue();
+			assertThat( filter.matches( div1, equal ) ).isFalse();
+			assertThat( filter.matches( div1, above ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_inserted_should_only_match_inserted_differences() {
+		String line = "matcher: type=nav, exclude(change=inserted)";
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( nav ) ).isTrue();
+			assertThat( filter.matches( nav, Filter.ChangeType.INSERTED ) ).isFalse();
+			assertThat( filter.matches( nav, Filter.ChangeType.DELETED ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_deleted_should_only_match_deleted_differences() {
+		String line = "matcher: type=nav, exclude(change=deleted)";
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( nav ) ).isTrue();
+			assertThat( filter.matches( nav, Filter.ChangeType.DELETED ) ).isFalse();
+			assertThat( filter.matches( nav, Filter.ChangeType.INSERTED ) ).isTrue();
+		} );
+	}
+
+	@Test
+	void exclude_import_content_should_match_content() {
+		String line = "matcher: type=body, exclude(import: content.filter)";
+		final AttributeDifference text = new AttributeDifference( "text", "foo", "bar" );
+		final AttributeDifference width = new AttributeDifference( "width", "10px", "20px" );
+		final AttributeDifference placeholder = new AttributeDifference( "placeholder", "Email", "Username" );
+
+		assertThat( loader.load( line ) ).hasValueSatisfying( filter -> {
+			assertThat( filter.matches( body ) ).isTrue();
+			assertThat( filter.matches( body, "width" ) ).isTrue();
+			assertThat( filter.matches( body, width ) ).isTrue();
+			assertThat( filter.matches( body, "title" ) ).isFalse();
+			assertThat( filter.matches( body, text ) ).isFalse();
+
+			assertThat( filter.matches( input ) ).isTrue();
+			assertThat( filter.matches( input, "placeholder" ) ).isFalse();
+			assertThat( filter.matches( input, placeholder ) ).isFalse();
+		} );
+	}
+
+	private RootElement root( final String type, final Attributes attributes ) {
+		return new RootElement( type, id( type, Path.fromString( type ) ), attributes, null, null, 0, null );
+	}
+
+	private Element element( final Element parent, final String type, final IdentifyingAttributes id ) {
+		return element( parent, type, id, attributes() );
+	}
+
+	private Element element( final Element parent, final String type, final IdentifyingAttributes id,
+			final Attributes attributes ) {
+		final Element element = Element.create( type, parent, id, attributes );
+		parent.addChildren( element );
+		return element;
+	}
+
+	private Attributes attributes( final String... attributes ) {
+		final MutableAttributes builder = new MutableAttributes();
+		for ( int i = 0; i < attributes.length; i += 2 ) {
+			builder.put( attributes[i], attributes[i + 1] );
+		}
+		return builder.immutable();
+	}
+
+	private IdentifyingAttributes id( final Element parent, final String type, final int suffix,
+			final String... attributes ) {
+		return id( type, Path.path( parent.getIdentifyingAttributes().getPathTyped(), new PathElement( type, suffix ) ),
+				attributes );
+	}
+
+	private IdentifyingAttributes id( final String type, final Path path, final String... attributes ) {
+		return new IdentifyingAttributes( // 
+				Stream.concat( // 
+						Stream.of( //
+								new PathAttribute( path ), //
+								new StringAttribute( IdentifyingAttributes.TYPE_ATTRIBUTE_KEY, type ) //
+						), //
+						IntStream.range( 0, attributes.length / 2 ) //
+								.mapToObj( i -> new StringAttribute( attributes[i], attributes[i + 1] ) ) // 
+				).collect( Collectors.toList() ) );
+	}
+}

--- a/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_ignore_everything_but_include_deleted_and_same_attributes_with_change_suffix.approved.txt
+++ b/src/test/resources/de/retest/recheck/RecheckImplIT.diff_should_ignore_everything_but_include_deleted_and_same_attributes_with_change_suffix.approved.txt
@@ -1,0 +1,10 @@
+A detailed report will be created at '*'. You can review the details by using our CLI (https://github.com/retest/recheck.cli/) or GUI (https://retest.de/review/).
+
+1 check(s) in 'de.retest.recheck.RecheckImplIT' found the following difference(s):
+Test 'with_exclude' has 3 difference(s) in 1 state(s):
+check resulted in:
+	same (same-id) at 'foo[1]/bar[1]/same[1]':
+		bar-2-change: expected="(default or absent)", actual="bar-2"
+		bar-3-change: expected="(default or absent)", actual="bar-3"
+	delete (delete-id) at 'foo[1]/bar[1]/remove[1]/delete[1]':
+		was deleted

--- a/src/test/resources/retest/recheck/de.retest.recheck.RecheckImplIT/with_exclude.check.recheck/retest.xml
+++ b/src/test/resources/retest/recheck/de.retest.recheck.RecheckImplIT/with_exclude.check.recheck/retest.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reTestXmlDataContainer xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" reTestVersion="${pom.parent.version}" dataType="de.retest.recheck.ui.descriptors.SutState" dataTypeVersion="4">
+	<data xsi:type="sutState">
+		<descriptors retestId="foo-id" screenId="0" screen="screen" title="title">
+			<identifyingAttributes>
+				<attributes>
+					<attribute key="name" xsi:type="textAttribute">test</attribute>
+					<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]</attribute>
+					<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+					<attribute key="text" xsi:type="textAttribute">test</attribute>
+					<attribute key="type" xsi:type="stringAttribute">test</attribute>
+				</attributes>
+			</identifyingAttributes>
+			<attributes>
+				<attributes>
+					<entry>
+						<key>foo-1</key>
+						<value xsi:type="xsd:string">bar-1</value>
+					</entry>
+					<entry>
+						<key>foo-2</key>
+						<value xsi:type="xsd:string">bar-2</value>
+					</entry>
+					<entry>
+						<key>foo-3</key>
+						<value xsi:type="xsd:string">bar-3</value>
+					</entry>
+				</attributes>
+			</attributes>
+			<containedElements retestId="same-id">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="name" xsi:type="textAttribute">same</attribute>
+						<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]/same[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="text" xsi:type="textAttribute">same</attribute>
+						<attribute key="type" xsi:type="stringAttribute">same</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>bar-1</key>
+							<value xsi:type="xsd:string">bar-1</value>
+						</entry>
+						<entry>
+							<key>bar-2</key>
+							<value xsi:type="xsd:string">bar-2</value>
+						</entry>
+						<entry>
+							<key>bar-3</key>
+							<value xsi:type="xsd:string">bar-3</value>
+						</entry>
+					</attributes>
+				</attributes>
+			</containedElements>
+			<containedElements retestId="delete-id">
+				<identifyingAttributes>
+					<attributes>
+						<attribute key="name" xsi:type="textAttribute">delete</attribute>
+						<attribute key="path" xsi:type="pathAttribute">foo[1]/bar[1]/remove[1]/delete[1]</attribute>
+						<attribute key="suffix" xsi:type="suffixAttribute">1</attribute>
+						<attribute key="text" xsi:type="textAttribute">delete</attribute>
+						<attribute key="type" xsi:type="stringAttribute">delete</attribute>
+					</attributes>
+				</identifyingAttributes>
+				<attributes>
+					<attributes>
+						<entry>
+							<key>bar-1</key>
+							<value xsi:type="xsd:string">bar-1</value>
+						</entry>
+						<entry>
+							<key>bar-2</key>
+							<value xsi:type="xsd:string">bar-2</value>
+						</entry>
+						<entry>
+							<key>bar-3</key>
+							<value xsi:type="xsd:string">bar-3</value>
+						</entry>
+					</attributes>
+				</attributes>
+			</containedElements>
+		</descriptors>
+		<metadata>
+			<entry>
+				<key>time.time</key>
+				<value>16:55:21.113</value>
+			</entry>
+			<entry>
+				<key>time.zone</key>
+				<value>Europe/Berlin</value>
+			</entry>
+			<entry>
+				<key>time.offset</key>
+				<value>+02:00</value>
+			</entry>
+			<entry>
+				<key>os.arch</key>
+				<value>amd64</value>
+			</entry>
+			<entry>
+				<key>vcs.commit</key>
+				<value>79327c351bef2439fde41247598b8cacd5c175f6</value>
+			</entry>
+			<entry>
+				<key>os.name</key>
+				<value>Windows 10</value>
+			</entry>
+			<entry>
+				<key>time.date</key>
+				<value>2020-07-03</value>
+			</entry>
+			<entry>
+				<key>vcs.branch</key>
+				<value>feature/negate-filters</value>
+			</entry>
+			<entry>
+				<key>vcs.name</key>
+				<value>git</value>
+			</entry>
+			<entry>
+				<key>machine.name</key>
+				<value>PC-BASTIAN</value>
+			</entry>
+			<entry>
+				<key>os.version</key>
+				<value>10.0</value>
+			</entry>
+		</metadata>
+	</data>
+</reTestXmlDataContainer>


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). (*pending*)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This allows to exclude sub-trees from ignore mechanism.

**This is first a draft to discuss necessary changes to syntax and the like, please do not approve until marked as ready for review. Please refer to the commit messages for additional information.**

Since matching elements always matches the [whole sub-tree](https://docs.retest.de/recheck/usage/filter/#what-are-filters), specific children of the filtered element cannot be excluded. This PR implements such a feature where specific changes can be excluded, be it an element or a single attribute.

This means for the ignore, that a parent can be ignored, but several child elements may still be included. Likewise the same syntax is applicable if the parent should be ignored, but specific attributes should still be included.

### Assumptions

During prototyping, the following assumptions have been made:

1. Exclusion, in contrast to the git-syntax, should not happen on a separate line. It shall be encompassed within the matching filter rule.
2. The exclude syntax must be enclosed by some sort of grouping mechanism. We have chosen to use parenthesis `($exclusion)`.
3. Excludes may be chained, so that the multiple children can be specified. However, once a exclude is specified, only other excludes may follow: `$matcher, $exclude, $exclude, ...`.
4. Excludes may be nested, to reverse another sub-tree.

### Syntax

Excludes can be chained, but once specified, only may be followed up by other excludes
```regex
$matcher(, exclude\($child\))*
```
where the child can be any of (similar to the matcher follow-ups):
```regex
$child=$matcher|$attribute|$value|$inserted|$deleted|$pixel-diff|$color-diff
```

*There may be no spaces before and after the parenthesis, because that would have made the parsing even more complex.*

#### Example

See [MatcherFilterIT](https://github.com/retest/recheck/blob/feature/add-exclude-filter/src/test/java/de/retest/recheck/review/ignore/MatcherFilterIT.java):

```
matcher: id=body, exclude(attribute=text), exclude(matcher: id=btn-subscribe), exclude(matcher: id=div, exclude(matcher: id=form))
```

I have indicated the elements to be ignored (red) and elements to be included (green):
```diff
-<body>
+    <div id="id">
-        <form>
-            <label for="email">Email</label>
-            <input id="email" type="email">
-        </form>       
+        <nav></nav> 
+    </div>
-    <div>
+        <button id="btn-subscribe">Subscribe</button>
-    </div>
-</body>
```

*More examples can be found in the tests.*

### Implementation

#### Parsing the expression

*All regular expressions have been verified with [regex101.com](regex101.com).*

The parsing of chainable and nestable expressions is not straight forward in Java. Therefore the expressions used are quite complex.

##### Chaining

Sadly, Java regular expressions are not able to parse expressions with variable number of groups (chunk), thus the parsing is quite complex to identify each exclude chunk. These chunks must be as small as possible, using the lazy quanitifier.

The identification is done in two stages:

1. Check if the expression is valid with a control expression.
2. Iterate through the string to have the another expression identify each chunk. Here the following cases must be looked at, for which a expression is used.
    1. Begin of the string `^exclude\(...\), `
    2. Middle of the string `, exclude(...\), `
    3. End of the string `, exclude\(...\)$)

##### Nesting

Since excludes can be nested `exclude(matcher: id=foo, exclude(attribute=bar))`,  it must be ensured that the correct closing parenthesis is matched. To work around the issue that the shortest chunk is used (which would always match the first available closing parenthesis), a positive lookahead is used to identify the separator.

##### Combining

Once a chunk is matched, the inner chunk is analyzed from the exclusively matched three groups (as described above). The inner chunk is passed to the delegating loader without pre-processing (i.e. trimming) and added to the filter list. If loading of the inner chunk fails, the loading is aborted with a warning message. Consequently, the loading should abort for the matcher filter.

#### Concatenating filters

Since excluded filters should be chainable with `, `, a container filter is required. The problem is the saving process: The filters are matched to their respective loaders by their class, so that the loaders are responsible for saving. Thus a loader should not be avoided to have generic container filters.

In general (syntax), the `, ` operator uses the `and` concatenation (`AllMatchFilter`).  For this reason, I changed the backing implementation to use a single filter (a.k.a. [De Morgan](https://en.wikipedia.org/wiki/De_Morgan%27s_laws)):

```
!a && !b && !c = !(a || b || c)
```

Thus the loader concatenates each inner part (`export(inner)`) into a `AnyMatchFilter` and wraps it into a `ExcludedFilter`. Thus the semantic is the same, but only one unique filter is exported, which can be assigned to the correct loader upon save.

This is reversed when saving the filter, to 

### State of this PR

The following things have to be discussed:

1. Where else (besides `matcher`) shall the `exclude` be allowed? E.g.: Does it make sense to have something `pixel-diff=5px, exclude(attribute=data-bar)`.
2. Should the exclude be allowed as top level?