### PR TITLE
Fix/improve pseudo element

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,8 +1,9 @@
 name: Deploy releases
 
 on:
-  create:
-    tags: v*
+  push:
+    tags:
+      - 'v*'
 
 env:
   MVN_ARGS: --batch-mode --errors --fail-fast --no-transfer-progress

--- a/src/main/java/de/retest/recheck/ui/descriptors/Element.java
+++ b/src/main/java/de/retest/recheck/ui/descriptors/Element.java
@@ -224,11 +224,7 @@ public class Element implements Serializable, Comparable<Element> {
 		}
 
 		final Object ordinaryAttribute = getAttributes().get( attributeName );
-		if ( ordinaryAttribute != null ) {
-			return ordinaryAttribute;
-		}
-
-		return null;
+		return ordinaryAttribute;
 	}
 
 	public String getRetestId() {
@@ -283,6 +279,9 @@ public class Element implements Serializable, Comparable<Element> {
 			return true;
 		}
 		if ( obj == null || getClass() != obj.getClass() ) {
+			return false;
+		}
+		if ( this.hashCode() != obj.hashCode() ) {
 			return false;
 		}
 		final Element other = (Element) obj;

--- a/src/main/java/de/retest/recheck/ui/diff/Alignment.java
+++ b/src/main/java/de/retest/recheck/ui/diff/Alignment.java
@@ -60,7 +60,7 @@ public final class Alignment {
 
 		for ( final Element childElement : element.getContainedElements() ) {
 			childParentMapping.put( childElement, element );
-			if ( AlignmentPseudoElementHack.isLeaf( childElement, pseudoElementsMapping ) ) {
+			if ( AlignmentPseudoElementHack.isLeafAndPrepareMapping( childElement, pseudoElementsMapping ) ) {
 				flattened.add( childElement );
 			} else {
 				flattened.addAll( flattenLeafElements( childElement, childParentMapping, pseudoElementsMapping ) );

--- a/src/main/java/de/retest/recheck/ui/diff/Alignment.java
+++ b/src/main/java/de/retest/recheck/ui/diff/Alignment.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class Alignment {
 
-	private static final double ELEMENT_MATCH_THRESHOLD = RecheckProperties.getInstance().elementMatchThreshold();
+	static final double ELEMENT_MATCH_THRESHOLD = RecheckProperties.getInstance().elementMatchThreshold();
 
 	/**
 	 * A mapping from each child element (key) to its parent (value), based on the <em>expected</em> elements.
@@ -35,30 +35,35 @@ public final class Alignment {
 
 	private final Map<Element, Element> alignment;
 
+	AlignmentPseudoElementHack pseudoElementHack = new AlignmentPseudoElementHack();
+
 	public static Alignment createAlignment( final Element expected, final Element actual ) {
 		return new Alignment( expected, actual );
 	}
 
 	private Alignment( final Element expected, final Element actual ) {
-		final List<Element> expectedElements = flattenLeafElements( expected, expectedChildParentMapping );
-		final List<Element> actualElements = flattenLeafElements( actual, actualChildParentMapping );
+		final List<Element> expectedElements =
+				flattenLeafElements( expected, expectedChildParentMapping, pseudoElementHack.expectedPseudoElementsMapping );
+		final List<Element> actualElements =
+				flattenLeafElements( actual, actualChildParentMapping, pseudoElementHack.actualPseudoElementsMapping );
 		log.debug(
 				"Creating assignment of old to new elements, trying to find differences. We are comparing {} with {} elements.",
 				expectedElements.size(), actualElements.size() );
 		alignment = createAlignment( expectedElements, toIdentityMapping( actualElements ) );
 		addParentAlignment();
+		pseudoElementHack.alignPseudoElements( alignment );
 	}
 
 	private static List<Element> flattenLeafElements( final Element element,
-			final Map<Element, Element> childParentMapping ) {
+			final Map<Element, Element> childParentMapping, final Map<Element, Element> pseudoElementsMapping ) {
 		final List<Element> flattened = new ArrayList<>();
 
 		for ( final Element childElement : element.getContainedElements() ) {
 			childParentMapping.put( childElement, element );
-			if ( !childElement.hasContainedElements() ) {
+			if ( AlignmentPseudoElementHack.isLeaf( childElement, pseudoElementsMapping ) ) {
 				flattened.add( childElement );
 			} else {
-				flattened.addAll( flattenLeafElements( childElement, childParentMapping ) );
+				flattened.addAll( flattenLeafElements( childElement, childParentMapping, pseudoElementsMapping ) );
 			}
 		}
 
@@ -151,11 +156,15 @@ public final class Alignment {
 	private void addParentAlignment() {
 		final Map<Element, Element> alignmentCopy = new HashMap<>( alignment );
 		for ( final Map.Entry<Element, Element> alignmentPair : alignmentCopy.entrySet() ) {
+
 			final List<Element> expectedParents = getParents( alignmentPair.getKey(), expectedChildParentMapping );
 			final List<Element> actualParents = getParents( alignmentPair.getValue(), actualChildParentMapping );
+
 			final Map<Element, Element> parentAlignment =
 					createAlignment( expectedParents, toIdentityMapping( actualParents ) );
+
 			for ( final Map.Entry<Element, Element> parentAlignmentPair : parentAlignment.entrySet() ) {
+
 				final Element aligned = alignment.get( parentAlignmentPair.getKey() );
 				if ( aligned == null ) {
 					alignment.put( parentAlignmentPair.getKey(), parentAlignmentPair.getValue() );
@@ -186,7 +195,7 @@ public final class Alignment {
 		return actualElements.stream().collect( toMap( Function.identity(), Function.identity() ) );
 	}
 
-	private static double match( final Element expected, final Element bestMatch ) {
+	static double match( final Element expected, final Element bestMatch ) {
 		return expected.getIdentifyingAttributes().match( bestMatch.getIdentifyingAttributes() );
 	}
 

--- a/src/main/java/de/retest/recheck/ui/diff/AlignmentPseudoElementHack.java
+++ b/src/main/java/de/retest/recheck/ui/diff/AlignmentPseudoElementHack.java
@@ -1,0 +1,66 @@
+package de.retest.recheck.ui.diff;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import de.retest.recheck.ui.descriptors.Element;
+
+/**
+ * Hack to fix pseudo element handling.
+ *
+ * This class contains knowledge about HTML Pseudo Elements, but this should be in recheck-web only.
+ */
+class AlignmentPseudoElementHack {
+
+	/**
+	 * A mapping from each pseudo element (key) to its parent (value), based on the <em>expected</em> elements.
+	 */
+	final Map<Element, Element> expectedPseudoElementsMapping = new HashMap<>();
+	/**
+	 * A mapping from each child element (key) to its parent (value), based on the <em>actual</em> elements.
+	 */
+	final Map<Element, Element> actualPseudoElementsMapping = new HashMap<>();
+
+	void alignPseudoElements( final Map<Element, Element> alignment ) {
+		expectedPseudoElementsMapping.forEach( ( expectedPseudo, expectedParent ) -> {
+
+			final Element actualParent = alignment.get( expectedParent );
+			if ( actualParent != null ) {
+
+				actualPseudoElementsMapping.entrySet().stream() //
+						.filter( entry -> entry.getValue().equals( actualParent ) ) //
+						.map( Entry::getKey ) //
+						// here we have a list of candidates based on parent assignment
+						.map( actualPseudoCandidate -> match( expectedPseudo, actualPseudoCandidate ) ) //
+						.filter( match -> match.similarity > Alignment.ELEMENT_MATCH_THRESHOLD ) //
+						.sorted().findFirst() //
+						.ifPresent( m -> {
+							alignment.put( expectedPseudo, m.element );
+						} );
+
+			}
+
+		} );
+	}
+
+	static boolean isLeaf( final Element element, final Map<Element, Element> pseudoElementsMapping ) {
+		boolean isLeaf = true;
+		for ( final Element child : element.getContainedElements() ) {
+			if ( isPseudoElement( child ) ) {
+				pseudoElementsMapping.put( child, element );
+			} else {
+				isLeaf = false;
+			}
+		}
+		return isLeaf;
+	}
+
+	private static boolean isPseudoElement( final Element e ) {
+		return e.getIdentifyingAttributes().getType().startsWith( "::" );
+	}
+
+	private static Match match( final Element expected, final Element actualCandidate ) {
+		return Match.of( Alignment.match( expected, actualCandidate ), actualCandidate );
+	}
+}

--- a/src/main/java/de/retest/recheck/ui/diff/AlignmentPseudoElementHack.java
+++ b/src/main/java/de/retest/recheck/ui/diff/AlignmentPseudoElementHack.java
@@ -44,7 +44,7 @@ class AlignmentPseudoElementHack {
 		} );
 	}
 
-	static boolean isLeaf( final Element element, final Map<Element, Element> pseudoElementsMapping ) {
+	static boolean isLeafAndPrepareMapping( final Element element, final Map<Element, Element> pseudoElementsMapping ) {
 		boolean isLeaf = true;
 		for ( final Element child : element.getContainedElements() ) {
 			if ( isPseudoElement( child ) ) {


### PR DESCRIPTION
*Before submission, please check that ...*

- [x] the code follows the [Clean Code](https://clean-code-developer.com/) guidelines.
- [x] the necessary tests are either created or updated.
- [x] all status checks (Travis CI, SonarCloud, etc.) pass.
- [x] your commit history is cleaned up.
- [x] you updated the changelog.
- [x] you updated necessary documentation within [retest/docs](https://github.com/retest/docs).

## Description

There are Alignment problems in `recheck-web` caused by the now supported HTML Pseudo Elements. This PR fixes these problems, but only by using knowledge about HTML Pseudo Elements which shouldn't be in `recheck`.
For short them I don't see any other solution.