### PR TITLE
Run tests with newest JDK 14

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -8,8 +8,8 @@ set -o pipefail
 # Compile with JDK 8
 mvn ${MVN_ARGS} clean package -DskipTests
 
-# Test with JDK 13
-wget --quiet https://github.com/sormuras/bach/raw/master/install-jdk.sh && . ./install-jdk.sh -F 13
+# Test with JDK 14
+wget --quiet https://github.com/sormuras/bach/raw/master/install-jdk.sh && . ./install-jdk.sh -F 14
 
 if [ ${TRAVIS_SECURE_ENV_VARS} = "true" ]; then
     mvn ${MVN_ARGS} verify sonar:sonar -Pcoverage


### PR DESCRIPTION
Finally I can get rid of this. 😉

PS: https://community.sonarsource.com/t/sonarcloud-knows-how-to-scan-your-java-14-code/28410

PPS: You have to update your SonarCloud token.