### PR TITLE
Feature/detect project layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Table of Contents
 * Metadata differences are now filterable via the recheck.ignore. New `volatile-metadata.filter` and `metadata.filter` filters have been added, where the first one filters metadata which is added for diagnosing purposes and too verbose to be displayed upon every change and the latter filters _all_ metadata. They can be imported with `import: volatile-metadata.filter` and `import: metadata.filter` in `recheck.ignore`.
 * Add `exclude()` filter expression to allow child elements to be excluded. Ignoring an element `matcher: type=body, exclude(matcher: type=button)` will ignore everything below the `body` element but still capture changes for `button` elements.
 * Add a `disableReportUpload` method.
+* The `ProjectLayout` will now be automatically detected (Maven and Gradle) and will throw an error if it cannot fall back to Maven, in which case a custom `ProjectLayout` has to be provided.
 
 ### Improvements
 

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -18,6 +18,7 @@ import de.retest.recheck.persistence.GradleProjectLayout;
 import de.retest.recheck.persistence.MavenProjectLayout;
 import de.retest.recheck.persistence.NamingStrategy;
 import de.retest.recheck.persistence.ProjectLayout;
+import de.retest.recheck.persistence.ProjectLayouts;
 import de.retest.recheck.ui.descriptors.idproviders.RetestIdProvider;
 import de.retest.recheck.util.RetestIdProviderUtil;
 import lombok.AccessLevel;
