### PR TITLE
Feature/fix inserted deleted element apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Table of Contents
 ### Bug Fixes
 
 * Add path info to filter, after they where missing in last release because of `FileSystemAlreadyExistsException` fix.
+* Fix some cases where applying deleted elements would not remove them from the Golden Master.
 
 ### New Features
 
@@ -48,7 +49,7 @@ Table of Contents
 ### Bug Fixes
 
 * Fix a rare `java.nio.file.FileSystemAlreadyExistsException` when accessing filters concurrently.
-* Fix 1-click-maintenance not respecting the key of the `AttributeDifference`. 
+* Fix 1-click-maintenance not respecting the key of the `AttributeDifference`.
 * Updated and now configurable URLs for rehub backend services
 
 ### New Features

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.eclipse.persistence.oxm.annotations.XmlInverseReference;
@@ -129,15 +130,16 @@ public class Element implements Serializable, Comparable<Element> {
 	private List<Element> removeDeleted( final ActionChangeSet actionChangeSet,
 			final List<Element> oldContainedElements ) {
 		final Set<IdentifyingAttributes> deletedChanges = actionChangeSet.getDeletedChanges();
-		final List<Element> newContainedElements = new ArrayList<>( oldContainedElements.size() );
-
-		for ( final Element oldElement : oldContainedElements ) {
-			if ( !deletedChanges.contains( oldElement.getIdentifyingAttributes() ) ) {
-				newContainedElements.add( oldElement );
-			}
-		}
-
-		return newContainedElements;
+		// IdentifyingAttributes#equals cannot be used here, due to volatile attributes (e.g. outline)
+		final List<String> deletedIdentifiers = deletedChanges.stream() //
+				.map( IdentifyingAttributes::identifier ) //
+				.collect( Collectors.toList() );
+		return oldContainedElements.stream() //
+				.filter( element -> {
+					final IdentifyingAttributes attributes = element.getIdentifyingAttributes();
+					return !deletedIdentifiers.contains( attributes.identifier() );
+				} ) //
+				.collect( Collectors.toList() );
 	}
 
 	private List<Element> applyChangesToContainedElements( final ActionChangeSet actionChangeSet,

--- a/src/test/java/de/retest/recheck/ui/descriptors/ElementIT.java
+++ b/src/test/java/de/retest/recheck/ui/descriptors/ElementIT.java
@@ -1,0 +1,85 @@
+package de.retest.recheck.ui.descriptors;
+
+import static de.retest.recheck.ui.Path.fromString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Rectangle;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import de.retest.recheck.ui.review.ActionChangeSet;
+
+class ElementIT {
+
+	@Test
+	void applyChanges_should_remove_slightly_different_element() {
+		final Element form = new RootElement( "old", new IdentifyingAttributes( Arrays.asList( //
+				new PathAttribute( fromString( "html/body/form" ) ), //
+				new SuffixAttribute( 1 ), //
+				new TextAttribute( "type", "form" ) //
+		) ), new Attributes(), null, "", 0, "" );
+
+		final IdentifyingAttributes original = new IdentifyingAttributes( Arrays.asList( // 
+				new PathAttribute( fromString( "html/body/form/input" ) ), //
+				new SuffixAttribute( 1 ), //
+				new TextAttribute( "type", "input" ), //
+				OutlineAttribute.create( new Rectangle( 0, 0, 200, 100 ) ), //
+				OutlineAttribute.createAbsolute( new Rectangle( 100, 50, 200, 100 ) ) //
+		) );
+		final IdentifyingAttributes altered = new IdentifyingAttributes( Arrays.asList( // 
+				new PathAttribute( fromString( "html/body/form/input" ) ), //
+				new SuffixAttribute( 1 ), //
+				new TextAttribute( "type", "input" ), //
+				OutlineAttribute.create( new Rectangle( 0, 0, 250, 150 ) ), //
+				OutlineAttribute.createAbsolute( new Rectangle( 100, 20, 250, 150 ) ) //
+		) );
+
+		form.addChildren( new Element( "input", form, original, new Attributes(), null ) );
+
+		final ActionChangeSet changeSet = ActionChangeSetTestUtils.createEmptyActionChangeSet();
+		changeSet.addDeletedChange( altered );
+
+		final Element changed = form.applyChanges( changeSet );
+		assertThat( changed.getContainedElements() ).isEmpty();
+	}
+
+	@Test
+	void applyChanges_should_properly_handle_inserted_deleted_element() {
+		final Element form = new RootElement( "old", new IdentifyingAttributes( Arrays.asList( //
+				new PathAttribute( fromString( "html/body/form" ) ), //
+				new SuffixAttribute( 1 ), //
+				new TextAttribute( "type", "form" ) //
+		) ), new Attributes(), null, "", 0, "" );
+
+		final IdentifyingAttributes original = new IdentifyingAttributes( Arrays.asList( // 
+				new PathAttribute( fromString( "html/body/form/input" ) ), //
+				new SuffixAttribute( 1 ), //
+				new TextAttribute( "type", "input" ), //
+				OutlineAttribute.create( new Rectangle( 0, 0, 200, 100 ) ), //
+				OutlineAttribute.createAbsolute( new Rectangle( 100, 50, 200, 100 ) ) //
+		) );
+		final IdentifyingAttributes altered = new IdentifyingAttributes( Arrays.asList( // 
+				new PathAttribute( fromString( "html/body/form/input" ) ), //
+				new SuffixAttribute( 1 ), //
+				new TextAttribute( "type", "input" ), //
+				OutlineAttribute.create( new Rectangle( 0, 0, 250, 150 ) ), //
+				OutlineAttribute.createAbsolute( new Rectangle( 100, 20, 250, 150 ) ) //
+		) );
+
+		form.addChildren( new Element( "input", form, original, new Attributes(), null ) );
+
+		final ActionChangeSet changeSet = ActionChangeSetTestUtils.createEmptyActionChangeSet();
+		changeSet.addDeletedChange( original );
+		changeSet.addInsertChange( new Element( "input", form, altered, new Attributes(), null ) );
+
+		final Element changed = form.applyChanges( changeSet );
+
+		assertThat( changed.getContainedElements() ) //
+				.hasSize( 1 ) //
+				.element( 0 ) //
+				.satisfies( input -> {
+					assertThat( input.getIdentifyingAttributes() ).isEqualTo( altered );
+				} );
+	}
+}


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] ~you updated necessary documentation within [retest/docs](https://github.com/retest/docs).~ (*not necessary*)

<!-- Note: You can always ask a maintainer to help you with the above tasks. -->

## Description

> TL;DR This should fix #598 where an assertion error is triggered due to duplicate elements within the Golden Master.

This was known for quite some time now, but the workaround at hand was to recreate the Golden Master. We never could pin-point the issues when they occurred, because the assertion is thrown out of flow where the problem lies. Since I have dealt with similar problems in this manner (see #726), I investigated the issue in depth, because I got that issue again while working on retest/recheck-web#642.

The issue is the volatile outline attributes, which change slightly across different runs (due to different os, browser versions or general instability). This causes the `IdentifyingAttributes` of the same element to be slightly different and thus `Element#removeDeleted` will never remove the deleted element. Furthermore, if the alignment gets confused and generates an inserted/deleted element, the element will be added as duplicate within the Golden Master and thus the next execution will result in the exception being triggered as described by #598,

While this is only a workaround already established by the other PR, I have [proposed](https://github.com/retest/recheck/issues/598#issuecomment-683292363) suggestions on what to do for an actual fix (or at least think about them).

I have created a new `ElementIT` instead of putting this inside the already existing `ElementTest` as I figured that this is more an integration test than an unit test (also I could not be bothered with JUnit4).

### State of this PR

Because of a weird issue not being able to compile the project locally with my current IDE or Maven configuration, I have not yet done an integration test with recheck-web. I will keep this as draft, until I (or someone else) can verify this has been resolved correctly and that it does not cause any other bugs along the road.

### Additional Context

Writing an integration test for the complete use case within recheck is tedious, as one would have to create an arbitrary element structure, perform a check, apply and rerun&mdash;this has been done before (to some extend), but frankly, I was to lazy do bother with that: The return seems not that great, because the (probable) cause and exception are very far apart and would consist of tying together large portions of the code.

Please refer to #598 for more information.