### PR TITLE
Allow to disable the uploading to rehub on individual tests...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Table of Contents
 ### New Features
 
 * Metadata differences are now filterable via the recheck.ignore. A new `metadata.filter` has been added which can be imported with `import: metadata.filter` in `recheck.ignore`.
+* Add a `disableReportUpload` method.
 
 ### Improvements
 

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -201,6 +201,17 @@ public class RecheckOptions {
 		}
 
 		/**
+		 * Disables upload to <a href="https://retest.de/rehub/">rehub</a> so that all reports are stored only locally.
+		 * Default: false.
+		 *
+		 * @return self
+		 */
+		public RecheckOptionsBuilder disableReportUpload() {
+			reportUploadEnabled = false;
+			return this;
+		}
+
+		/**
 		 * Overwrites the filter used for filtering the report after a test. The filter cannot be used in conjunction
 		 * with {@link #addIgnore(String)}.
 		 *


### PR DESCRIPTION
- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [ ] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [ ] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

## Description

TL;DR: Add a `disableReportUpload` method.