@@ -129,7 +130,7 @@ public class RecheckOptions {
 
 		private FileNamerStrategy fileNamerStrategy;
 		private NamingStrategy namingStrategy = new ClassAndMethodBasedNamingStrategy();
-		private ProjectLayout projectLayout = new MavenProjectLayout();
+		private ProjectLayout projectLayout;
 		private String suiteName = null;
 		private Boolean reportUploadEnabled;
 		private Filter ignoreFilter = null;
@@ -274,6 +275,9 @@ public class RecheckOptions {
 
 		public RecheckOptions build() {
 			ProjectConfiguration.getInstance().ensureProjectConfigurationInitialized();
+			if ( projectLayout == null ) {
+				projectLayout( ProjectLayouts.detect() );
+			}
 			final String suiteName = getSuiteName();
 			final NamingStrategy namingStrategy = new FixedSuiteNamingStrategy( suiteName, this.namingStrategy );
 			return new RecheckOptions( fileNamerStrategy, namingStrategy, projectLayout,

--- a/src/main/java/de/retest/recheck/persistence/ProjectLayouts.java
+++ b/src/main/java/de/retest/recheck/persistence/ProjectLayouts.java
@@ -1,0 +1,40 @@
+package de.retest.recheck.persistence;
+
+import java.nio.file.Path;
+
+import de.retest.recheck.configuration.ProjectRootFinderUtil;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor( access = AccessLevel.PRIVATE )
+public class ProjectLayouts {
+
+	public static final String POM_XML = "pom.xml";
+	public static final String BUILD_GRADLE = "build.gradle";
+
+	public static ProjectLayout detect() {
+		return ProjectRootFinderUtil.getProjectRoot() //
+				.map( ProjectLayouts::findProjectBasedOnFiles ) //
+				.orElseThrow( ProjectLayouts::noProjectLayoutFound );
+	}
+
+	private static ProjectLayout findProjectBasedOnFiles( final Path path ) {
+		if ( exists( path, POM_XML ) ) {
+			return new MavenProjectLayout();
+		}
+		if ( exists( path, BUILD_GRADLE ) ) {
+			return new GradleProjectLayout();
+		}
+		return null;
+	}
+
+	private static boolean exists( final Path path, final String mavenPomFile ) {
+		// https://rules.sonarsource.com/java/tag/performance/RSPEC-3725
+		return path.resolve( mavenPomFile ).toFile().exists();
+	}
+
+	private static IllegalStateException noProjectLayoutFound() {
+		return new IllegalStateException(
+				"Could not detect project layout. Please specify one explicitly with RecheckOptionsBuilder#projectLayout." );
+	}
+}

--- a/src/test/java/de/retest/recheck/RecheckOptionsIT.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsIT.java
@@ -1,0 +1,114 @@
+package de.retest.recheck;
+
+import static de.retest.recheck.persistence.ProjectLayouts.BUILD_GRADLE;
+import static de.retest.recheck.persistence.ProjectLayouts.POM_XML;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+
+import de.retest.recheck.configuration.ProjectConfiguration;
+import de.retest.recheck.persistence.GradleProjectLayout;
+import de.retest.recheck.persistence.MavenProjectLayout;
+import de.retest.recheck.persistence.ProjectLayout;
+
+class RecheckOptionsIT {
+
+	@Nested
+	@ClearSystemProperty( key = ProjectConfiguration.RETEST_PROJECT_ROOT )
+	class RecheckOptionsBuilderIT {
+
+		@BeforeEach
+		void setUp( @TempDir final Path root ) throws IOException {
+			System.setProperty( ProjectConfiguration.RETEST_PROJECT_ROOT, root.toString() );
+			createLayout( root );
+		}
+
+		@Test
+		void layout_should_not_throw_if_no_project_only_maven_is_present( @TempDir Path root ) throws IOException {
+			createFile( root, POM_XML );
+
+			final RecheckOptions options = RecheckOptions.builder().build();
+
+			assertThat( options.getProjectLayout() ).isInstanceOf( MavenProjectLayout.class );
+		}
+
+		@Test
+		void layout_should_identify_if_project_and_maven_present( @TempDir final Path root ) throws IOException {
+			createFolder( root );
+			createFile( root, POM_XML );
+
+			final RecheckOptions options = RecheckOptions.builder().build();
+
+			assertThat( options.getProjectLayout() ).isInstanceOf( MavenProjectLayout.class );
+		}
+
+		@Test
+		void layout_should_not_throw_if_no_project_only_gradle_is_present( @TempDir Path root ) throws IOException {
+			createFile( root, BUILD_GRADLE );
+
+			final RecheckOptions options = RecheckOptions.builder().build();
+
+			assertThat( options.getProjectLayout() ).isInstanceOf( GradleProjectLayout.class );
+		}
+
+		@Test
+		void layout_should_identify_if_project_and_gradle_present( @TempDir final Path root ) throws IOException {
+			createFolder( root );
+			createFile( root, BUILD_GRADLE );
+
+			final RecheckOptions options = RecheckOptions.builder().build();
+
+			assertThat( options.getProjectLayout() ).isInstanceOf( GradleProjectLayout.class );
+		}
+
+		@Test
+		void layout_should_prefer_maven_over_gradle( @TempDir final Path root ) throws IOException {
+			createFolder( root );
+			createFile( root, POM_XML );
+			createFile( root, BUILD_GRADLE );
+
+			final RecheckOptions options = RecheckOptions.builder().build();
+
+			assertThat( options.getProjectLayout() ).isInstanceOf( MavenProjectLayout.class );
+		}
+
+		@ParameterizedTest
+		@ValueSource( strings = { POM_XML, BUILD_GRADLE } )
+		void layout_should_use_specified_layout( String file, @TempDir Path root ) throws IOException {
+			createFolder( root );
+			createFile( root, file );
+
+			final ProjectLayout layout = mock( ProjectLayout.class );
+
+			final RecheckOptions options = RecheckOptions.builder() //
+					.projectLayout( layout ) //
+					.build();
+
+			assertThat( options.getProjectLayout() ).isEqualTo( layout );
+		}
+	}
+
+	private void createLayout( final Path root ) throws IOException {
+		Files.createDirectories( root.resolve( "src/main/java" ) );
+		Files.createDirectories( root.resolve( "src/test/java" ) );
+	}
+
+	private void createFolder( final Path root ) throws IOException {
+		Files.createDirectory( root.resolve( RecheckProperties.RETEST_FOLDER_NAME ) );
+	}
+
+	private void createFile( final Path root, final String file ) throws IOException {
+		Files.createFile( root.resolve( file ) );
+	}
+}

--- a/src/test/java/de/retest/recheck/persistence/ProjectLayoutsIT.java
+++ b/src/test/java/de/retest/recheck/persistence/ProjectLayoutsIT.java
@@ -1,0 +1,88 @@
+package de.retest.recheck.persistence;
+
+import static de.retest.recheck.persistence.ProjectLayouts.BUILD_GRADLE;
+import static de.retest.recheck.persistence.ProjectLayouts.POM_XML;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+
+import de.retest.recheck.RecheckProperties;
+import de.retest.recheck.configuration.ProjectConfiguration;
+
+@ClearSystemProperty( key = ProjectConfiguration.RETEST_PROJECT_ROOT )
+class ProjectLayoutsIT {
+
+	@BeforeEach
+	void setUp( @TempDir final Path root ) {
+		System.setProperty( ProjectConfiguration.RETEST_PROJECT_ROOT, root.toString() );
+	}
+
+	@Test
+	void detect_should_throw_if_project_not_present() {
+		assertThatThrownBy( ProjectLayouts::detect ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessageContaining( "Could not detect project layout" );
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { POM_XML, BUILD_GRADLE } )
+	void detect_should_throw_if_project_does_not_exist( final String file, @TempDir final Path root ) throws IOException {
+		createFile( root, file );
+
+		assertThatThrownBy( ProjectLayouts::detect ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessageContaining( "Could not detect project layout" );
+	}
+
+	@Test
+	void detect_should_throw_if_project_present_without_indicator_file( @TempDir final Path root ) throws IOException {
+		createFolder( root );
+
+		assertThatThrownBy( ProjectLayouts::detect ) //
+				.isInstanceOf( IllegalStateException.class ) //
+				.hasMessageContaining( "Could not detect project layout" );
+	}
+
+	@Test
+	void detect_should_be_maven_if_pom_present( @TempDir final Path root ) throws IOException {
+		createFolder( root );
+		createFile( root, POM_XML );
+
+		assertThat( ProjectLayouts.detect() ).isInstanceOf( MavenProjectLayout.class );
+	}
+
+	@Test
+	void detect_should_be_gradle_if_build_present( @TempDir final Path root ) throws IOException {
+		createFolder( root );
+		createFile( root, BUILD_GRADLE );
+
+		assertThat( ProjectLayouts.detect() ).isInstanceOf( GradleProjectLayout.class );
+	}
+
+	@Test
+	void detect_should_prefer_maven_over_gradle( @TempDir final Path root ) throws IOException {
+		createFolder( root );
+		createFile( root, POM_XML );
+		createFile( root, BUILD_GRADLE );
+
+		assertThat( ProjectLayouts.detect() ).isInstanceOf( MavenProjectLayout.class );
+	}
+
+	private void createFolder( final Path root ) throws IOException {
+		Files.createDirectory( root.resolve( RecheckProperties.RETEST_FOLDER_NAME ) );
+	}
+
+	private void createFile( final Path root, final String file ) throws IOException {
+		Files.createFile( root.resolve( file ) );
+	}
+}


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). (*retest/docs#121*)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR Instead of always using Maven, this performs checks to detect to see if the respective `pom.xml` or `build.gradle` as a central file.

The change is fairly simple:

1. Make the `ProjectLayout` optional instead of having a default.
2. If not defined by the time `RecheckOptions#build` is called, perform some checks to select the appropriate layout.

The detection mechanism only utilizes simple checks, which should suffice for the majority of setups (as explained above). In the future, we might need to do some more advanced checks (similar to `PathBasedProjectRootFinder`) and have multiple indicators. In such a case, we could take a look at what IDEs do when opening such folders.

Note that this will only work for simple use cases. Things like multiple directories with different build systems, multiple build systems or custom configurations of the build systems cannot be reflected with the auto detect. However, in this case I would argue that customizations must be reflected through a respective custom `ProjectLayout`, as we currently use the *convention-over-configuration* and not the *zero-configuration* policy.

Because of simplicity and flaws related to the project discovery (see below), the method layout detection does not differentiate between "project not found" and "no pom.xml or build.gradle file present"

### Initialization

In order to ensure that recheck is properly initialized, I have moved the initialization phase into `RecheckOptionsBuilder#build`. This is related to minimize flaws with the project discovery (see below).

### Testing

All tests are performed within a temporary directory to emulate and configure a clean project. Secondly, they each configure the base folder for the project root discovery (instead of using the execution directory) within `setUp`. But because of the way the project discovery works, especially tests that assume an empty project directory, may fail because some parent directory (e.g. user home) defines a `.retest` folder and is discovered through walking up the file system structure.

Furthermore, most methods `RecheckOptionsBuilderIT` create a project, because the builder might need it (e.g. filter files) for additional checks. Such checks are present in `ProjectLayoutsIT`.

### State of this PR

I am unsure, if we should use the project directory as discovered by `ProjectRootFinderUtil` or use the execution directory as `Paths#get`. The former allows for easier testing as a temporary directory can be used and utilizes the common approach for project discovery. However, as described by the `RecheckOptionsIT`, there are flaws in the project discovery. If there is no project and a custom project layout (i.e. no `src/main/java`) is used, the project directory cannot be identified, and thus an exception is thrown. Therefore we might need to rethink the initial project setup in such a case (i.e. `ProjectConfiguration#ensureProjectConfigurationInitialized`). The workaround for now is to create a `.retest` folder manually.

Although, this changes the default behavior, which could be seen as a breaking change, I would not consider it as such, because the `ProjectLayout` is such an critical component that has to be set. The only use case where this would be a breaking change, if the user never configured it (thus uses maven) and just accepted that the reports are saved within `target` (ignoring it in git or similar). Thus, with the update, this use case would either correctly save reports within `build` (in case of Gradle) or throw (in case of unsupported). If you think different, we could always add an additional warning inside *breaking changes*. In either case, I will double check and make sure that the updated documentation specifies the importance of the project layout.