### PR TITLE
Feature/fix disable report upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Table of Contents
 ### Improvements
 
 * Have the console output much more compact in terms of whitespace used. Con: makes it harder to spot difference details...
+* Project discovery and initialization is now done within `RecheckOptionsBuilder#build` instead of `RecheckImpl#new` to allow earlier access to project variables (e.g. retest.properties). Projects (i.e. `.retest` folders) should still be detected correctly.
+
 
 --------------------------------------------------------------------------------
 

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -74,7 +74,7 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 		suite = SuiteAggregator.getInstance().getSuite( suiteName,
 				options.getProjectLayout().getTestSourcesRoot().orElse( null ) );
 
-		if ( isRehubEnabled( options ) ) {
+		if ( options.isReportUploadEnabled() ) {
 			try {
 				Rehub.authenticate();
 			} catch ( final HeadlessException e ) {
@@ -82,10 +82,6 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 						+ CloudPersistence.RECHECK_API_KEY + "'." );
 			}
 		}
-	}
-
-	private boolean isRehubEnabled( final RecheckOptions options ) {
-		return options.isReportUploadEnabled() || RecheckProperties.getInstance().rehubReportUploadEnabled();
 	}
 
 	@Override

--- a/src/main/java/de/retest/recheck/RecheckImpl.java
+++ b/src/main/java/de/retest/recheck/RecheckImpl.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.execution.RecheckAdapters;
 import de.retest.recheck.execution.RecheckDifferenceFinder;
 import de.retest.recheck.persistence.CloudPersistence;
@@ -67,7 +66,6 @@ public class RecheckImpl implements Recheck, SutStateLoader {
 	}
 
 	public RecheckImpl( final RecheckOptions options ) {
-		ProjectConfiguration.getInstance().ensureProjectConfigurationInitialized();
 		Runtime.getRuntime().addShutdownHook( capWarner );
 		this.options = options;
 		suiteName = options.getNamingStrategy().getSuiteName();

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.retest.recheck.configuration.ProjectConfiguration;
 import de.retest.recheck.ignore.CompoundFilter;
 import de.retest.recheck.ignore.Filter;
 import de.retest.recheck.ignore.RecheckIgnoreLocator;
@@ -272,6 +273,7 @@ public class RecheckOptions {
 		}
 
 		public RecheckOptions build() {
+			ProjectConfiguration.getInstance().ensureProjectConfigurationInitialized();
 			final String suiteName = getSuiteName();
 			final NamingStrategy namingStrategy = new FixedSuiteNamingStrategy( suiteName, this.namingStrategy );
 			return new RecheckOptions( fileNamerStrategy, namingStrategy, projectLayout,

--- a/src/main/java/de/retest/recheck/RecheckOptions.java
+++ b/src/main/java/de/retest/recheck/RecheckOptions.java
@@ -130,7 +130,7 @@ public class RecheckOptions {
 		private NamingStrategy namingStrategy = new ClassAndMethodBasedNamingStrategy();
 		private ProjectLayout projectLayout = new MavenProjectLayout();
 		private String suiteName = null;
-		private boolean reportUploadEnabled = false;
+		private Boolean reportUploadEnabled;
 		private Filter ignoreFilter = null;
 		private RetestIdProvider retestIdProvider = RetestIdProviderUtil.getConfiguredRetestIdProvider();
 		private final List<Filter> ignoreFilterToAdd = new ArrayList<>();
@@ -274,7 +274,9 @@ public class RecheckOptions {
 		public RecheckOptions build() {
 			final String suiteName = getSuiteName();
 			final NamingStrategy namingStrategy = new FixedSuiteNamingStrategy( suiteName, this.namingStrategy );
-			return new RecheckOptions( fileNamerStrategy, namingStrategy, projectLayout, reportUploadEnabled,
+			return new RecheckOptions( fileNamerStrategy, namingStrategy, projectLayout,
+					reportUploadEnabled != null ? reportUploadEnabled
+							: RecheckProperties.getInstance().rehubReportUploadEnabled(),
 					buildFilter( suiteName ), retestIdProvider );
 		}
 

--- a/src/test/java/de/retest/recheck/RecheckOptionsTest.java
+++ b/src/test/java/de/retest/recheck/RecheckOptionsTest.java
@@ -14,6 +14,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.ClearSystemProperty;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 import de.retest.recheck.RecheckOptions.RecheckOptionsBuilder;
 import de.retest.recheck.ignore.CompoundFilter;
@@ -138,5 +141,41 @@ class RecheckOptionsTest {
 						.projectLayout( projectLayout )//
 						.suiteName( "name" ) //
 		);
+	}
+
+	@Test
+	@SetSystemProperty( key = RecheckProperties.REHUB_REPORT_UPLOAD_ENABLED_PROPERTY_KEY, value = "true" )
+	void build_with_rehub_not_set_should_read_property_true() {
+		final RecheckOptions cut = RecheckOptions.builder().build();
+		assertThat( cut.isReportUploadEnabled() ).isTrue();
+	}
+
+	@Test
+	@SetSystemProperty( key = RecheckProperties.REHUB_REPORT_UPLOAD_ENABLED_PROPERTY_KEY, value = "false" )
+	void build_with_rehub_not_set_should_read_property_false() {
+		final RecheckOptions cut = RecheckOptions.builder().build();
+		assertThat( cut.isReportUploadEnabled() ).isFalse();
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	@ClearSystemProperty( key = RecheckProperties.REHUB_REPORT_UPLOAD_ENABLED_PROPERTY_KEY )
+	void build_with_rehub_enabled_should_overwrite_property_regardless_of_its_value( String global ) {
+		System.setProperty( RecheckProperties.REHUB_REPORT_UPLOAD_ENABLED_PROPERTY_KEY, global );
+		final RecheckOptions cut = RecheckOptions.builder() //
+				.enableReportUpload() //
+				.build();
+		assertThat( cut.isReportUploadEnabled() ).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource( strings = { "true", "false" } )
+	@ClearSystemProperty( key = RecheckProperties.REHUB_REPORT_UPLOAD_ENABLED_PROPERTY_KEY )
+	void build_with_rehub_disabled_should_overwrite_property_regardless_of_its_value( String global ) {
+		System.setProperty( RecheckProperties.REHUB_REPORT_UPLOAD_ENABLED_PROPERTY_KEY, global );
+		final RecheckOptions cut = RecheckOptions.builder() //
+				.disableReportUpload() //
+				.build();
+		assertThat( cut.isReportUploadEnabled() ).isFalse();
 	}
 }


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] ~you updated the changelog.~ *(not necessary, since this feature has not been released yet)*
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs). *(retest/docs#120)*

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR If property not set, this will still upload if disabled locally, but enabled globally.

Since the `RecheckImpl` always checks the property if disabled locally, the feature introduced in #760 will not work.

For that to work, I have moved the check for upload into the options construction so that it will be evaluated upon construction. This is achieved by changing the `boolean` to a `Boolean` to allow for an tri-state evaluation, where `null` will read the property.

### State of this PR

Since this reads out the properties (i.e. `retest.properties`), it must be ensured that the project is correctly configured. More details can be read inside #763. This was discovered, because `GlobalChangeSetApplierIT` checks that no `absolute-outline` change is present. I included the respective commit (cherry-picked) for this branch to have the record show that this is required for both PRs&mdash;despite for slightly different reasons&mdash;, although it will result in merge conflicts in either this or #763, depending on which PR gets merged first.

I have not included an integration test for the `RecheckOptions` and `RecheckImpl`, since testing this is nearly impossible. That's why I did not check the original PR properly. However, I have verified that this works manually.