### PR TITLE
Add bot account for mergify to perform actions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,8 @@ pull_request_rules:
       - "#changes-requested-reviews-by=0"
       - "-draft"
     actions:
-      rebase: {}
+      rebase:
+        bot_account: rebazer
 
   - name: "merge non-release PRs with strict rebase"
     conditions:
@@ -19,6 +20,7 @@ pull_request_rules:
         strict: true
         strict_method: rebase
         method: merge
+        bot_account: rebazer
 
   - name: "merge release PRs with strict merge"
     conditions:
@@ -30,6 +32,7 @@ pull_request_rules:
       merge:
         strict: true
         method: merge
+        bot_account: rebazer
 
   - name: "delete PR branches after merge"
     conditions:


### PR DESCRIPTION
Mergify now has the option to allow specific users to perform merges/rebases: https://blog.mergify.io/selecting-your-bot-account/

As always, we will test this out with one repository, and if it works, release this to all repos currently using mergify.

Since this affects the mergify.yml, the PR must be merged manually and only then will we know, if that works.